### PR TITLE
Update GeneralExpensesSeeder to reduce the number of seeded entries a…

### DIFF
--- a/database/seeders/GeneralExpensesSeeder.php
+++ b/database/seeders/GeneralExpensesSeeder.php
@@ -30,13 +30,13 @@ class GeneralExpensesSeeder extends Seeder
                 continue;
             }
 
-            foreach (range(1, 15) as $index) {
+            foreach (range(1, 5) as $index) {
                 GeneralExpense::create([
                     'locality_id' => $localityId,
                     'created_by' => $faker->randomElement($users),
                     'concept' => $faker->word(),
                     'description' => $faker->sentence(),
-                    'amount' => mt_rand(10000, 500000) / 100,
+                    'amount' => mt_rand(10, 50) * 100,
                     'type' => $types[array_rand($types)],
                     'expense_date' => now(),
                     'created_at' => now(),


### PR DESCRIPTION
This pull request includes a change to the `GeneralExpensesSeeder.php` file to adjust the number of generated expenses and the range of their amounts.

Changes to `database/seeders/GeneralExpensesSeeder.php`:

* Reduced the number of generated expenses from 15 to 5 in the `foreach` loop.
* Adjusted the range of the `amount` field from `100.00 - 5000.00` to `1000 - 5000`.