### PR TITLE
Feature/Add locality selection, role-based permissions, and relationships for locality and user models

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Customer;
 use App\Models\Debt;
+use App\Models\Locality;
 use App\Models\Payment;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -16,6 +17,7 @@ class DashboardController extends Controller
 
         $authUser = Auth::user();
         $totalCustomers = Customer::count();
+        $localities = Locality::all();
 
         $customersWithDebts = Customer::whereHas('debts', function ($query) {
             $query->where('status', '!=', 'paid');
@@ -55,6 +57,7 @@ class DashboardController extends Controller
             'noDebtsForCurrentMonth' => $noDebtsForCurrentMonth,
             'months' => $months,
             'earningsPerMonth' => array_values($earningsPerMonth),
+            'localities' => $localities,
         ];
 
         return view('dashboard', compact('data', 'authUser'));

--- a/app/Models/Cost.php
+++ b/app/Models/Cost.php
@@ -16,4 +16,14 @@ class Cost extends Model
     ];
 
     public $timestamps = false;
+
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -51,6 +51,16 @@ class Customer extends Model implements HasMedia
         return $this->hasMany(Debt::class);
     }
 
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
     protected static function boot()
     {
         parent::boot();

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -19,6 +19,16 @@ class Debt extends Model
         return $this->belongsTo(Customer::class, 'customer_id');
     }
 
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
     public function payments()
     {
         return $this->hasMany(Payment::class, 'debt_id');

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -25,4 +25,14 @@ class Payment extends Model
     {
         return $this->belongsTo(Debt::class);
     }
+
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/database/migrations/2024_08_13_181323_create_costs_table.php
+++ b/database/migrations/2024_08_13_181323_create_costs_table.php
@@ -15,10 +15,15 @@ class CreateCostsTable extends Migration
     {
         Schema::create('costs', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('locality_id');
+            $table->unsignedBigInteger('user_id');
             $table->string('category');
             $table->decimal('price', 8, 2);
             $table->text('description')->nullable();
             $table->softDeletes();
+
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2024_08_13_181323_create_costs_table.php
+++ b/database/migrations/2024_08_13_181323_create_costs_table.php
@@ -15,15 +15,10 @@ class CreateCostsTable extends Migration
     {
         Schema::create('costs', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('locality_id');
-            $table->unsignedBigInteger('user_id');
             $table->string('category');
             $table->decimal('price', 8, 2);
             $table->text('description')->nullable();
             $table->softDeletes();
-
-            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2024_08_15_195444_create_customers_table.php
+++ b/database/migrations/2024_08_15_195444_create_customers_table.php
@@ -19,7 +19,7 @@ class CreateCustomersTable extends Migration
             $table->id();
             $table->unsignedBigInteger('cost_id');
             $table->unsignedBigInteger('locality_id');
-            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('created_by');
             $table->string('name');
             $table->string('last_name');
             $table->string('block');
@@ -41,7 +41,7 @@ class CreateCustomersTable extends Migration
           
             $table->foreign('cost_id')->references('id')->on('costs')->onDelete('cascade');
             $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2024_08_15_195444_create_customers_table.php
+++ b/database/migrations/2024_08_15_195444_create_customers_table.php
@@ -18,6 +18,8 @@ class CreateCustomersTable extends Migration
         Schema::create('customers', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('cost_id');
+            $table->unsignedBigInteger('locality_id');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->string('last_name');
             $table->string('block');
@@ -38,6 +40,8 @@ class CreateCustomersTable extends Migration
             $table->softDeletes();
           
             $table->foreign('cost_id')->references('id')->on('costs')->onDelete('cascade');
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2024_08_20_191329_create_debts_table.php
+++ b/database/migrations/2024_08_20_191329_create_debts_table.php
@@ -17,7 +17,7 @@ class CreateDebtsTable extends Migration
             $table->id();
             $table->unsignedBigInteger('customer_id');
             $table->unsignedBigInteger('locality_id');
-            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('created_by');
             $table->date('start_date');
             $table->date('end_date');
             $table->decimal('amount', 10, 2);
@@ -28,7 +28,7 @@ class CreateDebtsTable extends Migration
         
             $table->foreign('customer_id')->references('id')->on('customers')->onDelete('cascade');
             $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
         });
         
     }

--- a/database/migrations/2024_08_20_191329_create_debts_table.php
+++ b/database/migrations/2024_08_20_191329_create_debts_table.php
@@ -16,6 +16,8 @@ class CreateDebtsTable extends Migration
         Schema::create('debts', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('customer_id');
+            $table->unsignedBigInteger('locality_id');
+            $table->unsignedBigInteger('user_id');
             $table->date('start_date');
             $table->date('end_date');
             $table->decimal('amount', 10, 2);
@@ -25,6 +27,8 @@ class CreateDebtsTable extends Migration
             $table->softDeletes();
         
             $table->foreign('customer_id')->references('id')->on('customers')->onDelete('cascade');
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
         
     }

--- a/database/migrations/2024_08_23_213851_create_payments_table.php
+++ b/database/migrations/2024_08_23_213851_create_payments_table.php
@@ -17,7 +17,7 @@ class CreatePaymentsTable extends Migration
             $table->id();
             $table->unsignedBigInteger('debt_id');
             $table->unsignedBigInteger('locality_id');
-            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('created_by');
             $table->decimal('amount', 10, 2);
             $table->date('payment_date'); 
             $table->text('note')->nullable();
@@ -25,7 +25,7 @@ class CreatePaymentsTable extends Migration
        
             $table->foreign('debt_id')->references('id')->on('debts')->onDelete('cascade');
             $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2024_08_23_213851_create_payments_table.php
+++ b/database/migrations/2024_08_23_213851_create_payments_table.php
@@ -16,12 +16,16 @@ class CreatePaymentsTable extends Migration
         Schema::create('payments', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('debt_id');
+            $table->unsignedBigInteger('locality_id');
+            $table->unsignedBigInteger('user_id');
             $table->decimal('amount', 10, 2);
             $table->date('payment_date'); 
             $table->text('note')->nullable();
             $table->softDeletes();
        
             $table->foreign('debt_id')->references('id')->on('debts')->onDelete('cascade');
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(LocalitiesTableSeeder::class);
         $this->call(RolesAndPermissionsSeeder::class);
         $this->call(UsersTableSeeder::class);
         $this->call(CostsTableSeeder::class);
         $this->call(CustomersTableSeeder::class);
-        $this->call(LocalitiesTableSeeder::class);
-        
     }
 }

--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -21,7 +21,6 @@ class LocalitiesTableSeeder extends Seeder
             'zip_code' => '55749',
             
         ]);
-
         
         Locality::create([
             'locality_name' => 'Ojo de Agua',

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -82,6 +82,13 @@ class RolesAndPermissionsSeeder extends Seeder
             'name' => 'deleteLocation',
             'description' => 'Permite eliminar localidades.'
         ])->assignRole([$roleAdmin]);
-
+        Permission::create([
+            'name' => 'viewDashboardCards',
+            'description' => 'Permite ver las tarjetas de información en el dashboard.'
+        ])->assignRole([$roleSupervisor, $roleSecretariat]);
+        Permission::create([
+            'name' => 'viewLocalityCharts',
+            'description' => 'Permite ver las gráficas correspondientes a una localidad en el dashboard.'
+        ])->assignRole($roleAdmin);
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -121,11 +121,23 @@
 
 @section('css')
     <link rel="stylesheet" href="{{ asset('css/dashboard/dashboard.css') }}">
+    <style>
+        .select2-container .select2-selection--single {
+            height: 40px;
+            display: flex;
+            align-items: center;
+        }
+    </style>
 @stop
 
 @section('js')
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
+        $(document).ready(function(){
+            $('#mySelect').select2({
+            });
+        });
+
         var ctx = document.getElementById('earningsChart').getContext('2d');
         var earningsChart = new Chart(ctx, {
             type: 'bar', 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -28,51 +28,69 @@
                             </div>
                         </div>
                     </div>
-                    @if ($data['noDebtsForCurrentMonth'])
-                        <div class="alert alert-warning" role="alert">
-                            Ya ha iniciado un nuevo mes y no se han asignado deudas a los Usuarios para este periodo.
-                        </div>
-                    @endif
+                    @can('viewDashboardCards')
+                        @if ($data['noDebtsForCurrentMonth'])
+                            <div class="alert alert-warning" role="alert">
+                                Ya ha iniciado un nuevo mes y no se han asignado deudas a los Usuarios para este periodo.
+                            </div>
+                        @endif
 
-                    <div class="row">
-                        <div class="col-lg-4 col-xs-6">
-                            <div class="small-box bg-info">
-                                <div class="inner">
-                                    <h3>{{ $data['totalCustomers'] }}</h3>
-                                    <p>Total de Usuarios</p>
+                        <div class="row">
+                            <div class="col-lg-4 col-xs-6">
+                                <div class="small-box bg-info">
+                                    <div class="inner">
+                                        <h3>{{ $data['totalCustomers'] }}</h3>
+                                        <p>Total de Usuarios</p>
+                                    </div>
+                                    <div class="icon">
+                                        <i class="fas fa-users"></i>
+                                    </div>
+                                    <a href="{{ route('customers.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
                                 </div>
-                                <div class="icon">
-                                    <i class="fas fa-users"></i>
+                            </div>
+                            <div class="col-lg-4 col-xs-6">
+                                <div class="small-box bg-green">
+                                    <div class="inner">
+                                        <h3>{{ $data['customersWithoutDebts'] }}</h3>
+                                        <p>Usuarios al día</p>
+                                    </div>
+                                    <div class="icon">
+                                        <i class="fas fa-check-circle"></i>
+                                    </div>
+                                    <a href="{{ route('customers.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
                                 </div>
-                                <a href="{{ route('customers.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
+                            </div>
+                            <div class="col-lg-4 col-xs-6">
+                                <div class="small-box bg-red">
+                                    <div class="inner">
+                                        <h3>{{ $data['customersWithDebts'] }}</h3>
+                                        <p>Usuarios con Deudas</p>
+                                    </div>
+                                    <div class="icon">
+                                        <i class="fas fa-exclamation-circle"></i>
+                                    </div>
+                                    <a href="{{ route('debts.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
+                                </div>
                             </div>
                         </div>
-                        <div class="col-lg-4 col-xs-6">
-                            <div class="small-box bg-green">
-                                <div class="inner">
-                                    <h3>{{ $data['customersWithoutDebts'] }}</h3>
-                                    <p>Usuarios al día</p>
-                                </div>
-                                <div class="icon">
-                                    <i class="fas fa-check-circle"></i>
-                                </div>
-                                <a href="{{ route('customers.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
+                    @endcan
+
+                    @can('viewLocalityCharts')
+                        <div class="col-lg-6">
+                            <div class="form-group">
+                                <label for="locality_id" class="form-label">Seleccionar Localidad</label>
+                                <select id="mySelect" class="form-control select2" name="locality_id" required>
+                                    <option value="">Seleccione una localidad</option>
+                                    @foreach($data['localities'] as $locality)
+                                        <option value="{{ $locality->id }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>
+                                            {{ $locality->id }} - {{ $locality->locality_name }} , {{ $locality->municipality }}
+                                        </option>
+                                    @endforeach
+                                </select>
                             </div>
                         </div>
-                        <div class="col-lg-4 col-xs-6">
-                            <div class="small-box bg-red">
-                                <div class="inner">
-                                    <h3>{{ $data['customersWithDebts'] }}</h3>
-                                    <p>Usuarios con Deudas</p>
-                                </div>
-                                <div class="icon">
-                                    <i class="fas fa-exclamation-circle"></i>
-                                </div>
-                                <a href="{{ route('debts.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
-                            </div>
-                        </div>
-                    </div>
-                    
+                    @endcan
+
                     <div class="row">
                         <div class="col-md-6">
                             <div class="card">


### PR DESCRIPTION
### Summary

This PR introduces the following key features and improvements:

1. **Locality Selection for Dashboard**:
- Implemented `Select2 `for locality selection in the dashboard, allowing the admin to choose a specific locality for displaying relevant data like earning graphs.
- Added role-based permissions, ensuring that only users with the 'admin' role can view and select localities.

2. **Role-Based Dashboard Cards**:
- Added permission checks for displaying dashboard information cards.
- Users with roles like 'Supervisor' or 'Secretariat' can view specific dashboard sections, such as total customers and users without debts, but admin cannot.

3. **Model Relationships**:
- Introduced foreign key relationships between the `Locality`, `User`, `Customer`, `Cost`, `Debt`, and `Payment `models.
- Added `belongsTo `relationships in models (`Customer`, `Debt`, `Cost`, `Payment`) to link each entity with a `Locality `and `User`.

4. **Database Migrations and Seeders**:
- Updated migrations for `Costs`, `Customers`, `Debts`, and `Payments `tables to include foreign keys (`locality_id `and `user_id`) with appropriate cascading deletion rules.
- Updated the `RolesAndPermissionsSeeder `to include new permissions:
- `viewLocalityCharts `(for admins to view locality-based graphs).
- `viewDashboardCards `(for roles such as 'Supervisor' to view key metrics).

5.  **Reordered the `DatabaseSeeder`**:
- Ensured that the `LocalitiesTableSeeder `is executed first, as other tables depend on the existence of localities.