### PR TITLE
Feature/image files restrinction and cleaning form

### DIFF
--- a/database/seeders/CustomersTableSeeder.php
+++ b/database/seeders/CustomersTableSeeder.php
@@ -40,7 +40,6 @@ class CustomersTableSeeder extends Seeder
                 'water_days' => $faker->numberBetween(1, 7),
                 'has_water_pressure' => $faker->boolean,
                 'has_cistern' => $faker->boolean,
-                'has_cistern' => $faker->boolean,
                 'status' => $faker->boolean, 
                 'locality_id' => $faker->randomElement($localityIds),
                 'created_by' => $faker->randomElement($userIds),

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -24,7 +24,7 @@ class RolesAndPermissionsSeeder extends Seeder
         ])->assignRole($roleAdmin);
         Permission::create([
             'name' => 'viewCustomers',
-            'description' => 'Permite ver los Usuarios.'
+            'description' => 'Permite ver los Clientes.'
         ])->assignRole([$roleSupervisor, $roleSecretariat ]);
         Permission::create([
             'name' => 'viewPayments',
@@ -40,51 +40,47 @@ class RolesAndPermissionsSeeder extends Seeder
         ])->assignRole([$roleSupervisor, $roleSecretariat ]);
         Permission::create([
             'name' => 'deleteCost',
-            'description' => 'Permite eliminar los costos.'
+            'description' => 'Permite eliminar los Costos.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'editCost',
-            'description' => 'Permite editar los costos.'
+            'description' => 'Permite editar los Costos.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'deletePayment',
-            'description' => 'Permite editar los pagos.'
+            'description' => 'Permite eliminar los Pagos.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'editPayment',
-            'description' => 'Permite editar los pagos.'
+            'description' => 'Permite editar los Pagos.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'deleteDebt',
-            'description' => 'Permite eliminar deuda.'
-        ])->assignRole([$roleSupervisor]);
-        Permission::create([
-            'name' => 'editDebts',
-            'description' => 'Permite ver los Costos.'
+            'description' => 'Permite eliminar Deuda.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'editCustomer',
-            'description' => 'Permite ver los Costos.'
+            'description' => 'Permite editar los Clientes.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'deleteCustomer',
-            'description' => 'Permite ver los Costos.'
+            'description' => 'Permite eliminar los Clientes.'
         ])->assignRole([$roleSupervisor]);
         Permission::create([
             'name' => 'viewLocation',
-            'description' => 'Permite ver las localidades.'
+            'description' => 'Permite ver las Localidades.'
         ])->assignRole([$roleAdmin]);
         Permission::create([
             'name' => 'editLocation',
-            'description' => 'Permite editar las localidades.'
+            'description' => 'Permite editar las Localidades.'
         ])->assignRole([$roleAdmin]);
         Permission::create([
             'name' => 'deleteLocation',
-            'description' => 'Permite eliminar localidades.'
+            'description' => 'Permite eliminar Localidades.'
         ])->assignRole([$roleAdmin]);
         Permission::create([
             'name' => 'selectLocality',
-            'description' => 'Permite seleccionar localidades.'
+            'description' => 'Permite seleccionar Localidades.'
         ])->assignRole([$roleSecretariat, $roleSupervisor]);        
         Permission::create([
             'name' => 'viewDashboardCards',

--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -30,7 +30,7 @@
                                             <div class="image-preview-container" style="display: flex; justify-content: center; margin-top: 10px;">
                                                 <img id="photo-preview" src="#" alt="Vista previa de la foto" style="display: none; width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
-                                            <input type="file" class="form-control" name="photo" id="photo" aria-describedby="photoHelp" onchange="previewImage(event)" />
+                                            <input type="file" accept="image/*" class="form-control" name="photo" id="photo" aria-describedby="photoHelp" onchange="previewImage(event)" />
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
@@ -197,7 +197,21 @@
 
 <script>
     function previewImage(event) {
-    var reader = new FileReader();
+        var input = event.target;
+        var file = input.files[0];
+        var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
+
     reader.onload = function(){
         var output = document.getElementById('photo-preview');
         output.src = reader.result;

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -28,9 +28,9 @@
                                             <label for="photo-{{ $customer->id }}" class="form-label"></label>
                                             <div class="image-preview-container" style="display: flex; justify-content: center; margin-bottom: 10px;">
                                                 <img id="photo-preview-edit-{{ $customer->id }}" src="{{ $customer->getFirstMediaUrl('customerGallery') ? $customer->getFirstMediaUrl('customerGallery') : asset('img/userDefault.png') }}" 
-                                                  alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
+                                                    alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
-                                            <input type="file" class="form-control" name="photo" id="photo-{{ $customer->id }}" onchange="previewImageEdit(event, {{ $customer->id }})">
+                                            <input type="file" accept="image/*" class="form-control" name="photo" id="photo-{{ $customer->id }}" onchange="previewImageEdit(event, {{ $customer->id }})">
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
@@ -197,7 +197,20 @@
 <script>
     function previewImageEdit(event, id) {
         var input = event.target;
+        var file = input.files[0];
         var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
+
         reader.onload = function() {
             var dataURL = reader.result;
             var output = document.getElementById('photo-preview-edit-' + id);

--- a/resources/views/localities/create.blade.php
+++ b/resources/views/localities/create.blade.php
@@ -30,7 +30,7 @@
                                             <div class="image-preview-container" style="display: flex; justify-content: center; margin-top: 10px;">
                                                 <img id="photo-preview" src="#" alt="Vista previa de la foto" style="display: none; width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
-                                            <input type="file" class="form-control" name="photo" id="photo" aria-describedby="photoHelp" onchange="previewImage(event)" />
+                                            <input type="file" accept="image/*" class="form-control" name="photo" id="photo" aria-describedby="photoHelp" onchange="previewImage(event)" />
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
@@ -73,7 +73,20 @@
 
 <script>
     function previewImage(event) {
+        var input = event.target;
+        var file = input.files[0];
         var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
 
         reader.onload = function() {
             var output = document.getElementById('photo-preview');

--- a/resources/views/localities/editLogo.blade.php
+++ b/resources/views/localities/editLogo.blade.php
@@ -30,7 +30,7 @@
                                                 <img id="photo-preview-edit-{{ $locality->id }}" src="{{ $locality->getFirstMediaUrl('localityGallery') ? $locality->getFirstMediaUrl('localityGallery') : asset('img/localityDefault.png') }}"
                                                 alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
-                                            <input type="file" class="form-control" name="photo" id="photo-{{ $locality->id }}" onchange="previewImageEdit(event, {{ $locality->id }})">
+                                            <input type="file" accept="image/*" class="form-control" name="photo" id="photo-{{ $locality->id }}" onchange="previewImageEdit(event, {{ $locality->id }})">
                                         </div>
                                     </div>
                                 </div>
@@ -50,7 +50,20 @@
 <script>
     function previewImageEdit(event, id) {
         var input = event.target;
+        var file = input.files[0];
         var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
+
         reader.onload = function() {
             var dataURL = reader.result;
             var output = document.getElementById('photo-preview-edit-' + id);

--- a/resources/views/profile/editImage.blade.php
+++ b/resources/views/profile/editImage.blade.php
@@ -35,8 +35,20 @@
 <script>
     function previewAndReplaceImage(event) {
         const currentProfileImage = document.getElementById('currentProfileImage');
-        const file = event.target.files[0];
-        const reader = new FileReader();
+        var input = event.target;
+        var file = input.files[0];
+        var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
 
         reader.onload = function() {
             currentProfileImage.src = reader.result;

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -70,7 +70,7 @@
                                         Teléfono
                                     </label>
                                     <div class="col-sm-10">
-                                        <input type="tel" id="phoneUpdate" name="phoneUpdate"  class="form-control" placeholder="Teléfono" value="{{ $authUser->phone }}">
+                                        <input type="tel" pattern="^\d{10}$" id="phoneUpdate" name="phoneUpdate"  class="form-control" placeholder="Teléfono" title="Debe contener exactamente 10 dígitos" value="{{ $authUser->phone }}">
                                     </div>
                                 </div>
                                 <div class="form-group row">

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -29,7 +29,7 @@
                                             <div class="image-preview-container" style="display: flex; justify-content: center; margin-top: 10px;">
                                                 <img id="photo-preview" src="#" alt="Vista previa de la foto" style="display: none; width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
-                                            <input type="file" class="form-control" name="photo" id="photo" aria-describedby="photoHelp" onchange="previewImage(event)" />
+                                            <input type="file" accept="image/*" class="form-control" name="photo" id="photo" aria-describedby="photoHelp" onchange="previewImage(event)" />
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
@@ -116,14 +116,27 @@
 <script>
     function previewImage(event) {
         var input = event.target;
+        var file = input.files[0];
         var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
+
         reader.onload = function() {
             var dataURL = reader.result;
             var output = document.getElementById('photo-preview');
             output.src = dataURL;
             output.style.display = 'block';
         };
-        reader.readAsDataURL(input.files[0]);
+        reader.readAsDataURL(file);
     }
 
     function toggleLocalitySelect() {

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -53,7 +53,7 @@
                                     <div class="col-lg-4">
                                         <div class="form-group">
                                             <label for="phone" class="form-label">Teléfono(*)</label>
-                                            <input type="text" class="form-control" name="phone" placeholder="Ingresa número de teléfono" value="{{ old('phone') }}"/>
+                                            <input type="tel" pattern="^\d{10}$" class="form-control" name="phone" placeholder="Ingresa número de teléfono" title="Debe contener exactamente 10 dígitos" value="{{ old('phone') }}"/>
                                         </div>
                                     </div>
                                     <div class="col-lg-4">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -48,7 +48,7 @@
                                     <div class="col-lg-5">
                                         <div class="form-group">
                                             <label for="phoneUpdate" class="form-label">Teléfono (*)</label>
-                                            <input type="text" class="form-control" name="phoneUpdate" id="phoneUpdate" value="{{ $user->phone }}" >
+                                            <input type="tel" pattern="^\d{10}$" class="form-control" name="phoneUpdate" id="phoneUpdate" title="Debe contener exactamente 10 dígitos" value="{{ $user->phone }}" >
                                         </div>
                                     </div>
                                     <div class="col-lg-12">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -30,7 +30,7 @@
                                                 <img id="photo-preview-edit-{{ $user->id }}" src="{{ $user->getFirstMediaUrl('userGallery') ? $user->getFirstMediaUrl('userGallery') : asset('img/userDefault.png') }}" 
                                                     alt="Foto Actual" style="width: 120px; height: 120px; border-radius: 50%; margin-bottom: 5px;">
                                             </div>
-                                            <input type="file" class="form-control" name="photo" id="photo-{{ $user->id }}" onchange="previewImageEdit(event, {{ $user->id }})">
+                                            <input type="file" accept="image/*" class="form-control" name="photo" id="photo-{{ $user->id }}" onchange="previewImageEdit(event, {{ $user->id }})">
                                         </div>
                                     </div>
                                     <div class="col-lg-4">
@@ -107,14 +107,27 @@
 <script>
     function previewImageEdit(event, id) {
         var input = event.target;
+        var file = input.files[0];
         var reader = new FileReader();
+
+        if (!file.type.startsWith('image/')) {
+            Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+            });
+            input.value = '';
+            return;
+        }
+
         reader.onload = function() {
             var dataURL = reader.result;
             var output = document.getElementById('photo-preview-edit-' + id);
             output.src = dataURL;
             output.style.display = 'block';
         };
-        reader.readAsDataURL(input.files[0]);
+        reader.readAsDataURL(file);
     }
 
     function toggleLocalityChange(userId) {


### PR DESCRIPTION
### This PR includes
1. **File validation improvements**
A validation is added to ensure that the uploaded file is of type image. If the file is invalid, an error message will be displayed with SweetAlert requesting that an image file be uploaded.
2. **Added accept="image/*" attribute to input**
The file upload input now includes the accept="image/*" attribute, which restricts the file types the user can select to images.
3. **CustomersTableSeeder**:
A duplicate line for the `has_cistern` attribute is removed.
4. **RolesAndPermissionsSeeder**:
Permission descriptions are corrected, mainly to capitalize key terms such as "Customers", "Costs", "Payments", "Debt", and "Locations".
Adjusted the description for the `deletePayment` permission, which previously read "edit" instead of "delete".
5. **10-digit validation on phone number**:
Added a `pattern="^\d{10}$"` on phone input fields to ensure that only numbers with exactly 10 digits are accepted.
6. **Changed `input` type to `tel`**:
The field is now of type `tel`, ensuring that only phone numbers are entered, thus improving the semantics of the HTML.
7. **Custom validation messages**:
Added `title` attribute on the phone field to provide a clear message when the number of digits is not exactly 10.