### PR TITLE
Add N/A handling for out-of-range dates in weekly expenses and earnin…

### DIFF
--- a/app/Http/Controllers/GeneralExpenseController.php
+++ b/app/Http/Controllers/GeneralExpenseController.php
@@ -106,9 +106,13 @@ class GeneralExpenseController extends Controller
 
             $day = $currentStart->copy();
             while ($day->lte($currentEnd)) {
-                $expenses = GeneralExpense::where('locality_id', $authUser->locality_id)
-                    ->whereDate('expense_date', $day->toDateString())
-                    ->sum('amount');
+                if ($day->between($startDate, $endDate)) {
+                    $expenses = GeneralExpense::where('locality_id', $authUser->locality_id)
+                        ->whereDate('expense_date', $day->toDateString())
+                        ->sum('amount');
+                } else {
+                    $expenses = 'N/A';
+                }
 
                 $dailyExpenses[$day->format('l')] = $expenses;
                 $day->addDay();

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -233,9 +233,13 @@ class PaymentController extends Controller
 
             $day = $currentStart->copy();
             while ($day->lte($currentEnd)) {
-                $earnings = Payment::where('locality_id', $authUser->locality_id)
-                    ->whereDate('created_at', $day->toDateString())
-                    ->sum('amount');
+                if ($day->between($startDate, $endDate)) {
+                    $earnings = Payment::where('locality_id', $authUser->locality_id)
+                        ->whereDate('created_at', $day->toDateString())
+                        ->sum('amount');
+                } else {
+                    $earnings = 'N/A';
+                }
 
                 $dailyEarnings[$day->format('l')] = $earnings;
                 $day->addDay();

--- a/resources/views/reports/weeklyEarnings.blade.php
+++ b/resources/views/reports/weeklyEarnings.blade.php
@@ -210,13 +210,19 @@
                             <tr>
                                 @foreach ($daysInSpanish as $dayEnglish => $dayName)
                                     @php
-                                        $dayEarnings = $week['dailyEarnings'][$dayEnglish] ?? 0;
+                                        $dayEarnings = $week['dailyEarnings'][$dayEnglish] ?? 'N/A';
                                     @endphp
-                                    <td class="textcenter">${{ number_format($dayEarnings, 2) }}</td>
+                                    <td class="textcenter">
+                                        @if ($dayEarnings === 'N/A')
+                                            {{ $dayEarnings }}
+                                        @else
+                                            ${{ number_format($dayEarnings, 2) }}
+                                        @endif
+                                    </td>
                                 @endforeach
                             </tr>
                             <tr>
-                                <td colspan="7" class="total_payment"><strong>Total de la semana:</strong> ${{ number_format(array_sum($week['dailyEarnings']), 2) }}</td>
+                                <td colspan="7" class="total_payment"><strong>Total de la semana:</strong> ${{ number_format(array_sum(array_filter($week['dailyEarnings'], fn($value) => $value !== 'N/A')), 2) }}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/resources/views/reports/weeklyExpenses.blade.php
+++ b/resources/views/reports/weeklyExpenses.blade.php
@@ -210,13 +210,19 @@
                             <tr>
                                 @foreach ($daysInSpanish as $dayEnglish => $dayName)
                                     @php
-                                        $dayExpenses = $week['dailyExpenses'][$dayEnglish] ?? 0;
+                                        $dayExpenses = $week['dailyExpenses'][$dayEnglish] ?? 'N/A';
                                     @endphp
-                                    <td class="textcenter">${{ number_format($dayExpenses, 2) }}</td>
+                                    <td class="textcenter">
+                                        @if ($dayExpenses === 'N/A')
+                                            {{ $dayExpenses }}
+                                        @else
+                                            ${{ number_format($dayExpenses, 2) }}
+                                        @endif
+                                    </td>
                                 @endforeach
                             </tr>
                             <tr>
-                                <td colspan="7" class="total_payment"><strong>Total de la semana:</strong> ${{ number_format(array_sum($week['dailyExpenses']), 2) }}</td>
+                                <td colspan="7" class="total_payment"><strong>Total de la semana:</strong> ${{ number_format(array_sum(array_filter($week['dailyExpenses'], fn($value) => $value !== 'N/A')), 2) }}</td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
This pull request includes changes to handle cases where no data is available for certain dates in the weekly reports for expenses and earnings. The changes ensure that 'N/A' is displayed instead of a numeric value when no data is available.

Changes to handle 'N/A' values in reports:

* [`app/Http/Controllers/GeneralExpenseController.php`](diffhunk://#diff-8c3dc406a9a10817e1fa8a5855af5d6e12adfccb82f343d8fa9104eaccc03388R109-R115): Added a condition to set expenses to 'N/A' when the date is outside the specified range in the `weeklyExpensesReport` method.
* [`app/Http/Controllers/PaymentController.php`](diffhunk://#diff-fb7868e87ce53611024c953e45b102576be65cd32247df19b463ca9b13e60773R236-R242): Added a condition to set earnings to 'N/A' when the date is outside the specified range in the `weeklyEarningsReport` method.

Changes to display 'N/A' in views:

* [`resources/views/reports/weeklyEarnings.blade.php`](diffhunk://#diff-c39d28dfec442eca23f52852c8ab5c2b6a4a21ec77f9317a1575fe143f93baceL213-R225): Updated the view to display 'N/A' for days with no earnings data and adjusted the total calculation to exclude 'N/A' values.
* [`resources/views/reports/weeklyExpenses.blade.php`](diffhunk://#diff-d98cfb8793f7aa2be4eb4149f0e0891d0c54eeaa4f7c7a72429a96679121be33L213-R225): Updated the view to display 'N/A' for days with no expenses data and adjusted the total calculation to exclude 'N/A' values.