### PR TITLE
Feature/Implement locality earnings retrieval and display in graphs

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -34,18 +34,6 @@ class DashboardController extends Controller
 
         $noDebtsForCurrentMonth = ($debtsThisMonth === 0);
 
-        $monthlyEarnings = Payment::selectRaw('SUM(amount) as total, MONTH(payment_date) as month')
-            ->whereYear('payment_date', Carbon::now()->year)
-            ->groupBy('month')
-            ->orderBy('month')
-            ->get();
-
-        $earningsPerMonth = array_fill(1, 12, 0);
-
-        foreach ($monthlyEarnings as $earning) {
-            $earningsPerMonth[$earning->month] = $earning->total;
-        }
-
         $months = collect(range(1, 12))->map(function ($month) {
             return ucfirst(Carbon::create()->month($month)->locale('es')->monthName);
         });
@@ -56,7 +44,6 @@ class DashboardController extends Controller
             'customersWithoutDebts' => $customersWithoutDebts,
             'noDebtsForCurrentMonth' => $noDebtsForCurrentMonth,
             'months' => $months,
-            'earningsPerMonth' => array_values($earningsPerMonth),
             'localities' => $localities,
         ];
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -160,6 +160,12 @@
                     $('#localityInfoMonthly').text(' de ' + localityName + ', ' + municipality);
                     $('#localityInfoAnnual').text(' de ' + localityName + ', ' + municipality);
                 } else {
+                    earningsChart.data.datasets[0].data = Array(12).fill(0); 
+                    earningsChart.update();
+
+                    annualEarningsChart.data.datasets[0].data = Array(12).fill(0); 
+                    annualEarningsChart.update();
+
                     $('#localityInfoMonthly').text('');
                     $('#localityInfoAnnual').text('');
                 }
@@ -173,7 +179,6 @@
                 labels: @json($data['months']),
                 datasets: [{
                     label: 'Ganancias en $',
-                    data: @json($data['earningsPerMonth']),
                     backgroundColor: 'rgba(54, 162, 235, 0.5)',
                     borderColor: 'rgba(54, 162, 235, 1)',
                     borderWidth: 1
@@ -195,7 +200,6 @@
                 labels: @json($data['months']),
                 datasets: [{
                     label: 'Ganancias Anuales en $',
-                    data: @json($data['earningsPerMonth']),
                     backgroundColor: 'rgba(255, 99, 132, 0.5)',
                     borderColor: 'rgba(255, 99, 132, 1)',
                     borderWidth: 2

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -82,8 +82,8 @@
                                 <select id="mySelect" class="form-control select2" name="locality_id" required>
                                     <option value="">Seleccione una localidad</option>
                                     @foreach($data['localities'] as $locality)
-                                        <option value="{{ $locality->id }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>
-                                            {{ $locality->id }} - {{ $locality->locality_name }} , {{ $locality->municipality }}
+                                        <option value="{{ $locality->id }}" data-name="{{ $locality->locality_name }}" data-municipality="{{ $locality->municipality }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>
+                                            {{ $locality->locality_name }} , {{ $locality->municipality }}
                                         </option>
                                     @endforeach
                                 </select>
@@ -95,7 +95,7 @@
                         <div class="col-md-6">
                             <div class="card">
                                 <div class="card-header">
-                                    <h3 class="card-title">Ganancias Mensuales</h3>
+                                    <h3 class="card-title">Ganancias Mensuales<span id="localityInfoMonthly"></h3>
                                 </div>
                                 <div class="card-body">
                                     <canvas id="earningsChart" width="400" height="200"></canvas>
@@ -105,7 +105,7 @@
                         <div class="col-md-6">
                             <div class="card">
                                 <div class="card-header">
-                                    <h3 class="card-title">Ganancias Anuales por Mes</h3>
+                                    <h3 class="card-title">Ganancias Anuales por Mes<span id="localityInfoAnnual"></h3>
                                 </div>
                                 <div class="card-body">
                                     <canvas id="annualEarningsChart" width="400" height="200"></canvas>
@@ -134,7 +134,35 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         $(document).ready(function(){
-            $('#mySelect').select2({
+            $('#mySelect').select2();
+
+            $('#mySelect').on('change', function(){
+                var localityId = $(this).val();
+                var selectedOption = $(this).find('option:selected');
+                var localityName = selectedOption.data('name');
+                var municipality = selectedOption.data('municipality');
+                if(localityId){
+                    $.ajax({
+                        url:"{{ route('locality.earnings') }}",
+                        type: 'GET',
+                        data: { locality_id: localityId},
+                        success: function(response){
+                            earningsChart.data.datasets[0].data = response.earningsPerMonth;
+                            earningsChart.update();
+
+                            annualEarningsChart.data.datasets[0].data = response.earningsPerMonth;
+                            annualEarningsChart.update();
+                        },
+                        error: function(xhr) {
+                            console.log('Error al obtener los datos de la localidad');
+                        }
+                    });
+                    $('#localityInfoMonthly').text(' de ' + localityName + ', ' + municipality);
+                    $('#localityInfoAnnual').text(' de ' + localityName + ', ' + municipality);
+                } else {
+                    $('#localityInfoMonthly').text('');
+                    $('#localityInfoAnnual').text('');
+                }
             });
         });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::group(['middleware' => ['auth']], function () {
     Route::get('/localities', [LocalityController::class, 'index'])->name('localities.index');
     Route::resource('localities', LocalityController::class);
     Route::post('/localities/{locality}/update-logo', [LocalityController::class, 'updateLogo'])->name('localities.updateLogo');
+    Route::get('/locality-earnings', [DashboardController::class, 'getEarningsByLocality'])->name('locality.earnings');
 
     Route::get('/getCustomerDebts', [PaymentController::class, 'getCustomerDebts'])->name('getCustomerDebts');
     


### PR DESCRIPTION
## Summary

This PR implements the functionality to display earnings charts based on the selected locality from the dropdown menu on the dashboard. It introduces the following key changes:

### Changes in DashboardController:
- Added `getEarningsByLocality` method to retrieve monthly earnings for a specific locality.
- The method returns JSON data including earnings per month.
  
### Changes in dashboard.blade.php:
- Updated the Select2 dropdown to include `data-name` and `data-municipality` attributes for each locality.
- Modified the earnings and annual earnings chart titles to dynamically display the selected locality's name and municipality.
- Implemented a function that listens for changes in the locality dropdown and updates the charts accordingly via an AJAX request.
  
### Changes in routes/web.php:
- Added a new route for retrieving earnings data by locality, linked to the new `getEarningsByLocality` method in the DashboardController.

### Removed:
`DashboardController:
`
- Removed the logic for retrieving earnings for all localities within the current year. This data was previously fetched and stored in $earningsPerMonth but is no longer needed since the earnings are now dynamically retrieved based on the selected locality.

`dashboard.blade.php:
`
- Removed the static dataset for earnings and annual earnings, as the chart data is now populated dynamically based on the selected locality through AJAX requests.
