### PR TITLE
Fix/Payment method display issue on payment registration

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -108,6 +108,7 @@ class PaymentController extends Controller
             'locality_id' => $authUser->locality_id,
             'created_by' => $authUser->id,
             'debt_id' => $request->debt_id,
+            'method' => $request->method,
             'amount' => $request->amount,
             'note' => $request->note,
         ]);

--- a/resources/views/payments/create.blade.php
+++ b/resources/views/payments/create.blade.php
@@ -75,8 +75,8 @@
                                     </div>
                                     <div class="col-lg-12">
                                         <div class="form-group">
-                                            <label for="note" class="form-label">Método de Pago(*)</label>
-                                            <select id="mySelect" class="form-control select2" name="method" required>
+                                            <label for="method" class="form-label">Método de Pago(*)</label>
+                                            <select id="method" class="form-control select2" name="method" required>
                                                 <option value="">Selecciona un método de pago</option>
                                                 <option value="cash">Efectivo</option>
                                                 <option value="card">Tarjeta</option>


### PR DESCRIPTION
## Summary
This PR addresses an issue where the payment method was not being correctly displayed during the payment registration process. The root cause was a missing method in the `PaymentController`, which has now been added. Additionally, the view file `create.blade.php` has been updated to properly reflect the selected payment method.

### Files Modified
- `PaymentController.php`: Added the missing method responsible for managing the payment method display logic.
- `create.blade.php`: Updated the template to correctly name of select payment method.