### PR TITLE
Fix/waterconnection index and status

### DIFF
--- a/resources/views/customers/showDebtsPerWaterConnection.blade.php
+++ b/resources/views/customers/showDebtsPerWaterConnection.blade.php
@@ -26,22 +26,30 @@
                                         <input type="text" disabled class="form-control" value="{{ $customer->name }} {{ $customer->last_name }}" />
                                     </div>
                                 </div>
-                                
                                 @php
                                     $unpaidDebts = $customer->waterConnections->flatMap->debts->where('status', '!=', 'paid');
                                     $totalDebt = $unpaidDebts->sum('amount');
                                     $totalPaid = $unpaidDebts->sum('debt_current');
                                     $pendingBalance = $totalDebt - $totalPaid;
                                 @endphp
-
                                 <div class="col-lg-12">
+                                    @if ($pendingBalance > 0)
+                                        <div class="info-box">
+                                            <span class="info-box-icon bg-danger"><i class="fa fa-dollar-sign"></i></span>
+                                            <div class="info-box-content">
+                                                <span class="info-box-text">Saldo Total Pendiente</span>
+                                                <span class="info-box-number">${{ number_format($pendingBalance, 2, '.', ',') }}</span>
+                                            </div>
+                                        </div>
+                                    @else
                                     <div class="info-box">
                                         <span class="info-box-icon bg-success"><i class="fa fa-dollar-sign"></i></span>
                                         <div class="info-box-content">
-                                            <span class="info-box-text">Saldo Total Pendiente</span>
-                                            <span class="info-box-number">${{ number_format($pendingBalance, 2, '.', ',') }}</span>
+                                            <span class="info-box-text">Sin Deudas</span>
+                                            <span class="info-box-number">Este cliente no tiene deudas pendientes</span>
                                         </div>
                                     </div>
+                                    @endif
                                 </div>
                             </div>
                             <hr>

--- a/resources/views/debts/showDebts.blade.php
+++ b/resources/views/debts/showDebts.blade.php
@@ -35,13 +35,23 @@
                                     $pendingBalance = $totalDebt - $totalPaid;
                                 @endphp
                                 <div class="col-lg-12">
+                                    @if ($pendingBalance > 0)
+                                        <div class="info-box">
+                                            <span class="info-box-icon bg-danger"><i class="fa fa-dollar-sign"></i></span>
+                                            <div class="info-box-content">
+                                                <span class="info-box-text">Saldo Total Pendiente</span>
+                                                <span class="info-box-number">${{ number_format($pendingBalance, 2, '.', ',') }}</span>
+                                            </div>
+                                        </div>
+                                    @else
                                     <div class="info-box">
                                         <span class="info-box-icon bg-success"><i class="fa fa-dollar-sign"></i></span>
                                         <div class="info-box-content">
-                                            <span class="info-box-text">Saldo Total Pendiente</span>
-                                            <span class="info-box-number">${{ number_format($pendingBalance, 2, '.', ',') }}</span>
+                                            <span class="info-box-text">Sin Deudas</span>
+                                            <span class="info-box-number">Este cliente no tiene deudas pendientes</span>
                                         </div>
                                     </div>
+                                    @endif
                                 </div>
                             </div>
                             <hr>

--- a/resources/views/waterConnections/index.blade.php
+++ b/resources/views/waterConnections/index.blade.php
@@ -102,6 +102,12 @@
 @section('js')
 <script>
     $(document).ready(function() {
+        $('#waterConnections').DataTable({
+            responsive: true,
+            paging: false,
+            info: false,
+            searching: false
+        });
 
         var successMessage = "{{ session('success') }}";
         var errorMessage = "{{ session('error') }}";


### PR DESCRIPTION
This pull request includes updates to the views for displaying customer debts and water connections. The main changes involve enhancing the user interface to provide clearer information about customer debts and improving the table display for water connections.

Enhancements to customer debt views:

* [`resources/views/customers/showDebtsPerWaterConnection.blade.php`](diffhunk://#diff-2df83eb524cb6f2d049826055530fed24f63e5bde28c5ad2595b745b74969a63L29-R52): Added conditional logic to display a different info box based on whether the customer has pending debts. If there are pending debts, the info box is highlighted in red; otherwise, a green info box indicates no debts.
* [`resources/views/debts/showDebts.blade.php`](diffhunk://#diff-197f99e24b562d7a5591585ab11225fd8af4975bed827fba1e479a8b45632cb8R38-R54): Similar to the above, added conditional logic to show an info box with a red background for pending debts and a green background for no debts.

Improvements to water connections table:

* [`resources/views/waterConnections/index.blade.php`](diffhunk://#diff-e37df4faafbc3be0b6db4286a24780ca7096adb5e4006ca221deee9a58eca317R105-R110): Integrated DataTables to enhance the water connections table with responsive design, and disabled paging, info, and searching functionalities for a cleaner display.