### PR TITLE
Enhance customer edit view by updating responsible name handling and …

### DIFF
--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -100,18 +100,23 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="status" class="form-label">Estado del titular(*)</label>
-                                            <select class="form-control" id="statusUpdate" name="statusUpdate" onchange="toggleResponsibleFieldUpdate()">
+                                            <select class="form-control"
+                                                    id="statusUpdate-{{ $customer->id }}"
+                                                    name="statusUpdate"
+                                                    onchange="toggleResponsibleFieldUpdate({{ $customer->id }})">
                                                 <option value="">Selecciona una opción</option>
                                                 <option value="1" {{ $customer->status == 1 ? 'selected' : '' }}>Con Vida</option>
                                                 <option value="0" {{ $customer->status == 0 ? 'selected' : '' }}>Fallecido</option>
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="col-lg-12" id="responsibleNameUpdate">
+                                    <div class="col-lg-12"
+                                        id="responsibleNameUpdate-{{ $customer->id }}"
+                                        style="display: {{ $customer->status == 0 ? 'block' : 'none' }};">
                                         <div class="form-group">
-                                            <label for="responsibleNameUpdate" class="form-label">Nombre de la persona que será responsable</label>
-                                            <input type="text" class="form-control" name="responsibleNameUpdate" 
-                                            placeholder="Nombre de la persona responsable si el titular fallecio, si no hay dejalo vacio"  id="responsibleNameUpdate" value="{{ $customer->responsible_name }}">
+                                            <label for="responsibleNameUpdate-{{ $customer->id }}" class="form-label"> Nombre de la persona que será responsable </label>
+                                            <input type="text" class="form-control" name="responsibleNameUpdate"
+                                                placeholder="Nombre de la persona responsable si el titular falleció, si no hay déjalo vacío" id="responsibleNameUpdate-{{ $customer->id }}" value="{{ $customer->responsible_name }}">
                                         </div>
                                     </div>
                                     <div class="col-lg-12">
@@ -135,10 +140,6 @@
 </div>
 
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        toggleResponsibleFieldUpdate();
-    });
-
     function previewImageEdit(event, id) {
         var input = event.target;
         var file = input.files[0];
@@ -172,14 +173,24 @@
         photoPreview.src = customerGalleryUrl;
     }
 
-    function toggleResponsibleFieldUpdate() {
-        var statusSelect = document.getElementById('statusUpdate');
-        var responsibleField = document.getElementById('responsibleNameUpdate');
+    function toggleResponsibleFieldUpdate(id) {
+        const statusSelect = document.getElementById('statusUpdate-' + id);
+        const responsibleField = document.getElementById('responsibleNameUpdate-' + id);
 
-        if (statusSelect.value == '0') {
-            responsibleField.style.display = 'block';
-        } else {
-            responsibleField.style.display = 'none';
-        }
+        responsibleField.style.display = statusSelect.value === '0' ? 'block' : 'none';
     }
+
+    function initializeModal(id) {
+        toggleResponsibleFieldUpdate(id);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const modals = document.querySelectorAll('.modal');
+        modals.forEach(modal => {
+            modal.addEventListener('show.bs.modal', function () {
+                const customerId = modal.id.replace('edit', '');
+                initializeModal(customerId);
+            });
+        });
+    });
 </script>


### PR DESCRIPTION
This pull request includes changes to the `resources/views/customers/edit.blade.php` file to enhance the handling of customer status updates and improve the user interface. The most important changes include updating the `toggleResponsibleFieldUpdate` function to handle multiple customer forms, modifying the status and responsible fields to include customer-specific IDs, and initializing the modal with the appropriate customer data.

Enhancements to customer status updates:

* Updated the `toggleResponsibleFieldUpdate` function to accept a customer ID parameter and use customer-specific IDs for the status and responsible fields.

User interface improvements:

* Modified the `statusUpdate` and `responsibleNameUpdate` fields to include customer-specific IDs to ensure the correct fields are targeted for each customer.
* Added the `initializeModal` function to initialize the modal with the appropriate customer data when it is shown.
* Updated the `DOMContentLoaded` event listener to initialize the modal for each customer when the modal is shown.

Removal of redundant code:

* Removed the redundant `DOMContentLoaded` event listener that previously called `toggleResponsibleFieldUpdate` without customer-specific context.