### PR TITLE
Fix/profile image and debts

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -98,17 +98,6 @@ class DebtController extends Controller
                 continue;
             }
 
-            $existingDebt = Debt::where('customer_id', $customer->id)
-                ->where(function ($query) use ($startDate, $endDate) {
-                    $query->where('start_date', '<=', $endDate->format('Y-m-d'))
-                        ->where('end_date', '>=', $startDate->format('Y-m-d'));
-                })
-                ->exists();
-
-            if ($existingDebt) {
-                continue;
-            }
-
             $allHaveDebt = false;
             Debt::create([
                 'locality_id' => $authUser->locality_id,

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -30,10 +30,6 @@ class ProfileController extends Controller
 
     public function updateImage(Request $request)
     {
-        $request->validate([
-            'profileImage' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
-        ]);
-
         $user = User::find(Auth::id());
 
         if ($user->getFirstMedia('userGallery')) {

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -324,7 +324,7 @@ return [
              'can'  =>'viewRoles'
         ],
         [
-            'text' => 'Usuarios',
+            'text' => 'Clientes',
             'url' => '/customers',
             'icon' => 'fas fa-fw fa-users',
              'can'  =>'viewCustomers'

--- a/resources/views/costs/delete.blade.php
+++ b/resources/views/costs/delete.blade.php
@@ -12,7 +12,7 @@
                 @method('DELETE')
                 <div class="modal-body text-center text-danger">
                     ¿Estás seguro de eliminar el costo <strong>{{ $cost->category }}?</strong>
-                    , recuerda que puede estar asociado a un usuario, si es el caso se quedara sin ningun costo?
+                    , recuerda que puede estar asociado a un cliente, si es el caso se quedara sin ningun costo?
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>

--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -5,7 +5,7 @@
             <div class="card-success">
                 <div class="card-header">
                     <div class="d-sm-flex align-items-center justify-content-between">
-                        <h4 class="card-title">Agregar usuario <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <h4 class="card-title">Agregar cliente <small> &nbsp;(*) Campos requeridos</small></h4>
                         <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
@@ -16,7 +16,7 @@
                     <div class="card-body">
                         <div class="card">
                             <div class="card-header py-2 bg-secondary">
-                                <h3 class="card-title">Ingrese los Datos del Usuario</h3>
+                                <h3 class="card-title">Ingrese los Datos del Cliente</h3>
                                 <div class="card-tools">
                                     <button type="button" class="btn btn-tool" data-card-widget="collapse">
                                         <i class="fa fa-minus"></i>

--- a/resources/views/customers/delete.blade.php
+++ b/resources/views/customers/delete.blade.php
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header bg-danger">
-                <h5 class="modal-title" id="exampleModalLabel">Eliminar usuario</h5>
+                <h5 class="modal-title" id="exampleModalLabel">Eliminar cliente</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -12,7 +12,7 @@
                 @csrf
                 @method('DELETE')
                 <div class="modal-body text-center text-danger">
-                    ¿Estás seguro de eliminar al Usuario <strong>{{ $customer->name }}?</strong>
+                    ¿Estás seguro de eliminar al cliente <strong>{{ $customer->name }}?</strong>
                     Recuerda que si tiene deudas y pagos asociados se eliminaran
                 </div>
                 <div class="modal-footer">

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -4,7 +4,7 @@
             <div class="card-warning">
                 <div class="card-header">
                     <div class="d-sm-flex align-items-center justify-content-between">
-                        <h4 class="card-title">Editar Usuario <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <h4 class="card-title">Editar Cliente <small> &nbsp;(*) Campos requeridos</small></h4>
                         <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     </div>
                 </div>
@@ -14,7 +14,7 @@
                     <div class="card-body">
                         <div class="card">
                             <div class="card-header py-2 bg-secondary">
-                                <h3 class="card-title">Datos del Usuario</h3>
+                                <h3 class="card-title">Datos del Cliente</h3>
                                 <div class="card-tools">
                                     <button type="button" class="btn btn-tool" data-card-widget="collapse">
                                         <i class="fa fa-minus"></i>

--- a/resources/views/customers/index.blade.php
+++ b/resources/views/customers/index.blade.php
@@ -1,6 +1,6 @@
 @extends('adminlte::page')
 
-@section('title', config('adminlte.title') . ' | Usuarios')
+@section('title', config('adminlte.title') . ' | Clientes')
 
 @section('content')
 <section class="content">
@@ -8,12 +8,12 @@
         <div class="col-md-12 col-sm-12 ">
             <div class="x_panel">
                 <div class="x_title">
-                    <h2>Usuarios</h2>
+                    <h2>Clientes</h2>
                     <div class="row">
                         <div class="col-lg-12 text-right">
-                            <div class="btn-group" role="group" aria-label="Acciones de Usuario">
+                            <div class="btn-group" role="group" aria-label="Acciones de Cliente">
                                 <button class="btn btn-success mr-2" data-toggle='modal' data-target="#createCustomer">
-                                    <i class="fa fa-plus"></i> Registrar Usuario
+                                    <i class="fa fa-plus"></i> Registrar Cliente
                                 </button>
                                 <a type="button" class="btn btn-secondary" target="_blank" title="Customers" href="{{ route('customers.pdfCustomers') }}">
                                     <i class="fas fa-users"></i> Generar Lista

--- a/resources/views/customers/show.blade.php
+++ b/resources/views/customers/show.blade.php
@@ -4,7 +4,7 @@
             <div class="card-info">
                 <div class="card-header">
                     <div class="d-sm-flex align-items-center justify-content-between">
-                        <h4 class="card-title">Información del Usuario</h4>
+                        <h4 class="card-title">Información del Cliente</h4>
                         <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
@@ -17,7 +17,7 @@
                                 <div class="col-lg-12">
                                     <div class="form-group text-center">
                                         @if ($customer->getFirstMediaUrl('customerGallery'))
-                                            <img src="{{ $customer->getFirstMediaUrl('customerGallery') }}" alt="Foto del Usuario" class="img-fluid" 
+                                            <img src="{{ $customer->getFirstMediaUrl('customerGallery') }}" alt="Foto del Cliente" class="img-fluid" 
                                              style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                         @else
                                             <img src="{{ asset('img/userDefault.png') }}" alt="Foto del Usuario" class="img-fluid" 

--- a/resources/views/debts/create.blade.php
+++ b/resources/views/debts/create.blade.php
@@ -26,9 +26,9 @@
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="customer_id" class="form-label">Usuario(*)</label>
+                                            <label for="customer_id" class="form-label">Cliente(*)</label>
                                             <select id="mySelect" class="form-control select2" name="customer_id" required>
-                                                <option value="">Seleccione un usuario</option>
+                                                <option value="">Seleccione un cliente</option>
                                                 @foreach($customers as $customer)
                                                     <option value="{{ $customer->id }}" {{ old('customer_id') == $customer->id ? 'selected' : '' }}>
                                                         {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -47,7 +47,7 @@
                                     <thead>
                                         <tr>
                                             <th>ID</th>
-                                            <th>USUARIO</th>
+                                            <th>CLIENTE</th>
                                             <th>TOTAL DE LA DEUDA</th>
                                             <th>OPCIONES</th>
                                         </tr>

--- a/resources/views/debts/showDebts.blade.php
+++ b/resources/views/debts/showDebts.blade.php
@@ -4,7 +4,7 @@
             <div class="card-primary">
                 <div class="card-header">
                     <div class="d-sm-flex align-items-center justify-content-between">
-                        <h4 class="card-title">Información de Deudas del Usuario</h4>
+                        <h4 class="card-title">Información de Deudas del Cliente</h4>
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
@@ -16,13 +16,13 @@
                             <div class="row">
                                 <div class="col-lg-2">
                                     <div class="form-group">
-                                        <label>ID del Usuario</label>
+                                        <label>ID del Cliente</label>
                                         <input type="text" disabled class="form-control" value="{{ $debt->customer->id }}" />
                                     </div>
                                 </div>
                                 <div class="col-lg-10">
                                     <div class="form-group">
-                                        <label>Nombre del Usuario</label>
+                                        <label>Nombre del Cliente</label>
                                         <input type="text" disabled class="form-control" value="{{ $debt->customer->name }} {{ $debt->customer->last_name }}" />
                                     </div>
                                 </div>

--- a/resources/views/payments/clientPayments.blade.php
+++ b/resources/views/payments/clientPayments.blade.php
@@ -10,8 +10,9 @@
             <form id="clientPaymentForm" method="GET" action="{{ route('report.client-payments') }}">
                 <div class="modal-body">
                     <div class="form-group">
+                        <label for="customerId" class="form-label">Cliente(*)</label>
                         <select class="form-control select2" name="customerId" id="customerId" required>
-                            <option value="">Selecciona un usuario</option>
+                            <option value="">Selecciona un cliente</option>
                             @foreach($customers as $customer)
                                 <option value="{{ $customer->id }}">
                                     {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}

--- a/resources/views/payments/create.blade.php
+++ b/resources/views/payments/create.blade.php
@@ -34,9 +34,9 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="customer_id" class="form-label">Seleccionar Usuario(*)</label>
+                                            <label for="customer_id" class="form-label">Seleccionar Cliente(*)</label>
                                             <select class="form-control select2" name="customer_id" id="customer_id" required>
-                                                <option value="">Selecciona un usuario</option>
+                                                <option value="">Selecciona un cliente</option>
                                                 @foreach($customers as $customer)
                                                     <option value="{{ $customer->id }}">
                                                         {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -35,7 +35,7 @@
                                         <span class="input-group-text">
                                             <i class="fas fa-search"></i>
                                         </span>
-                                        <input type="text" name="name" id="searchName" class="form-control" placeholder="Buscar por nombre de usuario" value="{{ request('name') }}">
+                                        <input type="text" name="name" id="searchName" class="form-control" placeholder="Buscar por nombre de cliente" value="{{ request('name') }}">
                                         <input type="text" name="period" id="searchPeriod" class="form-control" placeholder="Buscar por Fecha ejemplo: enero / 2024" value="{{ request('period') }}">
                                         <div class="input-group-append">
                                             <button type="submit" class="btn btn-primary">Buscar</button>
@@ -53,7 +53,7 @@
                                         <thead>
                                             <tr>
                                                 <th>ID PAGO</th>
-                                                <th>USUARIO</th>
+                                                <th>CLIENTE</th>
                                                 <th>DEUDA</th>
                                                 <th>MONTO</th>
                                                 <th>OPCIONES</th>

--- a/resources/views/reports/clientPayments.blade.php
+++ b/resources/views/reports/clientPayments.blade.php
@@ -184,6 +184,7 @@
             }
 
             .logo img {
+                border-radius: 50%;
                 width: 140px;
                 height: 140px;
             }


### PR DESCRIPTION
This PR implements two primary changes:

Fixed profile imaged in update section, now can be imported .png, .jpg, .jpeg and .webp format.
Renaming 'Usuario' to 'Cliente' in Blade templates, including forms, table headers, modals, and notifications.
Debt Logic Update: The previous check for existing debts based on customer_id, start_date, and end_date has been removed. This allows debts to be assigned to customers even if a debt overlaps with existing dates.

Specific change:

Removed the logic from DebtController.php that prevents the assignment of overlapping debts to customers. This ensures that each new debt is treated independently and assigned without checking for existing debt conflicts.