### PR TITLE
Fix/Adjust modals and adjust total debt mount on index display

### DIFF
--- a/resources/views/customers/show.blade.php
+++ b/resources/views/customers/show.blade.php
@@ -85,7 +85,7 @@
                                         <input type="text" disabled class="form-control" value="{{ $customer->marital_status ? 'Casado' : 'Soltero' }}" />
                                     </div>
                                 </div>
-                                <div class="col-lg-12">
+                                <div class="col-lg-6">
                                     <div class="form-group">
                                         <label>Status</label>
                                         <input type="text" disabled class="form-control" value="{{ $customer->status ? 'Con vida' : 'Fallecido' }}" />

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -61,7 +61,17 @@
                                                 <tr>
                                                     <td>{{ $debt->waterConnection->customer->id }}</td>
                                                     <td>{{ $debt->waterConnection->customer->name }} {{ $debt->waterConnection->customer->last_name }}</td>
-                                                    <td>${{ number_format($totalDebts[$debt->waterConnection->customer_id] ?? 0, 2, '.', ',') }}</td>
+                                                    <td>
+                                                        @php
+                                                            $unpaidDebts = collect($debt->waterConnection->customer->waterConnections)->flatMap(function ($waterConnection) {
+                                                                return $waterConnection->debts->where('status', '!=', 'paid');
+                                                            });
+                                                            $totalDebt = $unpaidDebts->sum('amount');
+                                                            $totalPaid = $unpaidDebts->sum('debt_current');
+                                                            $pendingBalance = $totalDebt - $totalPaid;
+                                                        @endphp
+                                                        ${{ number_format($pendingBalance, 2, '.', ',') }}
+                                                    </td>
                                                     <td>
                                                         <div class="btn-group" role="group" aria-label="Opciones">
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles"


### PR DESCRIPTION
## Summary
This pull request includes changes to the `resources/views/customers/show.blade.php` and `resources/views/debts/index.blade.php` files to improve the layout and calculation logic for displaying customer and debt information.

Layout improvements:

* [`resources/views/customers/show.blade.php`](diffhunk://#diff-ba0c7dc56c711e555cef5f1c54f3c7709354020cf2f115ce0706f35f551ff9b2L88-R88): Adjusted the column width for the status information from `col-lg-12` to `col-lg-6` to better utilize the space on the page.

Calculation logic improvements:

* [`resources/views/debts/index.blade.php`](diffhunk://#diff-40eff735edf187743783b067717ad7fa2c162dbb0577924d5fb18c69a1c5ad41L64-R74): Updated the debt calculation to accurately reflect the pending balance by summing unpaid debts and subtracting the total paid amount.