### PR TITLE
Rename form and input IDs in annual expenses modal for clarity

### DIFF
--- a/resources/views/generalExpenses/annualExpenses.blade.php
+++ b/resources/views/generalExpenses/annualExpenses.blade.php
@@ -7,11 +7,11 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form id="yearForm">
+            <form id="yearExpensesForm">
                 <div class="modal-body">
                     <div class="form-group">
-                        <label for="year" class="form-label">Año(*)</label>
-                        <input type="number" id="year" name="year" class="form-control"  min="1900" max="{{ date('Y') }}" 
+                        <label for="yearExpenses" class="form-label">Año(*)</label>
+                        <input type="number" id="yearExpenses" name="yearExpenses" class="form-control"  min="1900" max="{{ date('Y') }}"
                                required placeholder="Ingrese el año ejemplo 2024" value="{{ old('year') }}" />
                     </div>
                 </div>
@@ -32,9 +32,9 @@
 </style>
 
 <script>
-    document.getElementById('yearForm').addEventListener('submit', function(event) {
+    document.getElementById('yearExpensesForm').addEventListener('submit', function(event) {
         event.preventDefault();
-        const year = document.getElementById('year').value;
+        const year = document.getElementById('yearExpenses').value;
         window.open(`/annual-expenses-report/${year}`, '_blank');
         $('#annualExpenses').modal('hide');
     });


### PR DESCRIPTION
This pull request includes changes to the `resources/views/generalExpenses/annualExpenses.blade.php` file to improve form element consistency and functionality. The most important changes include renaming form IDs and input names to be more descriptive.

Improvements to form element consistency:

* Renamed the form ID from `yearForm` to `yearExpensesForm`.
* Updated the input field ID and name from `year` to `yearExpenses`.

Enhancements to form functionality:

* Modified the JavaScript event listener to reference the new form ID `yearExpensesForm`.
* Updated the JavaScript code to use the new input field ID `yearExpenses` for retrieving the year value.