### PR TITLE
add incident status catalog to incident dropdowns

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Models\Incident;
 use App\Models\IncidentCategory;
 use App\Models\Employee;
+use App\Models\IncidentStatus;
 
 class IncidentController extends Controller
 {
@@ -18,8 +19,9 @@ class IncidentController extends Controller
         $categories = IncidentCategory::all();
 
         $employees = Employee::where('locality_id', $authUser->locality_id)->get();
+        $statuses = IncidentStatus::pluck('status');
 
-        return view('incidents.index', compact('incidents', 'categories','employees'));
+        return view('incidents.index', compact('incidents', 'categories','employees', 'statuses'));
     }
 
     public function create()

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,5 +22,6 @@ class DatabaseSeeder extends Seeder
         $this->call(DebtsTableSeeder::class);
         $this->call(PaymentsTableSeeder::class);
         $this->call(GeneralExpensesSeeder::class);
+        $this->call(IncidentStatusSeeder::class);
     }
 }

--- a/database/seeders/IncidentStatusSeeder.php
+++ b/database/seeders/IncidentStatusSeeder.php
@@ -13,8 +13,8 @@ class IncidentStatusSeeder extends Seeder
             [
                 'status' => 'Pendiente',
                 'description' => 'Incidencia en proceso de ser atendida',
-                'created_by' => 3,      // Cambia según corresponda
-                'locality_id' => 1,     // Cambia según corresponda
+                'created_by' => 3,
+                'locality_id' => 1,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],

--- a/database/seeders/IncidentStatusSeeder.php
+++ b/database/seeders/IncidentStatusSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class IncidentStatusSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::table('incident_statuses')->insert([
+            [
+                'status' => 'Pendiente',
+                'description' => 'Incidencia en proceso de ser atendida',
+                'created_by' => 3,      // Cambia según corresponda
+                'locality_id' => 1,     // Cambia según corresponda
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'status' => 'En progreso',
+                'description' => 'Incidencia en proceso de resolución',
+                'created_by' => 3,
+                'locality_id' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'status' => 'Terminada',
+                'description' => 'Incidencia resuelta y cerrada.',
+                'created_by' => 3,
+                'locality_id' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/resources/views/incidents/changeStatusModal.blade.php
+++ b/resources/views/incidents/changeStatusModal.blade.php
@@ -43,8 +43,9 @@
                                             <label for="status" class="form-label">Estatus(*)</label>
                                             <select class="form-control" name="status" required>
                                                 <option value="">Selecciona una opción</option>
-                                                <option value="Terminado">Terminado</option>
-                                                <option value="Proceso">Proceso</option>
+                                                @foreach ($statuses as $status)
+                                                    <option value="{{ $status }}">{{ $status }}</option>
+                                                @endforeach
                                             </select>
                                         </div>
                                     </div>

--- a/resources/views/incidents/create.blade.php
+++ b/resources/views/incidents/create.blade.php
@@ -56,15 +56,15 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="status" class="form-label">Estado(*)</label>
-                                            <select class="form-control" name="status" required>
-                                                <option value="">Selecciona una opción</option>
-                                                <option value="Pendiente">Pendiente</option>
-                                                <option value="Proceso">Proceso</option>
-                                                <option value="Terminado">Terminado</option>
-                                            </select>
+                                                <label for="status" class="form-label">Estado(*)</label>
+                                                <select class="form-control" name="status" required>
+                                                    <option value="">Selecciona una opción</option>
+                                                    @foreach ($statuses as $status)
+                                                        <option value="{{ $status }}">{{ $status }}</option>
+                                                    @endforeach
+                                                </select>
                                         </div>
-                                    </div
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/incidents/edit.blade.php
+++ b/resources/views/incidents/edit.blade.php
@@ -58,12 +58,12 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="status" class="form-label">Estado(*)</label>
-                                            <select class="form-control" name="statusUpdate">
-                                                <option value="">Selecciona una opción</option>
-                                                <option value="Pendiente" {{ $incident->status == 'Pendiente' ? 'selected' : '' }}>Pendiente</option>
-                                                <option value="Proceso" {{ $incident->status == 'Proceso' ? 'selected' : '' }}>Proceso</option>
-                                                <option value="Terminado" {{ $incident->status == 'Terminado' ? 'selected' : '' }}>Terminado</option>
-                                            </select>
+                                                <select class="form-control" name="statusUpdate" required>
+                                                    <option value="">Selecciona una opción</option>
+                                                    @foreach ($statuses as $status)
+                                                        <option value="{{ $status }}" {{ $incident->status == $status ? 'selected' : '' }}>{{ $status }}</option>
+                                                    @endforeach
+                                                </select>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION

This Pull Request adds the functionality to automatically populate the status dropdowns in the incidents module with the data registered in the incident status catalog, so that any status created or updated in that catalog is immediately reflected in the incident forms, avoiding manual duplication and ensuring the information is always kept in sync.