### PR TITLE
Fix/debts index

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -43,10 +43,10 @@ class DebtController extends Controller
                         });
                     });
             })
-            ->selectRaw('water_connection_id, SUM(amount) as total_amount, MAX(debts.created_at) AS latest_created_at')
+            ->selectRaw('water_connection_id, debts.created_at, SUM(amount) as total_amount')
             ->where('status', '!=', 'paid')
-            ->groupBy('water_connection_id')
-            ->orderBy('latest_created_at', 'desc')
+            ->groupBy('water_connection_id', 'debts.created_at')
+            ->orderByDesc('debts.created_at')
             ->paginate(10);
 
         $totalDebts = [];

--- a/database/seeders/DebtsTableSeeder.php
+++ b/database/seeders/DebtsTableSeeder.php
@@ -31,7 +31,6 @@ class DebtsTableSeeder extends Seeder
         foreach (range(1, self::DEBT_COUNT) as $index) {
             $waterConnectionId = $faker->randomElement($waterConnectionIds);
             $waterConnection = DB::table('water_connections')->find($waterConnectionId);
-            $createdAt = $faker->dateTimeBetween($startDate, $endDate);
             $debtStartDate = $faker->dateTimeBetween($startDate, $endDate);
             $debtDuration = $faker->numberBetween(1, 12);
             $debtEndDate = Carbon::instance($debtStartDate)->addMonths($debtDuration);
@@ -57,8 +56,8 @@ class DebtsTableSeeder extends Seeder
                 'status' => $status,
                 'note' => 'Deuda generada de prueba #' . $index,
                 'deleted_at' => null,
-                'created_at' => $createdAt,
-                'updated_at' => $createdAt,
+                'created_at' => now(),
+                'updated_at' => now(),
             ]);
         }
     }

--- a/public/js/datatables/datatable-language-es.js
+++ b/public/js/datatables/datatable-language-es.js
@@ -3,6 +3,6 @@ $(document).ready(function() {
         language: {
             url: '/lang/datatables/datatable-lang-es.json'
         },
-        order: [[0, "desc"]]
+        order: []
     });
 });

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -81,9 +81,6 @@
                                                     </td>
                                                 </tr>
                                                 @include('debts.showDebts')
-                                                @php
-                                                    $shownCustomers[] = $debt->waterConnection->customer_id;
-                                                @endphp
                                             @endif
                                         @empty
                                             <tr>

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -81,6 +81,9 @@
                                                     </td>
                                                 </tr>
                                                 @include('debts.showDebts')
+                                                @php
+                                                    $shownCustomers[] = $debt->waterConnection->customer_id;
+                                                @endphp
                                             @endif
                                         @empty
                                             <tr>


### PR DESCRIPTION
This pull request includes several changes to the debt management system, focusing on improving query performance, updating seeder logic, and adjusting frontend behavior. The most important changes are grouped by their themes below:

### Query Performance Improvements:
* [`app/Http/Controllers/DebtController.php`](diffhunk://#diff-ac610a796d37bf94e4c63d54433d0871e6c6dfc1fbf9280558e2cf75683b5566L46-R49): Modified the `index` method to include `debts.created_at` in the `selectRaw` statement, adjusted the `groupBy` clause, and changed the `orderBy` to `orderByDesc` for better query performance.

### Seeder Logic Updates:
* [`database/seeders/DebtsTableSeeder.php`](diffhunk://#diff-17a0fff14fad937ecb0ad2455dc373a7f394db91a5bd0b5f042eb1157db8d8eeL34): Removed the generation of a random `createdAt` date and replaced it with the current timestamp (`now()`) for both `created_at` and `updated_at` fields to ensure consistency in seed data. [[1]](diffhunk://#diff-17a0fff14fad937ecb0ad2455dc373a7f394db91a5bd0b5f042eb1157db8d8eeL34) [[2]](diffhunk://#diff-17a0fff14fad937ecb0ad2455dc373a7f394db91a5bd0b5f042eb1157db8d8eeL60-R60)

### Frontend Adjustments:
* [`public/js/datatables/datatable-language-es.js`](diffhunk://#diff-d23e5d9d3896f43a5ff288f63ec25900dc77a3df7fc32788b7be51bcbe2f12ddL6-R6): Removed the default order configuration from the DataTables initialization to allow for custom ordering.