### PR TITLE
feature/payment-module-date-correction

### DIFF
--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -196,5 +196,19 @@ $('#clientPayments').on('shown.bs.modal', function(){
         dropdownParent: $('#clientPayments')
     });
 });
+
+$('form').on('submit', function(e) {
+    var period = $('#searchPeriod').val();
+    var regex = /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\/\d{4}$/i;
+
+    if (!regex.test(period)) {
+        e.preventDefault();
+        Swal.fire({
+            icon: 'error',
+            title: 'Formato inválido',
+            text: 'El formato debe ser "mes/año".'
+        });
+    }
+});
 </script>
 @endsection


### PR DESCRIPTION

To correct a bug where the payment module allows searching only by month and generates an error because it does not comply with the expected month/year format, a validation must be implemented to ensure that the entered data strictly adheres to this format.