### PR TITLE
Update pending balance calculation in customer debt report

### DIFF
--- a/resources/views/reports/customersWithDebts.blade.php
+++ b/resources/views/reports/customersWithDebts.blade.php
@@ -181,9 +181,7 @@
                                         return $waterConnection->debts->where('status', '!=', 'paid');
                                     });
                                     $totalDebt = $unpaidDebts->sum('amount');
-                                    $totalPaid = $unpaidDebts->flatMap(function ($debt) {
-                                        return $debt->payments;
-                                    })->sum('amount');
+                                    $totalPaid = $unpaidDebts->sum('debt_current');
                                     $pendingBalance = $totalDebt - $totalPaid;
                                 @endphp
                                 ${{ number_format($pendingBalance, 2, '.', ',') }}


### PR DESCRIPTION
This pull request includes a change to the `resources/views/reports/customersWithDebts.blade.php` file to simplify the calculation of the total paid amount for unpaid debts.

* Simplified the calculation of `totalPaid` by summing the `debt_current` field directly instead of mapping through payments.