### PR TITLE
protect incident categories from deletion when related data exists

### DIFF
--- a/app/Models/IncidentCategory.php
+++ b/app/Models/IncidentCategory.php
@@ -26,4 +26,14 @@ class IncidentCategory extends Model
     {
         return $this->belongsTo(User::class, 'created_by');
     }
+
+    public function incidents()
+    {
+        return $this->hasMany(Incident::class, 'category_id');
+    }
+
+    public function hasDependencies()
+    {
+        return $this->incidents()->exists();
+    }
 }

--- a/resources/views/incidentCategories/index.blade.php
+++ b/resources/views/incidentCategories/index.blade.php
@@ -47,12 +47,22 @@
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $category->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
-                                                            <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $category->id }}">
-                                                                <i class="fas fa-edit"></i>
-                                                            </button>
-                                                            <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $category->id }}">
-                                                                <i class="fas fa-trash-alt"></i>
-                                                            </button>
+                                                            @can('editIncidentCategories')
+                                                                <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $category->id }}">
+                                                                    <i class="fas fa-edit"></i>
+                                                                </button>
+                                                            @endcan
+                                                            @can('deleteIncidentCategories')
+                                                                @if($category->hasDependencies())
+                                                                    <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen incidencias asociadas a esta categoría." disabled>
+                                                                        <i class="fas fa-trash-alt"></i>
+                                                                    </button>
+                                                                @else
+                                                                    <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $category->id }}">
+                                                                        <i class="fas fa-trash-alt"></i>
+                                                                    </button>
+                                                                @endif
+                                                            @endcan
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/resources/views/incidentCategories/index.blade.php
+++ b/resources/views/incidentCategories/index.blade.php
@@ -53,15 +53,14 @@
                                                                 </button>
                                                             @endcan
                                                             @can('deleteIncidentCategories')
-                                                                @if($category->hasDependencies())
-                                                                    <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen incidencias asociadas a esta categoría." disabled>
-                                                                        <i class="fas fa-trash-alt"></i>
-                                                                    </button>
-                                                                @else
-                                                                    <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $category->id }}">
-                                                                        <i class="fas fa-trash-alt"></i>
-                                                                    </button>
-                                                                @endif
+                                                                <button
+                                                                    type="button"
+                                                                    class="btn {{ $category->hasDependencies() ? 'btn-secondary' : 'btn-danger' }} mr-2"
+                                                                    title="{{ $category->hasDependencies() ? 'Eliminación no permitida: Existen incidencias asociadas a esta categoría.' : 'Eliminar Registro' }}"
+                                                                    {{ $category->hasDependencies() ? 'disabled' : 'data-toggle=modal data-target=#delete' . $category->id }}
+                                                                >
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
                                                             @endcan
                                                         </div>
                                                     </td>


### PR DESCRIPTION
A validation was implemented to prevent the deletion of an incident category if it has related incidents; the hasDependencies() method was added to the IncidentCategory model, and in the view, the delete button is disabled with an informative tooltip on hover, ensuring data integrity and avoiding errors from deleting related records.