### PR TITLE
Fix the advance payment index file

### DIFF
--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -192,7 +192,7 @@ class AdvancePaymentController extends Controller
             amount
         ')
         ->where('status', Debt::STATUS_PAID) 
-        ->where('start_date', '>', now())
+        ->where('end_date', '>=', now()->startOfMonth()->addMonth())
         ->first();
 
         Carbon::setLocale('es');

--- a/resources/views/advancePayments/index.blade.php
+++ b/resources/views/advancePayments/index.blade.php
@@ -10,7 +10,7 @@
     <div class="row">
         <div class="col-lg-12 text-right">
             <div class="btn-group" role="group" aria-label="Acciones de gráfica de pagos">
-                <button class="btn btn-primary mr-2" data-toggle="modal" data-target="#paymentChart">
+                <button class="btn btn-primary mr-2" id="btnGenerateReportGraph" data-toggle="modal" data-target="#paymentChart">
                     <i class="fa fa-money-bill"></i> Gráfica de pagos
                 </button>
                 <a class="btn btn-success mr-2" data-toggle="modal" data-target="#paymentHistoryModal" title="Historial de pagos">
@@ -95,7 +95,7 @@
                     success: function (response) {
                         $.each(response.waterConnections, function (index, connection) {
                             waterConnectionSelect.append(
-                                `<option value="${connection.id}">${connection.id} - ${connection.name}</option>`
+                                '<option value="${connection.id}">${connection.id} - ${connection.name}</option>'
                             );
                         });
                     },
@@ -188,7 +188,7 @@
             const canvas = document.getElementById(canvasId);
             const link = document.createElement('a');
             link.href = canvas.toDataURL('image/png');
-            link.download = `${canvasId}.png`;
+            link.download = '${canvasId}.png';
             link.click();
         });
     });

--- a/resources/views/advancePayments/index.blade.php
+++ b/resources/views/advancePayments/index.blade.php
@@ -20,27 +20,8 @@
                     data-target="#generateAdvancePaymentsReportModal">
                     <i class="fas fa-fw fa-calendar-plus"></i> Pagos Adelantados
                 </button>
-                <button class="btn btn-secondary mr-2" data-toggle="modal" data-target="#paymentChart">
-                    <i class="fa fa-dollar-sign"></i> Comprobante de pagos
-                </button>
             </div>
         </div>
-    </div>
-
-    <div class="col-lg-4 mt-3">
-        <form method="GET" action="" class="my-3">
-            <div class="input-group">
-                <input
-                    type="text"
-                    name="search"
-                    class="form-control"
-                    placeholder="Buscar por nombre o apellido"
-                    value="{{ request('search') }}">
-                <div class="input-group-append">
-                    <button type="submit" class="btn btn-primary">Buscar</button>
-                </div>
-            </div>
-        </form>
     </div>
 
     @include('advancePayments.paymentHistoryModal')

--- a/resources/views/reports/advancedPayments.blade.php
+++ b/resources/views/reports/advancedPayments.blade.php
@@ -281,7 +281,7 @@
                                         'residencial' => 'Residencial',
                                     ];
                                 @endphp
-                                <td style="width: 57%;">
+                                <td style="width: 59%;">
                                     <label>Tipo:</label>
                                     <p>{{ $types[$waterConnection->type] ?? ucfirst($waterConnection->type) }}</p>
                                 </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -119,20 +119,20 @@ Route::group(['middleware' => ['auth']], function () {
     });
 
     Route::group(['middleware' => ['can:viewAdvancePayments']], function () {
-       Route::get('/advancePayments', [AdvancePaymentController::class, 'index'])->name('advancePayments.index');
-       Route::get('/getAdavancedPaymentReportWithConnection', [AdvancePaymentController::class, 'generateAdvancedPaymentReport'])->name('advancePayments.report');
-       Route::post('/advancePaymentsGraphReport', [AdvancePaymentController::class, 'generatePaymentGraphReport'])->name('report.advancePaymentGraphReport');
-       Route::get('/getCustomersWithAdvancePayments', [AdvancePaymentController::class, 'getCustomersWithAdvancePayments'])->name('getCustomersWithAdvancePayments');
-       Route::get('/getAdvanceDebtDates', [AdvancePaymentController::class, 'getAdvanceDebtDates'])->name('getAdvanceDebtDates');
+        Route::get('/advancePayments', [AdvancePaymentController::class, 'index'])->name('advancePayments.index');
+        Route::get('/getAdavancedPaymentReportWithConnection', [AdvancePaymentController::class, 'generateAdvancedPaymentReport'])->name('advancePayments.report');
+        Route::post('/advancePaymentsGraphReport', [AdvancePaymentController::class, 'generatePaymentGraphReport'])->name('report.advancePaymentGraphReport');
+        Route::get('/getCustomersWithAdvancePayments', [AdvancePaymentController::class, 'getCustomersWithAdvancePayments'])->name('getCustomersWithAdvancePayments');
+        Route::get('/getAdvanceDebtDates', [AdvancePaymentController::class, 'getAdvanceDebtDates'])->name('getAdvanceDebtDates');
     });
 
     Route::group(['middleware' => ['can:viewIncidentCategories']], function () {
-       Route::resource('incidentCategories', IncidentCategoriesController::class);
+        Route::resource('incidentCategories', IncidentCategoriesController::class);
     });
 
     Route::group(['middleware' => ['can:viewIncidents']], function () {
-       Route::resource('incidents', IncidentController::class);
-       Route::post('/logIncidents', [LogIncidentController::class, 'store'])->name('logsIncidents.store');
+        Route::resource('incidents', IncidentController::class);
+        Route::post('/logIncidents', [LogIncidentController::class, 'store'])->name('logsIncidents.store');
     });
 
     Route::group(['middleware' => ['can:viewEmployee']], function () {


### PR DESCRIPTION
In this PR, the index file was corrected, since the "Payment Chart" button did not generate the PDF file. The "Payment Receipt" button was deleted since it had no function. Two lines of code that had an inverted tilde instead of a single quote were corrected. In the advance payment controller, two methods were added to query the dates to ensure they are correct and finally the indentation of the routes was corrected.