### PR TITLE
Resolution of different bugs found

### DIFF
--- a/resources/views/advancePayments/advancePaymentsReportForm.blade.php
+++ b/resources/views/advancePayments/advancePaymentsReportForm.blade.php
@@ -58,3 +58,57 @@
         align-items: center;
     }
 </style>
+
+@push('js')
+<script>
+    $(function () {
+        $('#generateAdvancePaymentsReportModal').on('shown.bs.modal', function () {
+            $('.select2').select2({
+                dropdownParent: $('#generateAdvancePaymentsReportModal')
+            });
+
+            $.ajax({
+                url: '{{ route("getCustomersWithAdvancePayments") }}',
+                method: 'GET',
+                success: function (response) {
+                    const customerSelect = $('#advancePaymentsCustomerSelect');
+                    customerSelect.empty().append('<option value="">Selecciona un cliente</option>');
+                    
+                    $.each(response.customers, function (index, customer) {
+                        customerSelect.append(
+                            `<option value="${customer.id}">${customer.name} ${customer.last_name}</option>`
+                        );
+                    });
+                },
+                error: function (xhr) {
+                    console.error('Error al cargar clientes con pagos adelantados', xhr.responseText);
+                }
+            });
+        });
+
+        $('#advancePaymentsCustomerSelect').on('change', function () {
+            const customerId = $(this).val();
+            const waterConnectionSelect = $('#advancePaymentsWaterConnectionSelect');
+            waterConnectionSelect.empty().append('<option value="">Selecciona una toma</option>');
+
+            if (customerId) {
+                $.ajax({
+                    url: '{{ route("getCustomersWithAdvancePayments") }}',
+                    method: 'GET',
+                    data: { customerId: customerId },
+                    success: function (response) {
+                        $.each(response.waterConnections, function (index, connection) {
+                            waterConnectionSelect.append(
+                                `<option value="${connection.id}">${connection.id} - ${connection.name}</option>`
+                            );
+                        });
+                    },
+                    error: function (xhr) {
+                        console.error('Error al cargar tomas de agua con pagos adelantados', xhr.responseText);
+                    }
+                });
+            }
+        });
+    });
+</script>
+@endpush

--- a/resources/views/generalExpenses/annualExpenses.blade.php
+++ b/resources/views/generalExpenses/annualExpenses.blade.php
@@ -11,8 +11,8 @@
                 <div class="modal-body">
                     <div class="form-group">
                         <label for="yearExpenses" class="form-label">Año(*)</label>
-                        <input type="number" id="yearExpenses" name="yearExpenses" class="form-control"  min="1900" max="{{ date('Y') }}"
-                               required placeholder="Ingrese el año ejemplo 2024" value="{{ old('year') }}" />
+                        <input type="number" id="yearExpenses" name="yearExpenses" class="form-control"  min="2000" max="{{ date('Y') }}"
+                                required placeholder="Ingrese el año ejemplo 2024" value="{{ old('year') }}" />
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/resources/views/generalExpenses/annualGains.blade.php
+++ b/resources/views/generalExpenses/annualGains.blade.php
@@ -11,8 +11,8 @@
                 <div class="modal-body">
                     <div class="form-group">
                         <label for="yearGains" class="form-label">Año(*)</label>
-                        <input type="number" id="yearGains" name="yearGains" class="form-control"  min="1900" max="{{ date('Y') }}" 
-                               required placeholder="Ingrese el año ejemplo 2024" value="{{ old('yearGains') }}" />
+                        <input type="number" id="yearGains" name="yearGains" class="form-control"  min="2000" max="{{ date('Y') }}" 
+                                required placeholder="Ingrese el año ejemplo 2024" value="{{ old('yearGains') }}" />
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/resources/views/payments/annualEarnings.blade.php
+++ b/resources/views/payments/annualEarnings.blade.php
@@ -11,8 +11,8 @@
                 <div class="modal-body">
                     <div class="form-group">
                         <label for="year" class="form-label">Año(*)</label>
-                        <input type="number" id="year" name="year" class="form-control"  min="1900" max="{{ date('Y') }}" 
-                               required placeholder="Ingrese el año ejemplo 2024" value="{{ old('year') }}" />
+                        <input type="number" id="year" name="year" class="form-control"  min="2000" max="{{ date('Y') }}" 
+                                required placeholder="Ingrese el año ejemplo 2024" value="{{ old('year') }}" />
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/resources/views/reports/advancePaymentGraphReport.blade.php
+++ b/resources/views/reports/advancePaymentGraphReport.blade.php
@@ -259,9 +259,12 @@
                         </td>
                     </tr>
                     <tr>
-                        <td colspan="2" style="padding: 8px; text-align: center;">
+                        <td style="padding: 8px; text-align: center; width: 50%;">
                             <img src="{{ $chartImages[2] }}" style="max-width: 80%; height: auto;">
                         </td>
+                        <td style="padding: 8px; text-align: center; width: 50%;">
+                            <img src="{{ $chartImages[3] }}" style="max-width: 80%; height: auto;">
+                       </td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
In this PR, the logic that helps the modal on the Advance Payments reports was moved and improved so that only those with advance payments already made appear, from the same Advance Payments Index, the icons and texts of the buttons were changed to give a good understanding of what the buttons do respectively, a timer was set so that the button, the "Generate PDF of Graphs" button is disabled while it finishes generating a report and the action is not duplicated. In the Dashboard, the minimum year in the inputs was modified from 1900 to 2000 since it may be a closer and more realistic year for the saved information and the 4 graphs were added to the advance payments graphs report since they were not available.