### PR TITLE
Feature/Update names and roles in seeders

### DIFF
--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -15,27 +15,24 @@ class LocalitiesTableSeeder extends Seeder
     public function run()
     {
         Locality::create([
-            'locality_name' => 'Sierra Hermosa',
-            'municipality' => 'Tecámac',
-            'state' => 'Estado de México',
-            'zip_code' => '55749',
-            
+            'locality_name' => 'Smallville',
+            'municipality' => 'Smallville',
+            'state' => 'Kansas',
+            'zip_code' => '66002',
         ]);
         
         Locality::create([
-            'locality_name' => 'Ojo de Agua',
-            'municipality' => 'Tecámac',
-            'state' => 'Estado de México',
-            'zip_code' => '55770',
-            
+            'locality_name' => 'Springfield',
+            'municipality' => 'Springfield',
+            'state' => 'Oregon',
+            'zip_code' => '97477',
         ]);
 
         Locality::create([
-            'locality_name' => 'Viento Nuevo',
-            'municipality' => 'Ecatepec',
-            'state' => 'Estado de México',
-            'zip_code' => '55074',
-            
+            'locality_name' => 'Dunder Mifflin',
+            'municipality' => 'Scranton',
+            'state' => 'Pennsylvania',
+            'zip_code' => '18503',
         ]);
     }
 }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -11,7 +11,7 @@ class RolesAndPermissionsSeeder extends Seeder
     public function run()
     {
         $roleAdmin = Role::create(['name' => 'Admin']);
-        $roleSecretariat = Role::create(['name' => 'secretariat']);
+        $roleSecretariat = Role::create(['name' => 'Secretaria']);
         $roleSupervisor = Role::create(['name' => 'Supervisor']);
       
         Permission::create([

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -27,7 +27,7 @@ class UsersTableSeeder extends Seeder
         User::create([
             'locality_id' => 2,
             'name' => 'Erika',
-            'last_name' => 'Lopez perez',
+            'last_name' => 'Lopez Perez',
             'email' => 'eri@gmail.com',
             'phone' => '7798745677',
             'password' => Hash::make('12345'),

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -31,7 +31,7 @@ class UsersTableSeeder extends Seeder
             'email' => 'eri@gmail.com',
             'phone' => '7798745677',
             'password' => Hash::make('12345'),
-        ])->assignRole('secretariat');
+        ])->assignRole('Secretaria');
 
         User::create([
             'locality_id' => 1,


### PR DESCRIPTION
## Summary
This PR introduces updates to several seeders in the database, adjusting locality names, user roles, and related data to reflect new requirements.

Changes include:

`LocalitiesTableSeeder.php
`

- Updated locality names to fictional places like Smallville, Springfield, and Dunder Mifflin.
- Changed corresponding municipalities, states, and ZIP codes for the new localities.


`RolesAndPermissionsSeeder.php:
`

- Changed the role name secretariat to Secretaria for consistency and better naming clarity.


`UsersTableSeeder.php:
`

- Updated user role assignment from secretariat to Secretaria to match the new role name.
