### PR TITLE
Add note field to water connection edit form

### DIFF
--- a/resources/views/waterConnections/edit.blade.php
+++ b/resources/views/waterConnections/edit.blade.php
@@ -151,7 +151,13 @@
                                                 @endforeach
                                             </select>
                                         </div>
-                                    </div>                                                                       
+                                    </div>
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="noteUpdate" class="form-label">Nota</label>
+                                            <textarea class="form-control" id="noteUpdate" name="noteUpdate">{{ $connection->note }}</textarea>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This pull request includes a small change to the `resources/views/waterConnections/edit.blade.php` file. The change adds a new form group for updating the note associated with a water connection.

* Added a new textarea field for `noteUpdate` to allow users to update the note associated with a water connection.