### PR TITLE
add validation spaces in input

### DIFF
--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -230,5 +230,45 @@
             responsibleField.style.display = 'none';
         }
     }
+    
+  document.addEventListener('DOMContentLoaded', function () {
+        function addValidSpace(formSelector) {
+            const form = document.querySelector(formSelector);
+            if (!form) return;
+            form.addEventListener('submit', function (e) {
+                let valid = true;
+                let message = "<ul style='text-align:left;'>";
+                const fieldsToValidate = [
+                    'name',
+                    'last_name',
+                    'street',
+                    'block',
+                    'locality',
+                    'state',
+                    'zip_code',
+                    'exterior_number',
+                    'interior_number'
+                ];
+                fieldsToValidate.forEach(function (id) {
+                    const field = form.querySelector(`#${id}`);
+                    if (field && field.value.trim() === '') {
+                        valid = false;
+                        let labelText = field.previousElementSibling.innerText.replace('(*)', '').trim();
+                        message += `⚠️ El campo <strong>${labelText}</strong> tiene caracteres invalidos.<br><br>`;
+                    }
+                });
+                message += "</ul>";
+                if (!valid) {
+                    e.preventDefault();
+                    Swal.fire({
+                        icon: 'warning',
+                        title: 'Revisa los campos',
+                        html: message,
+                        confirmButtonText: 'Corregir'
+                    });
+                }
+            });
+        }
+  addValidSpace('#createCustomer form');
+    });
 </script>
-


### PR DESCRIPTION
This pull request adds a new validation to the customer registration form to prevent users from submitting fields containing only spaces. When the user attempts to register a customer and any required field contains only whitespace characters, the system will now display an error notification indicating that invalid characters have been entered, and the registration will be blocked until the user provides valid input. This ensures data integrity by avoiding the creation of customer records with empty or meaningless data.