### PR TITLE
add new boolean column to water_connection table

### DIFF
--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 use Str;
-use Carbon\Carbon; 
 use App\Models\Debt;
 use Illuminate\Support\Facades\Log;
 

--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -111,6 +111,7 @@ class WaterConnectionController extends Controller
 
         $connection->cancel_description = $request->input('cancelDescription');
         $connection->canceled_at = now();
+        $connection->is_canceled = true;
         $connection->save();
 
         return redirect()->route('waterConnections.index')->with('success', 'Toma cancelada correctamente.');

--- a/app/Models/WaterConnection.php
+++ b/app/Models/WaterConnection.php
@@ -59,7 +59,7 @@ class WaterConnection extends Model
         return $this->debts()->where('status', '!=', Debt::STATUS_PAID)->exists();
     }
 
-   public function getCancelDescriptionAttribute()
+    public function getCancelDescriptionAttribute()
     {
         return $this->attributes['cancel_description'];
     }

--- a/database/migrations/2025_06_18_022356_add_is_canceled_to_water_connections_table.php
+++ b/database/migrations/2025_06_18_022356_add_is_canceled_to_water_connections_table.php
@@ -9,7 +9,7 @@ class AddIsCanceledToWaterConnectionsTable extends Migration
     public function up()
     {
         Schema::table('water_connections', function (Blueprint $table) {
-            $table->boolean('is_canceled')->default(false)->after('canceled_at');
+            $table->boolean('is_canceled')->default(false)->before('canceled_at');
         });
     }
 

--- a/database/migrations/2025_06_18_022356_add_is_canceled_to_water_connections_table.php
+++ b/database/migrations/2025_06_18_022356_add_is_canceled_to_water_connections_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIsCanceledToWaterConnectionsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('water_connections', function (Blueprint $table) {
+            $table->boolean('is_canceled')->default(false)->after('canceled_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('water_connections', function (Blueprint $table) {
+            $table->dropColumn('is_canceled');
+        });
+    }
+}


### PR DESCRIPTION
A new column named is_canceled was added to the water_connection table to store the water connection status using a boolean value.

- When the connection is active, the value will be false (displayed as 0).
- When the connection is canceled, the value will be true (displayed as 1).

This allows for an easy way to determine whether a water connection is active or canceled directly from the database.