### PR TITLE
Feature/Implement hasDependencies Method and Disable Delete for Entries with Dependencies

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -46,7 +46,12 @@ class Customer extends Model implements HasMedia
     {
         return $this->belongsTo(Cost::class);
     }
-   
+
+    public function hasDependencies()
+    {
+        return $this->debts()->exists();
+    }
+
     public function debts()
     {
         return $this->hasMany(Debt::class);

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -13,6 +13,11 @@ class Debt extends Model
         'customer_id', 'locality_id', 'created_by', 'start_date', 'end_date', 'amount', 'note'
     ];
 
+    public function hasDependencies()
+    {
+        return $this->payments()->exists();
+    }
+
     public function customer()
     {
         return $this->belongsTo(Customer::class, 'customer_id');

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -21,4 +21,23 @@ class Locality extends Model implements HasMedia
         'zip_code'
     ];
 
+    public function hasDependencies()
+    {
+        return $this->customers()->exists() || $this->users()->exists() || $this->costs()->exists();
+    }
+
+    public function customers()
+    {
+        return $this->hasMany(Customer::class);
+    }
+
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function costs()
+    {
+        return $this->hasMany(Cost::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,8 +44,33 @@ class User extends Authenticatable implements HasMedia
         'email_verified_at' => 'datetime',
     ];
 
+    public function hasDependencies()
+    {
+        return $this->locality()->exists() || $this->customers()->exists() || $this->costs()->exists() || $this->debts()->exists() || $this->payments()->exists();
+    }
+
     public function locality()
     {
         return $this->belongsTo(Locality::class, 'locality_id');
+    }
+
+    public function customers()
+    {
+        return $this->hasMany(Customer::class, 'created_at');
+    }
+
+    public function costs()
+    {
+        return $this->hasMany(Cost::class, 'created_at');
+    }
+
+    public function debts()
+    {
+        return $this->hasMany(Debt::class, 'created_at');
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class, 'created_at');
     }
 }

--- a/resources/views/customers/delete.blade.php
+++ b/resources/views/customers/delete.blade.php
@@ -13,7 +13,6 @@
                 @method('DELETE')
                 <div class="modal-body text-center text-danger">
                     ¿Estás seguro de eliminar al cliente <strong>{{ $customer->name }}?</strong>
-                    Recuerda que si tiene deudas y pagos asociados se eliminaran
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>

--- a/resources/views/customers/index.blade.php
+++ b/resources/views/customers/index.blade.php
@@ -78,9 +78,15 @@
                                                     </button>
                                                     @endcan
                                                     @can('deleteCustomer')
-                                                    <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{$customer->id}}">
-                                                        <i class="fas fa-trash-alt"></i>
-                                                    </button>
+                                                        @if($customer->hasDependencies())
+                                                            <button type="button" class="btn btn-secondary mr-2" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                                <i class="fas fa-trash-alt"></i>
+                                                            </button>
+                                                        @else
+                                                            <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{$customer->id}}">
+                                                                <i class="fas fa-trash-alt"></i>
+                                                            </button>
+                                                        @endif
                                                     @endcan
                                                 </div>
                                             </td>

--- a/resources/views/customers/index.blade.php
+++ b/resources/views/customers/index.blade.php
@@ -79,7 +79,7 @@
                                                     @endcan
                                                     @can('deleteCustomer')
                                                         @if($customer->hasDependencies())
-                                                            <button type="button" class="btn btn-secondary mr-2" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                            <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
                                                                 <i class="fas fa-trash-alt"></i>
                                                             </button>
                                                         @else

--- a/resources/views/debts/showDebts.blade.php
+++ b/resources/views/debts/showDebts.blade.php
@@ -67,9 +67,15 @@
                                                                     <i class="fas fa-eye"></i>
                                                                 </button>
                                                                 @can('deleteDebt')
-                                                                <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $customerDebt->id }}">
-                                                                    <i class="fas fa-trash-alt"></i>
-                                                                </button>
+                                                                    @if($customerDebt->hasDependencies() && $customerDebt->status !== 'paid')
+                                                                        <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                                            <i class="fas fa-trash-alt"></i>
+                                                                        </button>
+                                                                    @else
+                                                                        <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $customerDebt->id }}">
+                                                                            <i class="fas fa-trash-alt"></i>
+                                                                        </button>
+                                                                    @endif
                                                                 @endcan
                                                             </div>
                                                         </div>

--- a/resources/views/debts/showDebts.blade.php
+++ b/resources/views/debts/showDebts.blade.php
@@ -68,7 +68,7 @@
                                                                 </button>
                                                                 @can('deleteDebt')
                                                                     @if($customerDebt->hasDependencies() && $customerDebt->status !== 'paid')
-                                                                        <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                                        <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
                                                                             <i class="fas fa-trash-alt"></i>
                                                                         </button>
                                                                     @else

--- a/resources/views/localities/delete.blade.php
+++ b/resources/views/localities/delete.blade.php
@@ -13,7 +13,6 @@
                 @method('DELETE')
                 <div class="modal-body text-center text-danger">
                     ¿Estás seguro de eliminar la localidad <strong>{{ $locality->name }}?</strong>
-                    Recuerda que todos los clientes y supervisores relacionados a esta localidad se eliminarán
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -82,9 +82,15 @@
                                                     <button type="button" class="btn btn-primary mr-2" data-toggle="modal" title="Actualizar Imagen" data-target="#editLogo{{$locality->id}}">
                                                         <i class="fas fa-image"></i>
                                                     </button>
-                                                    <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{$locality->id}}">
-                                                        <i class="fas fa-trash-alt"></i>
-                                                    </button>
+                                                    @if($locality->hasDependencies())
+                                                        <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                            <i class="fas fa-trash-alt"></i>
+                                                        </button>
+                                                    @else
+                                                        <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{$locality->id}}">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                        </button>
+                                                    @endif
                                                 </div>
                                             </td>
                                             @include('localities.edit')

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -83,7 +83,7 @@
                                                         <i class="fas fa-image"></i>
                                                     </button>
                                                     @if($locality->hasDependencies())
-                                                        <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                        <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
                                                             <i class="fas fa-trash-alt"></i>
                                                         </button>
                                                     @else

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -70,9 +70,15 @@
                                                             <button type="button" class="btn btn-primary mr-2" data-toggle="modal" title="Editar Contraseña" data-target="#editPassword{{ $user->id }}">
                                                                 <i class="fas fa-lock"></i>
                                                             </button>
-                                                            <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $user->id }}">
-                                                                <i class="fas fa-trash-alt"></i>
-                                                            </button>
+                                                            @if($user->hasDependencies())
+                                                                <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
+                                                            @else
+                                                                <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $user->id }}">
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
+                                                            @endif
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -71,7 +71,7 @@
                                                                 <i class="fas fa-lock"></i>
                                                             </button>
                                                             @if($user->hasDependencies())
-                                                                <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="No se puede eliminar registro: Contiene dependencias." disabled>
+                                                                <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>
                                                             @else


### PR DESCRIPTION
## Summary

This PR introduces the following changes:

### Dependency Check Implementation:
- Added a new `hasDependencies` method in the `Customer`, `Debt`, `Locality`, and `User` models to check if records have related dependencies.
- Updated the delete buttons in the views to be disabled when the record has dependencies, ensuring that dependent data cannot be deleted.

### UI Updates for Record Deletion:
- Disabled the delete buttons for `customers`, `debts`, `localities`, and `users` if the record has associated dependencies (e.g., debts, customers, or related data).
- Updated the delete modals to remove old warning messages related to the deletion of dependent data.
- The delete button now shows a disabled state with a tooltip indicating why the action is not allowed.

---

**Files Changed**

#### Models:
- `app/Models/Customer.php`
- `app/Models/Debt.php`
- `app/Models/Locality.php`
- `app/Models/User.php`

#### Views:
- `resources/views/customers/delete.blade.php`
- `resources/views/customers/index.blade.php`
- `resources/views/debts/showDebts.blade.php`
- `resources/views/localities/delete.blade.php`
- `resources/views/localities/index.blade.php`
- `resources/views/users/index.blade.php`

---

**Notes**
- Ensure that the `hasDependencies` logic is functioning as expected in all relevant areas.
- Review UI changes to verify that the delete buttons are correctly disabled when dependencies exist.
