### PR TITLE
Added table to display soon to expire paid periods

### DIFF
--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -12,6 +12,7 @@ class Debt extends Model
     public const STATUS_PENDING = 'pending';
     public const STATUS_PARTIAL = 'partial';
     public const STATUS_PAID = 'paid';
+    public const DASHBOARD_EXPIRING_DAYS = 20;
 
     protected $fillable = [
         'water_connection_id', 'locality_id', 'created_by', 'start_date', 'end_date', 'amount', 'note'

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -167,7 +167,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach($data['activePeriods'] as $period)
+                                    @foreach($data['paidDebtsExpiringSoon'] as $period)
                                         <tr>
                                             <td>
                                                 <img src="{{ $period['customerPhoto'] }}"

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -151,6 +151,39 @@
                             </div>
                         </div>
                     </div>
+                    <div class="card">
+                        <div class="card-header">
+                            <h3 class="card-title">Períodos Proximos a Vencer</h3>
+                        </div>
+                        <div class="card-body">
+                            <table class="table table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>Foto</th>
+                                        <th>Cliente</th>
+                                        <th>Toma de Agua</th>
+                                        <th>Fecha de Término</th>
+                                        <th>Días Restantes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($data['activePeriods'] as $period)
+                                        <tr>
+                                            <td>
+                                                <img src="{{ $period['customerPhoto'] }}"
+                                                    alt="Foto de cliente"
+                                                    style="width: 50px; height: 50px; border-radius: 50%;">
+                                            </td>
+                                            <td>{{ $period['customerName'] }}</td>
+                                            <td>{{ $period['waterConnectionName'] }}</td>
+                                            <td>{{ $period['endDate'] }}</td>
+                                            <td>{{ $period['daysRemaining'] }} días</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
A new table was added to the dashboard to display data of customers whose payments are about to expire. This improves tracking and management of payments to prevent delays.