### PR TITLE
Fix/suggested amount rounding and format

### DIFF
--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -10,7 +10,9 @@ class CostController extends Controller
     public function index()
     {
         $authUser = auth()->user();
-        $costs = Cost::where('locality_id', $authUser->locality_id)->get();
+        $costs = Cost::where('locality_id', $authUser->locality_id)
+        ->orderBy('created_at', 'desc')
+        ->get();
         return view('costs.index', compact('costs'));
     }
 

--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -13,7 +13,7 @@ class CustomerController extends Controller
     public function index(Request $request)
     {
         $authUser = auth()->user();
-        $query = Customer::where('locality_id', $authUser->locality_id);
+        $query = Customer::where('locality_id', $authUser->locality_id)->orderBy('created_at', 'desc');
 
         if ($request->has('search')) {
             $search = $request->input('search');

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -29,6 +29,7 @@ class DebtController extends Controller
             ->where('status', '!=', 'paid')
             ->select('customer_id')
             ->groupBy('customer_id')
+            ->orderBy('created_at', 'desc')
             ->selectRaw('SUM(amount) as total_amount')
             ->paginate(10);
 

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -10,7 +10,7 @@ class LocalityController extends Controller
 
     public function index(Request $request)
     {
-        $query = Locality::query();
+        $query = Locality::query()->orderBy('created_at', 'desc');
 
         if ($request->has('search')) {
             $search = $request->input('search');

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -11,7 +11,7 @@ class RoleController extends Controller
     public function index()
     {
         $permissions = Permission::all();
-        $roles = Role::all();
+        $roles = Role::orderBy('created_at', 'desc')->get();
         return view('roles.index', compact('roles', 'permissions'));
     }
 

--- a/public/js/datatables/datatable-language-es.js
+++ b/public/js/datatables/datatable-language-es.js
@@ -2,6 +2,7 @@ $(document).ready(function() {
     $.extend(true, $.fn.dataTable.defaults, {
         language: {
             url: '/lang/datatables/datatable-lang-es.json'
-        }
+        },
+        order: [[0, "desc"]]
     });
 });

--- a/resources/views/payments/create.blade.php
+++ b/resources/views/payments/create.blade.php
@@ -55,10 +55,10 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="suggested_amount" class="form-label" style="font-weight: bold; color: #555;">Monto Sugerido a Pagar</label>
+                                            <label for="suggested_amount" class="form-label" style="font-weight: bold; color: #555;">Saldo Pendiente</label>
                                             <div style="border-radius: 8px; background-color: #d2e0ca; padding: 10px; box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1); display: flex; align-items: center;">
                                                 <i class="fas fa-money-bill-wave" style="margin-right: 8px; color: #28a745;"></i>
-                                                <p id="suggested_amount" class="form-control-static" style="margin: 0; font-size: 16px; color: #333;">Selecciona una deuda para ver el monto sugerido.</p>
+                                                <p id="suggested_amount" class="form-control-static" style="margin: 0; font-size: 16px; color: #333;">Selecciona una deuda para ver el saldo pendiente.</p>
                                             </div>
                                         </div>
                                     </div>                                                                       
@@ -69,7 +69,7 @@
                                                 <div class="input-group-prepend">
                                                     <span class="input-group-text"><i class="fa fa-dollar-sign"></i></span>
                                                 </div>
-                                                <input type="number" class="form-control" name="amount" placeholder="Ingresa el monto" required />
+                                                <input type="number" class="form-control" name="amount" placeholder="Ingresa el monto" value="{{ old('amount') }}" required />
                                             </div>
                                         </div>
                                     </div>                                

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -155,7 +155,8 @@ $(document).ready(function() {
         var remainingAmount = selectedOption.data('remaining-amount');
         
         if (remainingAmount !== undefined) {
-            $('#suggested_amount').text('Monto sugerido a pagar: $' + remainingAmount);
+            var roundedAmount = parseFloat(remainingAmount).toFixed(2);
+            $('#suggested_amount').text('Saldo pendiente: $' + roundedAmount);
         } else {
             $('#suggested_amount').text('');
         }


### PR DESCRIPTION
## Summary
This PR includes the following changes:

### Ordering for Controller Queries:

- Added orderBy('created_at', 'desc') to the following controllers to ensure that records are displayed in descending order based on their creation date:
```
CostController
CustomerController
DebtController
LocalityController
RoleController
```
### DataTables Language File Update:

- Modified the public/js/datatables/datatable-language-es.js file to set the default ordering for DataTables to descending.

### Payment View Updates:

- Updated the label in resources/views/payments/create.blade.php from "Monto Sugerido a Pagar" to "Saldo Pendiente".
- Changed the corresponding text in the payment display to reflect the new label.
- Updated the logic in resources/views/payments/index.blade.php to display the rounded remaining amount with two decimal places.

### Files Changed
`Controllers`:
app/Http/Controllers/CostController.php
app/Http/Controllers/CustomerController.php
app/Http/Controllers/DebtController.php
app/Http/Controllers/LocalityController.php
app/Http/Controllers/RoleController.php
JavaScript:
public/js/datatables/datatable-language-es.js

`Views`:
resources/views/payments/create.blade.php
resources/views/payments/index.blade.php