### PR TITLE
display advance payments per water connection with detailed dates

### DIFF
--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -9,6 +9,10 @@ class Debt extends Model
 {
     use HasFactory , SoftDeletes;
 
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PARTIALITY_PAID = 'partial';
+    public const STATUS_PAID = 'paid';
+
     protected $fillable = [
         'water_connection_id', 'locality_id', 'created_by', 'start_date', 'end_date', 'amount', 'note'
     ];

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -10,7 +10,7 @@ class Debt extends Model
     use HasFactory , SoftDeletes;
 
     public const STATUS_PENDING = 'pending';
-    public const STATUS_PARTIALITY_PAID = 'partial';
+    public const STATUS_PARTIAL = 'partial';
     public const STATUS_PAID = 'paid';
 
     protected $fillable = [

--- a/resources/views/customers/showDebtsPerWaterConnection.blade.php
+++ b/resources/views/customers/showDebtsPerWaterConnection.blade.php
@@ -36,7 +36,7 @@
                                     $pendingBalance = $totalDebt - $totalPaid;
 
                                     $futurePaidDebts = $customer->waterConnections->flatMap->debts->filter(function ($debt) use ($today) {
-                                    return $debt->status === 'paid' && Carbon::parse($debt->start_date)->gt($today);
+                                        return $debt->status === 'paid' && Carbon::parse($debt->start_date)->gt($today);
                                     });
 
                                     $hasAdvancePayment = $futurePaidDebts->isNotEmpty();
@@ -77,7 +77,7 @@
                                     </div>
                                 @endif
                             </div>
-                            </div>
+                        </div>
                             <hr>
                             <h5>Deudas Asociadas Por Tomas</h5>
                             <div class="form-group">

--- a/resources/views/customers/showDebtsPerWaterConnection.blade.php
+++ b/resources/views/customers/showDebtsPerWaterConnection.blade.php
@@ -28,6 +28,7 @@
                                 </div>
                                 @php
                                     use Carbon\Carbon;
+                                    use App\Models\Debt;
                                     $today = Carbon::today();
 
                                     $unpaidDebts = $customer->waterConnections->flatMap->debts->where('status', '!=', 'paid');
@@ -36,7 +37,7 @@
                                     $pendingBalance = $totalDebt - $totalPaid;
 
                                     $futurePaidDebts = $customer->waterConnections->flatMap->debts->filter(function ($debt) use ($today) {
-                                        return $debt->status === 'paid' && Carbon::parse($debt->start_date)->gt($today);
+                                        return $debt->status === Debt::STATUS_PAID && Carbon::parse($debt->start_date)->gt($today);
                                     });
 
                                     $hasAdvancePayment = $futurePaidDebts->isNotEmpty();
@@ -59,9 +60,9 @@
                                             @foreach ($futurePaidDebts as $debt)
                                                 <span class="info-box-number">
                                                     {{ $debt->waterConnection->name ?? 'Desconocida' }} — Pagada del 
-                                                    {{ \Carbon\Carbon::parse($debt->start_date)->locale('es')->isoFormat('D [de] MMMM') }} 
+                                                    {{ Carbon::parse($debt->start_date)->locale('es')->isoFormat('D [de] MMMM') }} 
                                                     al 
-                                                    {{ \Carbon\Carbon::parse($debt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
+                                                    {{ Carbon::parse($debt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
                                                 </span>
                                             @endforeach
                                         </div>


### PR DESCRIPTION
Functionality was added to detect and display advance payments made for specific water connections.
Each advance payment includes the associated connection name and the covered date range, displayed in Spanish for clarity.
This ensures that customers can clearly identify which connections have prepaid debts and for which periods.