### PR TITLE
prevent duplicate client registration by disabling submit button on click

### DIFF
--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -230,5 +230,14 @@
             responsibleField.style.display = 'none';
         }
     }
+    document.addEventListener('DOMContentLoaded', function() {
+    const form = document.querySelector('#createCustomer form');
+    const saveButton = document.getElementById('save');
+
+    form.addEventListener('submit', function() {
+        saveButton.disabled = true;
+        saveButton.innerHTML = 'Guardando...';
+    });
+});
 </script>
 


### PR DESCRIPTION
This pull request fixes a bug where the "Save" button in the client registration form allowed multiple submissions if clicked repeatedly, to prevent duplicate records, the button is now disabled immediately after the first click.