### PR TITLE
add logic to replace default mail constants with admin user config per locality

### DIFF
--- a/app/Http/Controllers/MailConfigurationController.php
+++ b/app/Http/Controllers/MailConfigurationController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Locality;
+
+class MailConfigurationController extends Controller
+{
+    public function createOrUpdateMailConfigurations(Request $request, $localityId)
+    {
+        $validated = $request->validate([
+            'mailer' => 'required|string',
+            'host' => 'required|string',
+            'port' => 'required|numeric',
+            'username' => 'required|string',
+            'password' => 'required|string',
+            'encryption' => 'required|string',
+            'from_address' => 'required|email',
+            'from_name' => 'nullable|string',
+        ]);
+
+        $locality = Locality::findOrFail($localityId);
+
+        $locality->mailConfiguration()->updateOrCreate([], $validated);
+
+        return redirect()->route('localities.index')->with('success', '¡Configuración de correo guardada!');
+    }
+}

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -40,4 +40,9 @@ class Locality extends Model implements HasMedia
     {
         return $this->hasMany(Cost::class);
     }
+
+    public function mailConfiguration()
+    {
+        return $this->hasOne(MailConfiguration::class);
+    }
 }

--- a/app/Models/MailConfiguration.php
+++ b/app/Models/MailConfiguration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MailConfiguration extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'locality_id',
+        'mailer',
+        'host',
+        'port',
+        'username',
+        'password',
+        'encryption',
+        'from_address',
+        'from_name'
+    ];
+
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+
+    public function isComplete()
+    {
+        return
+            !empty($this->mailer) &&
+            !empty($this->host) &&
+            !empty($this->port) &&
+            !empty($this->username) &&
+            !empty($this->password) &&
+            !empty($this->encryption) &&
+            !empty($this->from_address);
+    }
+}

--- a/database/migrations/2025_06_25_220155_create_mail_configurations_table.php
+++ b/database/migrations/2025_06_25_220155_create_mail_configurations_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMailConfigurationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mail_configurations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('locality_id')->unique();
+            $table->string('mailer');
+            $table->string('host');
+            $table->integer('port');
+            $table->string('username');
+            $table->string('password');
+            $table->string('encryption');
+            $table->string('from_address');
+            $table->string('from_name')->nullable();
+            $table->timestamps();
+
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mail_configurations');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,5 +23,6 @@ class DatabaseSeeder extends Seeder
         $this->call(PaymentsTableSeeder::class);
         $this->call(DashboardExpiringPaidDebtsSeeder::class);
         $this->call(GeneralExpensesSeeder::class);
+        $this->call(MailConfigurationsTableSeeder::class); 
     }
 }

--- a/database/seeders/MailConfigurationsTableSeeder.php
+++ b/database/seeders/MailConfigurationsTableSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\MailConfiguration;
+
+class MailConfigurationsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        MailConfiguration::create([
+            'locality_id' => 1,
+            'mailer' => 'smtp',
+            'host' => 'smtp.smallville.com',
+            'port' => 587,
+            'username' => 'smallville_user',
+            'password' => 'smallville_pass',
+            'encryption' => 'tls',
+            'from_address' => 'noreply@smallville.com',
+            'from_name' => 'Smallville Water Services',
+        ]);
+
+        MailConfiguration::create([
+            'locality_id' => 2,
+            'mailer' => 'smtp',
+            'host' => 'smtp.springfield.com',
+            'port' => 465,
+            'username' => 'springfield_user',
+            'password' => 'springfield_pass',
+            'encryption' => 'ssl',
+            'from_address' => 'noreply@springfield.com',
+            'from_name' => 'Springfield Water Dept',
+        ]);
+    }
+}

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -15,7 +15,7 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        User::create([
+        User::firstOrCreate([
             'locality_id' => null,
             'name' => 'Jose',
             'last_name' => 'Lopez Osorio',
@@ -24,7 +24,7 @@ class UsersTableSeeder extends Seeder
             'password' => Hash::make('12345'),
         ])->assignRole('Admin');
 
-        User::create([
+        User::firstOrCreate([
             'locality_id' => 2,
             'name' => 'Erika',
             'last_name' => 'Lopez Perez',
@@ -33,12 +33,21 @@ class UsersTableSeeder extends Seeder
             'password' => Hash::make('12345'),
         ])->assignRole('Secretaria');
 
-        User::create([
+        User::firstOrCreate([
             'locality_id' => 1,
             'name' => 'Juan',
             'last_name' => 'Perez Garcia',
             'email' => 'juan@gmail.com',
             'phone' => '5512998832',
+            'password' => Hash::make('12345'),
+        ])->assignRole('Supervisor');
+
+        User::firstOrCreate([
+            'locality_id' => 3,
+            'name' => 'Mario',
+            'last_name' => 'Gomez Fernandez',
+            'email' => 'mario@gmail.com',
+            'phone' => '5588997766',
             'password' => Hash::make('12345'),
         ])->assignRole('Supervisor');
     }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -151,6 +151,7 @@
                             </div>
                         </div>
                     </div>
+                    @can('viewDashboardCards')
                     <div class="card">
                         <div class="card-header">
                             <div class="row w-100">
@@ -160,7 +161,14 @@
                                 <div class="col-md-6 d-flex justify-content-end">
                                     <form action="{{ route('dashboard.sendEmailsForDebtsExpiringSoon') }}" method="POST" class="m-0">
                                         @csrf
-                                        <button type="submit" class="btn btn-primary btn-sm">
+                                        <button
+                                            type="submit"
+                                            class="btn {{ $hasMailConfig ? 'btn-primary' : 'btn-secondary disabled' }} btn-sm"
+                                            title="{{ $hasMailConfig 
+                                                ? 'Enviar correos de recordatorio' 
+                                                : 'No hay configuración de correo válida para esta localidad' }}"
+                                            {{ $hasMailConfig ? '' : 'disabled' }}
+                                        >
                                             <i class="fas fa-envelope"></i> Enviar recordatorios
                                         </button>
                                     </form>
@@ -200,8 +208,12 @@
                                     @endif
                                 </tbody>
                             </table>
+                            <div class="d-flex justify-content-center mt-3">
+                                {{ $data['paidDebtsExpiringSoon']->appends(request()->query())->links('pagination::bootstrap-4') }}
+                            </div>
                         </div>
                     </div>
+                    @endcan
                 </div>
             </div>
         </div>
@@ -268,6 +280,15 @@
                     confirmButtonText: 'Aceptar'
                 });
             }
+            var errorMessage = "{{ session('error') }}";
+            if (errorMessage) {
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Error',
+                    text: errorMessage,
+                    confirmButtonText: 'Aceptar'
+                });
+            }   
         });
 
         var ctx = document.getElementById('earningsChart').getContext('2d');

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -86,6 +86,9 @@
                                                             <i class="fas fa-image"></i>
                                                         </button>
                                                     @endcan
+                                                    <button type="button" class="btn btn-primary mr-2" data-toggle="modal"  title="Configurar correo" data-target="#mailConfigModal{{$locality->id}}">
+                                                        <i class="fas fa-envelope"></i>
+                                                    </button>
                                                     @can('deleteLocality')
                                                         @if($locality->hasDependencies())
                                                             <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
@@ -103,6 +106,7 @@
                                             @include('localities.delete')
                                             @include('localities.show')
                                             @include('localities.editLogo')
+                                            @include('localities.mailConfiguration')
                                         </tr>
                                         @endforeach
                                         @endif

--- a/resources/views/localities/mailConfiguration.blade.php
+++ b/resources/views/localities/mailConfiguration.blade.php
@@ -1,0 +1,106 @@
+@foreach($localities as $locality)
+    <div class="modal fade" id="mailConfigModal{{ $locality->id }}" tabindex="-1" role="dialog" aria-labelledby="mailConfigLabel{{ $locality->id }}" aria-hidden="true">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="card-success">
+                    <div class="card-header">
+                        <div class="d-sm-flex align-items-center justify-content-between">
+                            <h4 class="card-title">
+                                Configuración de Correo - {{ $locality->name }}
+                                <small>&nbsp;(*) Campos requeridos</small>
+                            </h4>
+                            <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                    </div>
+                    <form action="{{ route('mailConfigurations.createOrUpdate', $locality->id) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+                        <div class="card-body">
+                            <div class="card">
+                                <div class="card-header py-2 bg-secondary">
+                                    <h3 class="card-title">Ingrese los Datos de Configuración de Correo</h3>
+                                    <div class="card-tools">
+                                        <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                                            <i class="fa fa-minus"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="card-body">
+                                    <div class="row">
+                                        @php
+                                            $config = $locality->mailConfiguration;
+                                        @endphp
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="mailer{{ $locality->id }}">Mailer(*)</label>
+                                                <input type="text" name="mailer" class="form-control" id="mailer{{ $locality->id }}" placeholder="Ingresa el mailer" value="{{ old('mailer', $config?->mailer) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="host{{ $locality->id }}">Host(*)</label>
+                                                <input type="text" name="host" class="form-control" id="host{{ $locality->id }}" placeholder="Ingresa el host" value="{{ old('host', $config?->host) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="port{{ $locality->id }}">Puerto(*)</label>
+                                                <input type="number" name="port" class="form-control" id="port{{ $locality->id }}" placeholder="Ingresa el puerto" value="{{ old('port', $config?->port) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="username{{ $locality->id }}">Usuario(*)</label>
+                                                <input type="text" name="username" class="form-control" id="username{{ $locality->id }}" placeholder="Ingresa el usuario" value="{{ old('username', $config?->username) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="password{{ $locality->id }}">Contraseña(*)</label>
+                                                <input type="text" name="password" class="form-control" id="password{{ $locality->id }}" placeholder="Ingresa la contraseña" value="{{ old('password', $config?->password) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="encryption{{ $locality->id }}">Encriptación(*)</label>
+                                                <input type="text" name="encryption" class="form-control" id="encryption{{ $locality->id }}" placeholder="Ingresa el tipo de encriptación" value="{{ old('encryption', $config?->encryption) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="fromAddress{{ $locality->id }}">Correo de Envío(*)</label>
+                                                <input type="email" name="from_address" class="form-control" id="fromAddress{{ $locality->id }}" placeholder="Ingresa el correo de envío" value="{{ old('from_address', $config?->from_address) }}" required>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label for="fromName{{ $locality->id }}">Nombre del Remitente</label>
+                                                <input type="text" name="from_name" class="form-control" id="fromName{{ $locality->id }}" placeholder="Ingresa el nombre del remitente" value="{{ old('from_name', $config?->from_name) }}">
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                            <button type="submit" class="btn btn-success">Guardar</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endforeach
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -103,7 +103,6 @@ Route::group(['middleware' => ['auth']], function () {
         Route::post('/localities/{locality}/update-logo', [LocalityController::class, 'updateLogo'])->name('localities.updateLogo');
         Route::get('/locality-earnings', [DashboardController::class, 'getEarningsByLocality'])->name('locality.earnings');
         Route::put('/localities/{locality}/mailConfiguration',[MailConfigurationController::class, 'createOrUpdateMailConfigurations'])->name('mailConfigurations.createOrUpdate');
-
     });
 
     Route::group(['middleware' => ['can:viewWaterConnection']], function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\IncidentController;
 use App\Http\Controllers\EmployeeController;
 use App\Http\Controllers\LogIncidentController;
 use App\Http\Controllers\IncidentStatusController;
+use App\Http\Controllers\MailConfigurationController;
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -101,6 +102,8 @@ Route::group(['middleware' => ['auth']], function () {
         Route::resource('localities', LocalityController::class);
         Route::post('/localities/{locality}/update-logo', [LocalityController::class, 'updateLogo'])->name('localities.updateLogo');
         Route::get('/locality-earnings', [DashboardController::class, 'getEarningsByLocality'])->name('locality.earnings');
+        Route::put('/localities/{locality}/mailConfiguration',[MailConfigurationController::class, 'createOrUpdateMailConfigurations'])->name('mailConfigurations.createOrUpdate');
+
     });
 
     Route::group(['middleware' => ['can:viewWaterConnection']], function () {


### PR DESCRIPTION
This PR adds the logic to replace the default mail configuration constants with dynamic settings based on the admin users of each locality. This enables sending emails using the personalized mail configuration for each locality.
Additionally, seeders were included to populate test data related to mail configurations and users, facilitating functional testing during development.