### PR TITLE
prevent double submit by disabling save button

### DIFF
--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -168,5 +168,18 @@
             responsibleField.style.display = 'none';
         }
     }
+
+        const form = document.getElementById('createCustomer');
+    if (form) {
+      form.addEventListener('submit', function(e) {
+        const submitButtons = form.querySelectorAll('button[type="submit"], input[type="submit"]');
+        submitButtons.forEach(button => {
+          button.disabled = true;
+          if (button.innerHTML) {
+            button.innerHTML = 'Guardando...';
+          }
+        });
+      });
+    }
 </script>
 


### PR DESCRIPTION
This PR addresses the issue of duplicate records caused by multiple clicks on the save button.
The save button is now disabled immediately upon form submission to prevent users from submitting the form multiple times.
This fix improves data integrity by ensuring only one submission is processed per user action.