### PR TITLE
add charts to the advance payments module

### DIFF
--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -6,40 +6,41 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use App\Models\Debt;
+
 
 class AdvancePaymentController extends Controller
 {
     public function index()
-{
-    $advancePayments = DB::table('debts')
-        ->where('status', 'paid')
-        ->whereColumn('created_at', '<=', DB::raw('DATE_ADD(start_date, INTERVAL 1 MONTH)'))
-        ->select(
-            DB::raw("YEAR(start_date) as year"),
-            DB::raw("MONTH(start_date) as month"),
-            DB::raw("SUM(amount) as total")
-        )
-        ->groupBy(DB::raw("YEAR(start_date), MONTH(start_date)"))
-        ->orderBy(DB::raw("YEAR(start_date), MONTH(start_date)"))
-        ->get();
-
-    $months = [];
-    $totals = [];
-
-    foreach ($advancePayments as $payment)
     {
-        $monthName = Carbon::create()
-            ->month($payment->month)
-            ->locale('es')
-            ->translatedFormat('F');
+        $advancePayments = DB::table('debts')
+            ->where('status',Debt::STATUS_PAID)
+            ->whereColumn('created_at', '<=', DB::raw('DATE_ADD(start_date, INTERVAL 1 MONTH)'))
+            ->select(
+                DB::raw("YEAR(start_date) as year"),
+                DB::raw("MONTH(start_date) as month"),
+                DB::raw("SUM(amount) as total")
+            )
+            ->groupBy(DB::raw("YEAR(start_date), MONTH(start_date)"))
+            ->orderBy(DB::raw("YEAR(start_date), MONTH(start_date)"))
+            ->get();
 
-        $months[] = $monthName . ' ' . $payment->year;
-        $totals[] = $payment->total;
+        $months = [];
+        $totals = [];
+
+        foreach ($advancePayments as $payment)
+        {
+            $monthName = Carbon::create()
+                ->month($payment->month)
+                ->locale('es')
+                ->translatedFormat('F');
+
+            $months[] = $monthName . ' ' . $payment->year;
+            $totals[] = $payment->total;
+        }
+
+        return view('advancePayments.index', compact('months', 'totals'));
     }
-
-    return view('advancePayments.index', compact('months', 'totals'));
-}
-
 
     public function create()
     {

--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -4,13 +4,42 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 class AdvancePaymentController extends Controller
 {
     public function index()
+{
+    $advancePayments = DB::table('debts')
+        ->where('status', 'paid')
+        ->whereColumn('created_at', '<=', DB::raw('DATE_ADD(start_date, INTERVAL 1 MONTH)'))
+        ->select(
+            DB::raw("YEAR(start_date) as year"),
+            DB::raw("MONTH(start_date) as month"),
+            DB::raw("SUM(amount) as total")
+        )
+        ->groupBy(DB::raw("YEAR(start_date), MONTH(start_date)"))
+        ->orderBy(DB::raw("YEAR(start_date), MONTH(start_date)"))
+        ->get();
+
+    $months = [];
+    $totals = [];
+
+    foreach ($advancePayments as $payment)
     {
-        return view('advancePayments.index');
+        $monthName = Carbon::create()
+            ->month($payment->month)
+            ->locale('es')
+            ->translatedFormat('F');
+
+        $months[] = $monthName . ' ' . $payment->year;
+        $totals[] = $payment->total;
     }
+
+    return view('advancePayments.index', compact('months', 'totals'));
+}
+
 
     public function create()
     {

--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -14,7 +14,7 @@ class AdvancePaymentController extends Controller
     public function index()
     {
         $advancePayments = DB::table('debts')
-            ->where('status',Debt::STATUS_PAID)
+            ->where('status', Debt::STATUS_PAID)
             ->whereColumn('created_at', '<=', DB::raw('DATE_ADD(start_date, INTERVAL 1 MONTH)'))
             ->select(
                 DB::raw("YEAR(start_date) as year"),

--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 use App\Models\Debt;
 
-
 class AdvancePaymentController extends Controller
 {
     public function index()

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -9,6 +9,10 @@ class Debt extends Model
 {
     use HasFactory , SoftDeletes;
 
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PARTIALITY_PAID = 'partial';
+    public const STATUS_PAID = 'paid';
+
     protected $fillable = [
         'water_connection_id', 'locality_id', 'created_by', 'start_date', 'end_date', 'amount', 'note'
     ];

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -10,7 +10,7 @@ class Debt extends Model
     use HasFactory , SoftDeletes;
 
     public const STATUS_PENDING = 'pending';
-    public const STATUS_PARTIALITY_PAID = 'partial';
+    public const STATUS_PARTIAL = 'partial';
     public const STATUS_PAID = 'paid';
 
     protected $fillable = [

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -500,12 +500,12 @@ return [
             ],
         ],
         'Chartjs' => [
-            'active' => false,
+            'active' => true,
             'files' => [
                 [
                     'type' => 'js',
                     'asset' => false,
-                    'location' => '//cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.0/Chart.bundle.min.js',
+                    'location' => 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js',
                 ],
             ],
         ],

--- a/resources/views/advancePayments/index.blade.php
+++ b/resources/views/advancePayments/index.blade.php
@@ -56,10 +56,8 @@
 @endsection
 
 @section('js')
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
 <script>
-     const labels = @json($months);
+    const labels = @json($months);
     const data = @json($totals);
 
     new Chart(document.getElementById('barChart'), {

--- a/resources/views/advancePayments/index.blade.php
+++ b/resources/views/advancePayments/index.blade.php
@@ -6,7 +6,7 @@
 
 <h2>Pagos adelantados</h2>
 
-<div class="row">
+<div class="row mb-4">
     <div class="col-lg-12 text-right">
         <div class="btn-group" role="group" aria-label="Acciones de gráfica de pagos">
             <button class="btn btn-primary mr-2" data-toggle='modal' data-target="#paymentChart">
@@ -24,15 +24,125 @@
     </div>
 </div>
 
-<div class="col-lg-4 mt-3">
-    <form method="GET" action="" class="my-3">
-        <div class="input-group">
-            <input type="text" name="search" class="form-control" placeholder="Buscar por nombre o apellido" value="{{ request('search') }}">
-            <div class="input-group-append">
-                <button type="submit" class="btn btn-primary">Buscar</button>
+@php
+    $chartHeight = '250px';
+@endphp
+
+<div class="row mt-5">
+
+    @foreach ([
+        ['id' => 'barChart', 'title' => 'Gráfica de Barras'],
+        ['id' => 'lineChart', 'title' => 'Gráfica de Líneas'],
+        ['id' => 'pieChart', 'title' => 'Gráfica de Pastel'],
+        ['id' => 'radarChart', 'title' => 'Gráfica de Radar']
+    ] as $chart)
+    <div class="col-md-6 mb-4">
+        <div class="card h-100">
+            <div class="card-header d-flex align-items-center">
+                <strong class="flex-grow-1">{{ $chart['title'] }}</strong>
+                <button class="btn btn-sm btn-outline-dark download-btn" data-canvas="{{ $chart['id'] }}">
+                    <i class="fas fa-download"></i> Descargar
+                </button>
+            </div>
+            <div class="card-body d-flex justify-content-center align-items-center" style="height: {{ $chartHeight }};">
+                <canvas id="{{ $chart['id'] }}"></canvas>
             </div>
         </div>
-    </form> 
+    </div>
+    @endforeach
+
 </div>
 
+@endsection
+
+@section('js')
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<script>
+     const labels = @json($months);
+    const data = @json($totals);
+
+    new Chart(document.getElementById('barChart'), {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Pagos',
+                data: data,
+                backgroundColor: '#007bff'
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false
+        }
+    });
+
+    new Chart(document.getElementById('lineChart'), {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Pagos',
+                data: data,
+                borderColor: '#28a745',
+                backgroundColor: 'rgba(40,167,69,0.2)',
+                fill: true
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false
+        }
+    });
+
+    new Chart(document.getElementById('pieChart'), {
+        type: 'pie',
+        data: {
+            labels: labels,
+            datasets: [{
+                data: data,
+                backgroundColor: ['#007bff', '#28a745', '#ffc107', '#dc3545']
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false
+        }
+    });
+
+    new Chart(document.getElementById('radarChart'), {
+        type: 'doughnut',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Pagos',
+                data: data,
+                backgroundColor: 'rgba(255,99,132,0.2)',
+                borderColor: 'rgba(255,99,132,1)',
+                pointBackgroundColor: 'rgba(255,99,132,1)'
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            elements: {
+                line: {
+                    borderWidth: 3
+                }
+            }
+        }
+    });
+
+    document.querySelectorAll('.download-btn').forEach(button => {
+        button.addEventListener('click', function () {
+            const canvasId = this.dataset.canvas;
+            const canvas = document.getElementById(canvasId);
+            const link = document.createElement('a');
+            link.href = canvas.toDataURL('image/png');
+            link.download = `${canvasId}.png`;
+            link.click();
+        });
+    });
+</script>
 @endsection


### PR DESCRIPTION
Charts were added to the advance payments module.
Four different charts are now displayed to visualize the monthly income from advance payments.
Additionally, a download button was added to each chart, allowing users to export them individually.