### PR TITLE
Fix/Update Payment Receipt Layout and Default Locality Images

### DIFF
--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -14,7 +14,7 @@ class LocalityController extends Controller
 
         if ($request->has('search')) {
             $search = $request->input('search');
-            $query->whereRaw("CONCAT(locality_name, ' ', municipality, ' ', zip_code) LIKE ?", ["%{$search}%"]);
+            $query->whereRaw("CONCAT(name, ' ', municipality, ' ', zip_code) LIKE ?", ["%{$search}%"]);
         }
 
         $localities = $query->paginate(10);
@@ -42,7 +42,7 @@ class LocalityController extends Controller
     {
         $locality = Locality::find($id);
         if ($locality) {
-            $locality->locality_name = $request->input('localityNameUpdate');
+            $locality->name = $request->input('localityNameUpdate');
             $locality->municipality = $request->input('municipalityUpdate');
             $locality->state = $request->input('stateUpdate');
             $locality->zip_code = $request->input('zipCodeUpdate');

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -15,7 +15,7 @@ class Locality extends Model implements HasMedia
     use HasFactory, InteractsWithMedia, SoftDeletes;
 
     protected $fillable = [
-        'locality_name',
+        'name',
         'municipality',
         'state',
         'zip_code'

--- a/database/migrations/2014_09_14_013205_create_localities_table.php
+++ b/database/migrations/2014_09_14_013205_create_localities_table.php
@@ -10,7 +10,7 @@ class CreateLocalitiesTable extends Migration
     {
         Schema::create('localities', function (Blueprint $table) {
             $table->id();
-            $table->string('locality_name');
+            $table->string('name');
             $table->string('municipality');
             $table->string('state');
             $table->string('zip_code', 5);

--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -15,21 +15,21 @@ class LocalitiesTableSeeder extends Seeder
     public function run()
     {
         Locality::create([
-            'locality_name' => 'Smallville',
+            'name' => 'Smallville',
             'municipality' => 'Smallville',
             'state' => 'Kansas',
             'zip_code' => '66002',
         ]);
         
         Locality::create([
-            'locality_name' => 'Springfield',
+            'name' => 'Springfield',
             'municipality' => 'Springfield',
             'state' => 'Oregon',
             'zip_code' => '97477',
         ]);
 
         Locality::create([
-            'locality_name' => 'Dunder Mifflin',
+            'name' => 'Dunder Mifflin',
             'municipality' => 'Scranton',
             'state' => 'Pennsylvania',
             'zip_code' => '18503',

--- a/resources/views/customers/show.blade.php
+++ b/resources/views/customers/show.blade.php
@@ -136,7 +136,7 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label>Localidad</label>
-                                        <input type="text" disabled class="form-control" value="{{ $customer->locality->locality_name ?? 'Desconocido' }}" />
+                                        <input type="text" disabled class="form-control" value="{{ $customer->locality->name ?? 'Desconocido' }}" />
                                     </div>
                                 </div>
                                 <div class="col-lg-6">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -82,8 +82,8 @@
                                 <select id="mySelect" class="form-control select2" name="locality_id" required>
                                     <option value="">Seleccione una localidad</option>
                                     @foreach($data['localities'] as $locality)
-                                        <option value="{{ $locality->id }}" data-name="{{ $locality->locality_name }}" data-municipality="{{ $locality->municipality }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>
-                                            {{ $locality->locality_name }} , {{ $locality->municipality }}
+                                        <option value="{{ $locality->id }}" data-name="{{ $locality->name }}" data-municipality="{{ $locality->municipality }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>
+                                            {{ $locality->name }} , {{ $locality->municipality }}
                                         </option>
                                     @endforeach
                                 </select>

--- a/resources/views/localities/create.blade.php
+++ b/resources/views/localities/create.blade.php
@@ -35,8 +35,8 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="locality_name" class="form-label">Nombre de la localidad(*)</label>
-                                            <input type="text" class="form-control" id="locality_name" name="locality_name" placeholder="Ingresa nombre de la localidad" value="{{ old('locality_name') }}" required />
+                                            <label for="name" class="form-label">Nombre de la localidad(*)</label>
+                                            <input type="text" class="form-control" id="name" name="name" placeholder="Ingresa nombre de la localidad" value="{{ old('name') }}" required />
                                         </div>
                                     </div>
                                     <div class="col-lg-6">

--- a/resources/views/localities/delete.blade.php
+++ b/resources/views/localities/delete.blade.php
@@ -12,7 +12,7 @@
                 @csrf
                 @method('DELETE')
                 <div class="modal-body text-center text-danger">
-                    ¿Estás seguro de eliminar la localidad <strong>{{ $locality->locality_name }}?</strong>
+                    ¿Estás seguro de eliminar la localidad <strong>{{ $locality->name }}?</strong>
                     Recuerda que todos los clientes y supervisores relacionados a esta localidad se eliminarán
                 </div>
                 <div class="modal-footer">

--- a/resources/views/localities/edit.blade.php
+++ b/resources/views/localities/edit.blade.php
@@ -26,7 +26,7 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="localityNameUpdate" class="form-label">Nombre de la localidad(*)</label>
-                                            <input type="text" class="form-control" name="localityNameUpdate" id="localityNameUpdate" value="{{ $locality->locality_name }}" required>
+                                            <input type="text" class="form-control" name="localityNameUpdate" id="localityNameUpdate" value="{{ $locality->name }}" required>
                                         </div>
                                     </div>
                                     <div class="col-lg-6">

--- a/resources/views/localities/editLogo.blade.php
+++ b/resources/views/localities/editLogo.blade.php
@@ -27,7 +27,7 @@
                                         <div class="form-group text-center">
                                             <label for="photo-{{ $locality->id }}" class="form-label"></label>
                                             <div class="image-preview-container" style="display: flex; justify-content: center; margin-bottom: 10px;">
-                                                <img id="photo-preview-edit-{{ $locality->id }}" src="{{ $locality->getFirstMediaUrl('localityGallery') ? $locality->getFirstMediaUrl('localityGallery') : asset('img/userDefault.png') }}" 
+                                                <img id="photo-preview-edit-{{ $locality->id }}" src="{{ $locality->getFirstMediaUrl('localityGallery') ? $locality->getFirstMediaUrl('localityGallery') : asset('img/localityDefault.png') }}"
                                                 alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
                                             <input type="file" class="form-control" name="photo" id="photo-{{ $locality->id }}" onchange="previewImageEdit(event, {{ $locality->id }})">

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -63,7 +63,7 @@
                                                 <img src="{{$locality->getFirstMediaUrl('localityGallery') }}" alt="Foto de {{$locality->locality_name}}"
                                                 style="width: 50px; height: 50px; border-radius: 50%;">
                                             @else
-                                                <img src="{{ asset('img/userDefault.png') }}" 
+                                                <img src="{{ asset('img/localityDefault.png') }}"
                                                 style="width: 50px; height: 50px; border-radius: 50%;">
                                             @endif
                                             </td>

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -60,14 +60,14 @@
                                             <td scope="row">{{$locality->id}}</td>
                                             <td>
                                                 @if ($locality->getFirstMediaUrl('localityGallery'))
-                                                <img src="{{$locality->getFirstMediaUrl('localityGallery') }}" alt="Foto de {{$locality->locality_name}}"
+                                                <img src="{{$locality->getFirstMediaUrl('localityGallery') }}" alt="Foto de {{$locality->name}}"
                                                 style="width: 50px; height: 50px; border-radius: 50%;">
                                             @else
                                                 <img src="{{ asset('img/localityDefault.png') }}"
                                                 style="width: 50px; height: 50px; border-radius: 50%;">
                                             @endif
                                             </td>
-                                            <td>{{$locality->locality_name}}</td>
+                                            <td>{{$locality->name}}</td>
                                             <td>{{$locality->municipality}}</td>
                                             <td>{{$locality->state}}</td>
                                             <td>{{$locality->zip_code}}</td>

--- a/resources/views/localities/show.blade.php
+++ b/resources/views/localities/show.blade.php
@@ -32,7 +32,7 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label>Nombre de la localidad</label>
-                                        <input type="text" disabled class="form-control" value="{{ $locality->locality_name }}" />
+                                        <input type="text" disabled class="form-control" value="{{ $locality->name }}" />
                                     </div>
                                 </div>
                                 <div class="col-lg-6">

--- a/resources/views/localities/show.blade.php
+++ b/resources/views/localities/show.blade.php
@@ -16,10 +16,10 @@
                             <div class="row">
                                 <div class="col-lg-12 text-center">
                                     @if ($locality->getFirstMediaUrl('localityGallery'))
-                                        <img src="{{ $locality->getFirstMediaUrl('localityGallery') }}" alt="Foto de la localidad" class="img-fluid" 
+                                        <img src="{{ $locality->getFirstMediaUrl('localityGallery') }}" alt="Foto de la localidad" class="img-fluid"
                                         style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                     @else
-                                        <img src="{{ asset('img/userDefault.png') }}" alt="Foto de la localidad" class="img-fluid" 
+                                        <img src="{{ asset('img/localityDefault.png') }}" alt="Foto de la localidad" class="img-fluid"
                                         style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                     @endif
                                 </div>

--- a/resources/views/reports/clientPayments.blade.php
+++ b/resources/views/reports/clientPayments.blade.php
@@ -203,7 +203,7 @@
         <div id="page_pdf">
             <div class="logo">
                 @if ($authUser->locality->hasMedia('localityGallery'))
-                    <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}" alt="Photo of {{ $authUser->locality->locality_name }}">
+                    <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}" alt="Photo of {{ $authUser->locality->name }}">
                 @else
                     <img src='img/localityDefault.png' alt="Default Photo">
                 @endif
@@ -212,7 +212,7 @@
                 <tr>
                     <td class="info_empresa">
                         <div>
-                            <p class="aqua_titulo"> COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->locality_name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
+                            <p class="aqua_titulo"> COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
                             </p><br>
                             <a class="link_Whats" href="https://wa.me/525623640302">WhatsApp: +52 56 2364 0302</a><br>
                             <a class="link_Email" href="mailto:info@rootheim.com">Email: info@rootheim.com</a>

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -127,16 +127,16 @@
     <div class="receipt">
         <header class="receipt-header">           
             @if ($payment->locality->hasMedia('localityGallery'))
-                <img src="{{ $payment->locality->getFirstMediaUrl('localityGallery') }}" alt="Logo de {{ $payment->locality->locality_name }}">
+                <img src="{{ $payment->locality->getFirstMediaUrl('localityGallery') }}" alt="Logo de {{ $payment->locality->name }}">
             @else
-                <img src='img/localityDefault.png' alt="Logo de {{ $payment->locality->locality_name }}">
+                <img src='img/localityDefault.png' alt="Logo de {{ $payment->locality->name }}">
             @endif
             <div class="folio">
                 <p>FOLIO. {{ $payment->id }}</p>
             </div>
         </header>
         <div class="title">
-            <h2>COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $payment->locality->locality_name }} A.C.</h2>
+            <h2>COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $payment->locality->name }} A.C.</h2>
             <p>{{ $payment->locality->municipality }}, {{ $payment->locality->state }}</p>
         </div>
         <div class="date">
@@ -147,7 +147,7 @@
                 <h4>Datos del cliente</h4>
                 <p>{{ $payment->debt->customer->name }} {{ $payment->debt->customer->last_name }}</p>
                 <p>{{ $payment->debt->customer->street }} #{{ $payment->debt->customer->interior_number }}, {{ $payment->debt->customer->block }}, {{$payment->locality->zip_code }}</p>
-                <p>{{ $payment->locality->locality_name }}, {{ $payment->locality->state }}</p>
+                <p>{{ $payment->locality->name }}, {{ $payment->locality->state }}</p>
             </div>
             <div class="debt-info">
                 <h4>Datos de la deuda</h4>

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -23,8 +23,10 @@
         .receipt {
             margin: auto;
             padding: 20mm;
+            position: relative;
+            min-height: 100vh;
+            box-sizing: border-box;
         }
-
         .receipt-header {
             margin-top: 20px;
             text-align: left;
@@ -32,7 +34,9 @@
         }
 
         .receipt-header img {
-            max-width: 115px;
+            max-width: 120px;
+            max-height: 120px;
+            border-radius: 50%;
         }
 
         .folio {
@@ -69,7 +73,7 @@
         }
 
         .info-container {
-            margin-top: 30px;
+            margin-top: 5px;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -77,7 +81,7 @@
 
         .customer-info, .debt-info, .payment-info {
             padding-left: 150px;
-            margin: 11px auto;
+            margin: 11px;
             text-align: left;
             width: fit-content;
             word-wrap: break-word;
@@ -86,7 +90,25 @@
         .signature {
             text-align: center;
             font-size: 12px;
-            margin-top: 10px;
+            page-break-before: avoid;
+        }
+
+        .company-info {
+            text-align: center;
+            font-weight: bold;
+            font-size: 15px;
+            margin-top: 180px;
+            page-break-inside: avoid;
+        }
+
+        a.text_infoE, img.text_infoE {
+            display: inline-block;
+        }
+
+        a {
+            font-weight: normal;
+            color: white;
+            text-decoration: none;
         }
 
         h4 {
@@ -99,19 +121,6 @@
             margin: 5px 0;
             font-size: 16px;
         }
-
-        .company-info {
-            text-align: center;
-            margin-top: 215px;
-            font-weight: bold;
-            font-size: 15px;
-        }
-
-        a {
-            font-weight: normal;
-            color: white;
-            text-decoration: none;
-        }
     </style>
 </head>
 <body>
@@ -120,7 +129,7 @@
             @if ($payment->locality->hasMedia('localityGallery'))
                 <img src="{{ $payment->locality->getFirstMediaUrl('localityGallery') }}" alt="Logo de {{ $payment->locality->locality_name }}">
             @else
-                <img src='img/userDefault.png' alt="Logo por defecto">
+                <img src='img/localityDefault.png' alt="Logo de {{ $payment->locality->locality_name }}">
             @endif
             <div class="folio">
                 <p>FOLIO. {{ $payment->id }}</p>
@@ -131,7 +140,7 @@
             <p>{{ $payment->locality->municipality }}, {{ $payment->locality->state }}</p>
         </div>
         <div class="date">
-            <p>{{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de ]MMMM [del] YYYY') }} a las {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->format('H:i') }}</p>
+            <p>{{ \Carbon\Carbon::parse($payment->created_at)->setTimezone('America/Mexico_City')->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }} a las {{ \Carbon\Carbon::parse($payment->created_at)->setTimezone('America/Mexico_City')->locale('es')->format('H:i') }}</p>
         </div>
         <div class="info-container">
             <div class="customer-info">
@@ -147,7 +156,21 @@
                 <p>Fecha de vencimiento: {{ \Carbon\Carbon::parse($payment->debt->end_date)->locale('es')->isoFormat('D [de ]MMMM [del] YYYY') }}</p>
             </div>
             <div class="payment-info">
-                <p><strong>Monto total del pago: </strong>${{ $payment->amount }}</p>
+                <br>
+                <p><strong>Monto del pago: </strong>${{ $payment->amount }}</p>
+                <p>
+                    @switch($payment->method)
+                        @case('cash')
+                        <strong>Método de pago: </strong> Efectivo
+                            @break
+                        @case('card')
+                        <strong>Método de pago: </strong>Tarjeta
+                            @break
+                        @case('transfer')
+                        <strong>Método de pago: </strong>Transferencia
+                            @break
+                    @endswitch
+                </p>
             </div>
         </div>
     </div>
@@ -156,8 +179,10 @@
         <p>{{ $payment->creator->name }} {{ $payment->creator->last_name }}</p>
     </div>
     <footer class="company-info">
-        <a class="text_infoE" href="https://www.rootheim.com/"><strong>AquaControl</strong> powered by <strong>Root Heim Company</strong></a>
-        <img src="img/rootheim.png" width="18px">
+        <a class="text_infoE" href="https://www.rootheim.com/">
+            <strong>AquaControl</strong> powered by <strong>Root Heim Company</strong>
+            <img src="img/rootheim.png" width="18px">
+        </a>
     </footer>
 </body>
 </html>

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -85,7 +85,7 @@
                                                 <option value="">Selecciona la localidad</option>
                                                 @foreach($localities as $locality)
                                                     <option value="{{ $locality->id }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>
-                                                        {{ $locality->locality_name }}
+                                                        {{ $locality->name }}
                                                     </option>
                                                 @endforeach
                                             </select>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -76,7 +76,7 @@
                                                 <option value="">Sin localidad</option>
                                                 @foreach($localities as $locality)
                                                     <option value="{{ $locality->id }}" {{ $user->locality_id == $locality->id ? 'selected' : '' }}>
-                                                        {{ $locality->locality_name }}
+                                                        {{ $locality->name }}
                                                     </option>
                                                 @endforeach
                                             </select>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -58,7 +58,7 @@
                                                     <td>{{ $user->phone }}</td>
                                                     <td>{{ $user->email }}</td>
                                                     <td>{{ $user->roles->first()->name }}</td>
-                                                    <td>{{ $user->locality_id ? $user->locality->locality_name : 'Sin localidad' }}</td>
+                                                    <td>{{ $user->locality_id ? $user->locality->name : 'Sin localidad' }}</td>
                                                     <td>
                                                         <div class="btn-group" role="group" aria-label="Opciones">
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $user->id }}">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -58,7 +58,7 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label>Localidad</label>
-                                        <input type="text" disabled class="form-control" value="{{ $user->locality_id ? $user->locality->locality_name : 'Sin localidad' }}" />
+                                        <input type="text" disabled class="form-control" value="{{ $user->locality_id ? $user->locality->name : 'Sin localidad' }}" />
                                     </div>
                                 </div>
                                 <div class="col-lg-6">


### PR DESCRIPTION
## Summary

This PR includes the following changes:

1. **Payment Receipt Layout Adjustments**:
   - Adjusted the layout of the payment receipt to ensure the `enterprise-info` div does not get misaligned based on the logo size.
   - Updated the payment method display on the receipt to show the correct payment method.

2. **Locality Default Image Updates**:
   - Replaced the default user image with the locality default image in the locality views.
   - Updated the image preview in the edit logo view to reflect the new locality default image.
   - Ensured the locality images are displayed with a circular border radius for a consistent look across all views.

### Files Changed
- **Views**:
  - resources/views/localities/editLogo.blade.php
  - resources/views/localities/index.blade.php
  - resources/views/localities/show.blade.php
  - resources/views/reports/receiptPayment.blade.php

### Notes
- Review the adjustments to the payment receipt layout to verify that it appears correctly.
- Ensure that the locality default images are displayed consistently in all relevant views.