### PR TITLE
Fix/users without locality

### DIFF
--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -123,13 +123,13 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="occupants_number" class="form-label">Número de Ocupantes(*)</label>
-                                            <input type="number" class="form-control" id="occupants_number" name="occupants_number" placeholder="Ingresa número de ocupantes" value="{{ old('occupants_number') }}" required />
+                                            <input type="number" min="1" class="form-control" id="occupants_number" name="occupants_number" placeholder="Ingresa número de ocupantes" value="{{ old('occupants_number') }}" required />
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="water_days" class="form-label">Días de Agua(*)</label>
-                                            <input type="number" class="form-control" id="water_days" name="water_days" placeholder="Ingresa días de agua" value="{{ old('water_days') }}" required />
+                                            <input type="number" min="0" class="form-control" id="water_days" name="water_days" placeholder="Ingresa días de agua" value="{{ old('water_days') }}" required />
                                         </div>
                                     </div>
                                     <div class="col-lg-6">

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -122,13 +122,13 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="occupantsNumberUpdate" class="form-label">Número de Ocupantes(*)</label>
-                                            <input type="number" class="form-control" name="occupantsNumberUpdate" id="occupantsNumberUpdate" value="{{ $customer->occupants_number }}" required>
+                                            <input type="number" min="1" class="form-control" name="occupantsNumberUpdate" id="occupantsNumberUpdate" value="{{ $customer->occupants_number }}" required>
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="waterDaysUpdate" class="form-label">Días de Agua(*)</label>
-                                            <input type="number" class="form-control" name="waterDaysUpdate" id="waterDaysUpdate" value="{{ $customer->water_days }}" required>
+                                            <input type="number" min="0" class="form-control" name="waterDaysUpdate" id="waterDaysUpdate" value="{{ $customer->water_days }}" required>
                                         </div>
                                     </div>
                                     <div class="col-lg-6">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -40,7 +40,7 @@
                                 <div class="small-box bg-info">
                                     <div class="inner">
                                         <h3>{{ $data['customersByLocality'] }}</h3>
-                                        <p>Total de Usuarios</p>
+                                        <p>Total de Clientes</p>
                                     </div>
                                     <div class="icon">
                                         <i class="fas fa-users"></i>
@@ -52,7 +52,7 @@
                                 <div class="small-box bg-green">
                                     <div class="inner">
                                         <h3>{{ $data['customersWithoutDebts'] }}</h3>
-                                        <p>Usuarios al día</p>
+                                        <p>Clientes al Día</p>
                                     </div>
                                     <div class="icon">
                                         <i class="fas fa-check-circle"></i>
@@ -64,7 +64,7 @@
                                 <div class="small-box bg-red">
                                     <div class="inner">
                                         <h3>{{ $data['customersWithDebts'] }}</h3>
-                                        <p>Usuarios con Deudas</p>
+                                        <p>Clientes con Deudas</p>
                                     </div>
                                     <div class="icon">
                                         <i class="fas fa-exclamation-circle"></i>

--- a/resources/views/payments/create.blade.php
+++ b/resources/views/payments/create.blade.php
@@ -69,7 +69,7 @@
                                                 <div class="input-group-prepend">
                                                     <span class="input-group-text"><i class="fa fa-dollar-sign"></i></span>
                                                 </div>
-                                                <input type="number" class="form-control" name="amount" placeholder="Ingresa el monto" value="{{ old('amount') }}" required />
+                                                <input type="number" min="1" class="form-control" name="amount" placeholder="Ingresa el monto" value="{{ old('amount') }}" required />
                                             </div>
                                         </div>
                                     </div>

--- a/resources/views/payments/edit.blade.php
+++ b/resources/views/payments/edit.blade.php
@@ -44,7 +44,7 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="amount" class="form-label">Monto del Pago(*)</label>
-                                            <input type="number" class="form-control" name="amount" id="amount" value="{{ $payment->amount }}" required>
+                                            <input type="number" min="1" class="form-control" name="amount" id="amount" value="{{ $payment->amount }}" required>
                                         </div>
                                     </div>
                                     <div class="col-lg-12">

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -67,8 +67,8 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="role" class="form-label">ROL(*)</label>
-                                            <select id="role_id" class="form-control select2" name="roles[]" required onchange="toggleLocalitySelect()">
+                                            <label for="role" class="form-label">Rol(*)</label>
+                                            <select id="role_id" class="form-control select2" name="roles[]" required onchange="toggleLocalitySelect()" required>
                                                 <option value="" data-select-locality="false">Selecciona el rol</option>
                                                 @foreach($roles as $role)
                                                 <option value="{{ $role->id }}" data-select-locality="{{ $role->hasPermissionTo('selectLocality') ? 'true' : 'false' }}" {{ old('role_id') == $role->id ? 'selected' : '' }}>
@@ -80,8 +80,8 @@
                                     </div>
                                     <div class="col-lg-6" id="localityContainer">
                                         <div class="form-group">
-                                            <label for="locality" class="form-label">LOCALIDAD(*)</label>
-                                            <select id="locality_id" class="form-control select2" name="locality_id">
+                                            <label for="locality" class="form-label">Localidad(*)</label>
+                                            <select id="locality_id" class="form-control select2" name="locality_id" required>
                                                 <option value="">Selecciona la localidad</option>
                                                 @foreach($localities as $locality)
                                                     <option value="{{ $locality->id }}" {{ old('locality_id') == $locality->id ? 'selected' : '' }}>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -28,7 +28,7 @@
                                             <label for="photo-{{ $user->id }}" class="form-label"></label>
                                             <div class="image-preview-container" style="display: flex; justify-content: center; margin-bottom: 10px;">
                                                 <img id="photo-preview-edit-{{ $user->id }}" src="{{ $user->getFirstMediaUrl('userGallery') ? $user->getFirstMediaUrl('userGallery') : asset('img/userDefault.png') }}" 
-                                                  alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
+                                                    alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
                                             <input type="file" class="form-control" name="photo" id="photo-{{ $user->id }}" onchange="previewImageEdit(event, {{ $user->id }})">
                                         </div>
@@ -53,14 +53,14 @@
                                     </div>
                                     <div class="col-lg-12">
                                         <div class="form-group">
-                                            <label for="emailUpdate" class="form-label">Email (*)</label>
+                                            <label for="emailUpdate" class="form-label">Email(*)</label>
                                             <input type="email" class="form-control" name="emailUpdate" id="emailUpdate" value="{{ $user->email }}" required>
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="roleUpdate" class="form-label">Rol (*)</label>
-                                            <select id="roleUpdate-{{ $user->id }}" class="form-control select2" name="roleUpdate" required onchange="toggleLocalityChange({{ $user->id }})">
+                                            <label for="roleUpdate" class="form-label">Rol(*)</label>
+                                            <select id="roleUpdate-{{ $user->id }}" class="form-control select2" name="roleUpdate" required onchange="toggleLocalityChange({{ $user->id }})" required>
                                                 @foreach($roles as $role)
                                                     <option value="{{ $role->id }}" {{ $user->roles->contains($role->id) ? 'selected' : '' }} data-change-locality="{{ $role->hasPermissionTo('selectLocality') ? 'true' : 'false' }}">
                                                         {{ $role->name }}
@@ -71,9 +71,9 @@
                                     </div>
                                     <div class="col-lg-6" id="localityContainer">
                                         <div class="form-group">
-                                            <label for="localityUpdate" class="form-label">Localidad (*)</label>
+                                            <label for="localityUpdate" class="form-label">Localidad(*)</label>
                                             <select id="localityUpdate-{{ $user->id }}" class="form-control select2" name="localityUpdate" required>
-                                                <option value="">Sin localidad</option>
+                                                <option value="">No aplica</option>
                                                 @foreach($localities as $locality)
                                                     <option value="{{ $locality->id }}" {{ $user->locality_id == $locality->id ? 'selected' : '' }}>
                                                         {{ $locality->name }}

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -58,7 +58,7 @@
                                                     <td>{{ $user->phone }}</td>
                                                     <td>{{ $user->email }}</td>
                                                     <td>{{ $user->roles->first()->name }}</td>
-                                                    <td>{{ $user->locality_id ? $user->locality->name : 'Sin localidad' }}</td>
+                                                    <td>{{ $user->locality_id ? $user->locality->name : 'No aplica' }}</td>
                                                     <td>
                                                         <div class="btn-group" role="group" aria-label="Opciones">
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $user->id }}">


### PR DESCRIPTION
This pull request includes the following changes:

1. **Form Label Fixes**: Formatting of labels for role, locality, and email fields has been adjusted, removing unnecessary spaces between text and asterisks indicating required fields.

2. **Location Selector Improvements**:
- On the user creation and editing forms, the field to select a locality now displays "Not Applicable" instead of "No Locality" when no locale is assigned.
- Added `required` attribute to the locale and role selectors to ensure that the user completes these fields.

3. **Location Display in User Table**: In the user table view, the locale column now displays "Not Applicable" when a user does not have a locality assigned, instead of "No Locale."

4. **Changed from "Users" to "Customers"**:
- The text that previously displayed "Total Users", "Users in good standing" and "Users with Debts" has been updated to "Total Clients", "Customers in good standing" and "Customers with Debts" respectively to properly reflect the customer focus within the system.

5. **Setting minimum values ​​for numeric fields**:
- Added `min` attribute to several numeric fields on forms:
- The "Number of Occupants" field now has a minimum value of 1.
- The "Days of Water" field has a minimum value of 0.
- The "Amount" field on payment forms is set to a minimum of 1.