### PR TITLE
add examples section to email configuration

### DIFF
--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -21,14 +21,14 @@ class LocalityController extends Controller
         $localities = $query->paginate(10);
 
         $mailExamples = [
-        'mailer'       => MailConfiguration::EXAMPLE_MAILER,
-        'host'         => MailConfiguration::EXAMPLE_HOST,
-        'port'         => MailConfiguration::EXAMPLE_PORT,
-        'username'     => MailConfiguration::EXAMPLE_USERNAME,
-        'password'     => MailConfiguration::EXAMPLE_PASSWORD,
-        'encryption'   => MailConfiguration::EXAMPLE_ENCRYPTION,
-        'from_address' => MailConfiguration::EXAMPLE_FROM_ADDRESS,
-        'from_name'    => MailConfiguration::EXAMPLE_FROM_NAME,
+            'mailer'  => MailConfiguration::EXAMPLE_MAILER,
+            'host'  => MailConfiguration::EXAMPLE_HOST,
+            'port'  => MailConfiguration::EXAMPLE_PORT,
+            'username'  => MailConfiguration::EXAMPLE_USERNAME,
+            'password'  => MailConfiguration::EXAMPLE_PASSWORD,
+            'encryption'  => MailConfiguration::EXAMPLE_ENCRYPTION,
+            'from_address'  => MailConfiguration::EXAMPLE_FROM_ADDRESS,
+            'from_name'  => MailConfiguration::EXAMPLE_FROM_NAME,
         ];
         
         return view('localities.index', compact('localities','mailExamples'));

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Locality;
 use Illuminate\Http\Request;
+use App\Models\MailConfiguration;
 
 class LocalityController extends Controller
 {
@@ -18,7 +19,19 @@ class LocalityController extends Controller
         }
 
         $localities = $query->paginate(10);
-        return view('localities.index', compact('localities'));
+
+        $mailExamples = [
+        'mailer'       => MailConfiguration::EXAMPLE_MAILER,
+        'host'         => MailConfiguration::EXAMPLE_HOST,
+        'port'         => MailConfiguration::EXAMPLE_PORT,
+        'username'     => MailConfiguration::EXAMPLE_USERNAME,
+        'password'     => MailConfiguration::EXAMPLE_PASSWORD,
+        'encryption'   => MailConfiguration::EXAMPLE_ENCRYPTION,
+        'from_address' => MailConfiguration::EXAMPLE_FROM_ADDRESS,
+        'from_name'    => MailConfiguration::EXAMPLE_FROM_NAME,
+        ];
+        
+        return view('localities.index', compact('localities','mailExamples'));
     }
 
     public function store(Request $request)

--- a/app/Models/MailConfiguration.php
+++ b/app/Models/MailConfiguration.php
@@ -9,6 +9,15 @@ class MailConfiguration extends Model
 {
     use HasFactory;
 
+    public const EXAMPLE_MAILER = 'smtp';
+    public const EXAMPLE_HOST = 'smtp.gmail.com';
+    public const EXAMPLE_PORT = '587';
+    public const EXAMPLE_USERNAME = 'usuario@tudominio.com';
+    public const EXAMPLE_PASSWORD = 'tu contraseña segura';
+    public const EXAMPLE_ENCRYPTION = 'tls';
+    public const EXAMPLE_FROM_ADDRESS = 'notificaciones@tudominio.com';
+    public const EXAMPLE_FROM_NAME = 'Tu Empresa o Servicio';
+
     protected $fillable = [
         'locality_id',
         'mailer',

--- a/resources/views/emails/upcomingPaymentAlert.blade.php
+++ b/resources/views/emails/upcomingPaymentAlert.blade.php
@@ -24,24 +24,6 @@
             border-bottom: 2px solid #0B1C80;
         }
 
-        .logoContainer {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: 20px;
-            margin-bottom: 15px;
-        }
-
-        .logo {
-            height: 50px;
-        }
-
-        .brandName {
-            color: #0B1C80;
-            font-size: 24px;
-            font-weight: bold;
-        }
-
         .title {
             color: #0B1C80;
             font-size: 20pt;
@@ -120,13 +102,18 @@
 <body>
     <div class="container">
         <div class="header">
-            <div class="logoContainer">
-                <img src="{{ $logoCid }}" alt="Logo AquaControl" class="logo">
-                <div class="brandName">AquaControl</div>
-            </div>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center">
+                <tr>
+                    <td style="padding-right:20px;">
+                        <img src="{{ $logoCid }}" alt="Logo AquaControl" height="50" style="width:auto; display:block;">
+                    </td>
+                    <td style="color:#0B1C80; font-size:24px; font-weight:bold; font-family: Montserrat, sans-serif;">
+                        AquaControl
+                    </td>
+                </tr>
+            </table>
             <h1 class="title">RECORDATORIO DE PAGO</h1>
         </div>
-
         <div class="content">
             <p>Estimado(a) <strong>{{ $customerName }}</strong>,</p>
 

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -86,7 +86,7 @@
                                                             <i class="fas fa-image"></i>
                                                         </button>
                                                     @endcan
-                                                    <button type="button" class="btn btn-primary mr-2" data-toggle="modal"  title="Configurar correo" data-target="#mailConfigModal{{$locality->id}}">
+                                                    <button type="button" class="btn bg-purple mr-2" data-toggle="modal"  title="Configurar correo" data-target="#mailConfigModal{{$locality->id}}">
                                                         <i class="fas fa-envelope"></i>
                                                     </button>
                                                     @can('deleteLocality')

--- a/resources/views/localities/mailConfiguration.blade.php
+++ b/resources/views/localities/mailConfiguration.blade.php
@@ -3,7 +3,7 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="card-success">
-                    <div class="card-header">
+                    <div class="card-header bg-purple">
                         <div class="d-sm-flex align-items-center justify-content-between">
                             <h4 class="card-title">
                                 Configuración de Correo - {{ $locality->name }}
@@ -32,70 +32,125 @@
                                         @php
                                             $config = $locality->mailConfiguration;
                                         @endphp
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="mailer{{ $locality->id }}">Mailer(*)</label>
                                                 <input type="text" name="mailer" class="form-control" id="mailer{{ $locality->id }}" placeholder="Ingresa el mailer" value="{{ old('mailer', $config?->mailer) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="host{{ $locality->id }}">Host(*)</label>
                                                 <input type="text" name="host" class="form-control" id="host{{ $locality->id }}" placeholder="Ingresa el host" value="{{ old('host', $config?->host) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="port{{ $locality->id }}">Puerto(*)</label>
                                                 <input type="number" name="port" class="form-control" id="port{{ $locality->id }}" placeholder="Ingresa el puerto" value="{{ old('port', $config?->port) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="username{{ $locality->id }}">Usuario(*)</label>
                                                 <input type="text" name="username" class="form-control" id="username{{ $locality->id }}" placeholder="Ingresa el usuario" value="{{ old('username', $config?->username) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="password{{ $locality->id }}">Contraseña(*)</label>
                                                 <input type="text" name="password" class="form-control" id="password{{ $locality->id }}" placeholder="Ingresa la contraseña" value="{{ old('password', $config?->password) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="encryption{{ $locality->id }}">Encriptación(*)</label>
                                                 <input type="text" name="encryption" class="form-control" id="encryption{{ $locality->id }}" placeholder="Ingresa el tipo de encriptación" value="{{ old('encryption', $config?->encryption) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="fromAddress{{ $locality->id }}">Correo de Envío(*)</label>
                                                 <input type="email" name="from_address" class="form-control" id="fromAddress{{ $locality->id }}" placeholder="Ingresa el correo de envío" value="{{ old('from_address', $config?->from_address) }}" required>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label for="fromName{{ $locality->id }}">Nombre del Remitente</label>
                                                 <input type="text" name="from_name" class="form-control" id="fromName{{ $locality->id }}" placeholder="Ingresa el nombre del remitente" value="{{ old('from_name', $config?->from_name) }}">
                                             </div>
                                         </div>
-
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card mt-3 collapsed-card">
+                                <div class="card-header py-2 bg-secondary">
+                                    <h3 class="card-title">
+                                        Ejemplos de Llenado de Configuración de Correo
+                                    </h3>
+                                    <div class="card-tools">
+                                        <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                                            <i class="fa fa-minus"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="card-body">
+                                    <div class="row">
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Mailer</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['mailer'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Host</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['host'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Puerto</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['port'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Usuario</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['username'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Contraseña</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['password'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Encriptación</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['encryption'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Correo de Envío</label>
+                                                <input type="email" class="form-control" value="{{ $mailExamples['from_address'] }}" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Nombre del Remitente</label>
+                                                <input type="text" class="form-control" value="{{ $mailExamples['from_name'] }}" readonly>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
-                            <button type="submit" class="btn btn-success">Guardar</button>
+                            <button type="submit" class="btn bg-purple mr-2">Guardar</button>
                         </div>
                     </form>
                 </div>
@@ -103,4 +158,3 @@
         </div>
     </div>
 @endforeach
-


### PR DESCRIPTION
An examples section was added to the email configuration so users can view reference values when filling in the fields. Additionally, an issue with the logo size in the email preview was resolved to ensure a more consistent presentation.