### PR TITLE
Implement Select2 for dropdown fields

### DIFF
--- a/resources/views/incidents/changeStatusModal.blade.php
+++ b/resources/views/incidents/changeStatusModal.blade.php
@@ -28,7 +28,7 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="employee" class="form-label">Responsable(*)</label>
-                                            <select class="form-control" name="employee" required>
+                                            <select class="form-control select2" name="employee" required>
                                                 <option value="">Selecciona una opción</option>
                                                 @foreach ($employees as $employee)
                                                     <option value="{{ $employee->id }}">

--- a/resources/views/incidents/create.blade.php
+++ b/resources/views/incidents/create.blade.php
@@ -46,7 +46,7 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="category" class="form-label">Categoria(*)</label>
-                                            <select class="form-control" name="category" required>
+                                            <select class="form-control select2" name="category" required>
                                                 <option value="">Selecciona una opción</option>
                                                 @foreach ($categories as $category)
                                                     <option value="{{ $category->id }}">{{ $category->name }}</option>
@@ -78,3 +78,11 @@
         </div>
     </div>
 </div>
+
+<style>
+    .select2-container .select2-selection--single {
+        height: 40px;
+        display: flex;
+        align-items: center;
+    }
+</style>

--- a/resources/views/incidents/edit.blade.php
+++ b/resources/views/incidents/edit.blade.php
@@ -45,7 +45,7 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="category" class="form-label">Categoria(*)</label>
-                                            <select class="form-control" name="categoryUpdate" required>
+                                            <select class="form-control select2" name="categoryUpdate" required>
                                                 <option value="">Selecciona una opción</option>
                                                 @foreach($incident->incidentCategory->all() as $category)
                                                     <option value="{{ $category->id }}" {{ $incident->category_id == $category->id ? 'selected' : '' }}>

--- a/resources/views/incidents/index.blade.php
+++ b/resources/views/incidents/index.blade.php
@@ -119,5 +119,23 @@
             });
         }
     });
+
+    $('#createIncidence').on('shown.bs.modal', function () {
+        $(this).find('.select2').select2({
+            dropdownParent: $('#createIncidence')
+        });
+    });
+
+    $('[id^="edit"]').on('shown.bs.modal', function () {
+        $(this).find('.select2').select2({
+            dropdownParent: $(this)
+        });
+    });
+
+    $('#createResponsible').on('shown.bs.modal', function () {
+        $(this).find('.select2').select2({
+            dropdownParent: $('#createResponsible'),
+        });
+    });
 </script>
 @endsection


### PR DESCRIPTION
This PR integrates Select2 in incident modals (create, edit, and change status) to improve dropdown usability, adding Select2 for #createIncidence, #createResponsible, and edit modals and configuring dropdownParent to fix modal display issues.