### PR TITLE
Bug fix when canceling water connection

### DIFF
--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -13,10 +13,11 @@ class WaterConnectionController extends Controller
     {
         $authUser = auth()->user();
 
-        $query = WaterConnection::where('water_connections.locality_id', $authUser->locality_id)
-            ->join('customers', 'water_connections.customer_id', '=', 'customers.id')
-            ->orderBy('water_connections.created_at', 'desc')
-            ->select('water_connections.*');
+    $query = WaterConnection::withoutGlobalScope('notCanceled')
+        ->where('water_connections.locality_id', $authUser->locality_id)
+        ->join('customers', 'water_connections.customer_id', '=', 'customers.id')
+        ->orderBy('water_connections.created_at', 'desc')
+        ->select('water_connections.*');
 
         if ($request->has('search')) {
             $search = $request->input('search');

--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -13,11 +13,11 @@ class WaterConnectionController extends Controller
     {
         $authUser = auth()->user();
 
-    $query = WaterConnection::withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED)
-        ->where('water_connections.locality_id', $authUser->locality_id)
-        ->join('customers', 'water_connections.customer_id', '=', 'customers.id')
-        ->orderBy('water_connections.created_at', 'desc')
-        ->select('water_connections.*');
+        $query = WaterConnection::withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED)
+            ->where('water_connections.locality_id', $authUser->locality_id)
+            ->join('customers', 'water_connections.customer_id', '=', 'customers.id')
+            ->orderBy('water_connections.created_at', 'desc')
+            ->select('water_connections.*');
 
         if ($request->has('search')) {
             $search = $request->input('search');

--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -13,7 +13,7 @@ class WaterConnectionController extends Controller
     {
         $authUser = auth()->user();
 
-    $query = WaterConnection::withoutGlobalScope('notCanceled')
+    $query = WaterConnection::withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED)
         ->where('water_connections.locality_id', $authUser->locality_id)
         ->join('customers', 'water_connections.customer_id', '=', 'customers.id')
         ->orderBy('water_connections.created_at', 'desc')

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -79,4 +79,9 @@ class Customer extends Model implements HasMedia
             $customer->waterConnections()->delete();
         });
     }
+    
+    public function waterConnectionsAll()
+    {
+        return $this->hasMany(WaterConnection::class)->withoutGlobalScope('notCanceled');
+    }
 }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -82,6 +82,6 @@ class Customer extends Model implements HasMedia
     
     public function waterConnectionsAll()
     {
-        return $this->hasMany(WaterConnection::class)->withoutGlobalScope('notCanceled');
+        return $this->hasMany(WaterConnection::class)->withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED);
     }
 }

--- a/app/Models/WaterConnection.php
+++ b/app/Models/WaterConnection.php
@@ -16,10 +16,11 @@ class WaterConnection extends Model
     public const VIEW_STATUS_DEBT = 'Adeudo';
     public const VIEW_STATUS_ADVANCED = 'Adelantado';
     public const VIEW_STATUS_CANCELED = 'Cancelado';
+    public const SCOPE_NOT_CANCELED = 'notCanceled';
 
     protected static function booted()
     {
-        static::addGlobalScope('notCanceled', function ($query) {
+        static::addGlobalScope(self::SCOPE_NOT_CANCELED, function ($query) {
             $query->where('is_canceled', false);
         });
     }

--- a/app/Models/WaterConnection.php
+++ b/app/Models/WaterConnection.php
@@ -17,6 +17,13 @@ class WaterConnection extends Model
     public const VIEW_STATUS_ADVANCED = 'Adelantado';
     public const VIEW_STATUS_CANCELED = 'Cancelado';
 
+    protected static function booted()
+    {
+        static::addGlobalScope('notCanceled', function ($query) {
+            $query->where('is_canceled', false);
+        });
+    }
+
     protected $fillable = [
         'locality_id',
         'created_by',

--- a/resources/views/customers/waterConnections.blade.php
+++ b/resources/views/customers/waterConnections.blade.php
@@ -51,7 +51,7 @@
                             @endif
                             <div class="water-connection-list" style="overflow-y: auto; max-height: 300px; overflow-x: hidden;">
                                 @php $connectionCounter = 0; @endphp
-                                @foreach ($customer->waterConnections as $waterConnection)
+                                @foreach ($customer->waterConnectionsAll as $waterConnection)
                                     @if ($waterConnection)
                                         @php $connectionCounter++; @endphp
                                         @if ($connectionCounter > 1)


### PR DESCRIPTION
A bug related to water connection cancellation was fixed. The issue was that even after a connection was canceled, it was still possible to assign debts or make payments to it.
The implemented solution ensures that once a connection is canceled, it remains visible in the necessary records for historical reference, but can no longer be selected for actions such as assigning debts or processing payments.