### PR TITLE
Refactor seeders to use updateOrCreate and prevent duplicate records

### DIFF
--- a/database/seeders/CostsTableSeeder.php
+++ b/database/seeders/CostsTableSeeder.php
@@ -3,19 +3,13 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
+use App\Models\Cost;
 
 class CostsTableSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
-        DB::table('costs')->insert([
+        $costs = [
             [
                 'locality_id' => 1,
                 'created_by' => 2,
@@ -44,6 +38,21 @@ class CostsTableSeeder extends Seeder
                 'price' => 100.00,
                 'description' => 'Tarifas para Madres Solteras',
             ],
-        ]);
+        ];
+
+        foreach ($costs as $cost) {
+            Cost::updateOrCreate(
+                [
+                    'locality_id' => $cost['locality_id'],
+                    'category' => $cost['category'],
+                ],
+                [
+                    'price' => $cost['price'],
+                    'description' => $cost['description'],
+                    'created_by' => $cost['created_by'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
     }
 }

--- a/database/seeders/IncidentCategorySeeder.php
+++ b/database/seeders/IncidentCategorySeeder.php
@@ -3,45 +3,51 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use App\Models\IncidentCategory;
 
 class IncidentCategorySeeder extends Seeder
 {
     public function run()
     {
-        DB::table('incident_categories')->insert([
+        $categories = [
             [
                 'name' => 'Eléctrica',
                 'description' => 'Problemas con instalación o alumbrado eléctrico.',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'name' => 'Plomería',
                 'description' => 'Fugas, tuberías dañadas o problemas de agua.',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'name' => 'Infraestructura',
                 'description' => 'Daños estructurales como techos, paredes o pisos.',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'name' => 'Tecnología',
                 'description' => 'Fallas con equipo de cómputo, redes o sistemas.',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]
-        ]);
+            ],
+        ];
+
+        foreach ($categories as $category) {
+            IncidentCategory::updateOrCreate(
+                [
+                    'name' => $category['name'],
+                    'locality_id' => $category['locality_id'],
+                ],
+                [
+                    'description' => $category['description'],
+                    'created_by' => $category['created_by'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
     }
 }

--- a/database/seeders/IncidentSeeder.php
+++ b/database/seeders/IncidentSeeder.php
@@ -3,14 +3,14 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use App\Models\Incident;
 use Carbon\Carbon;
 
 class IncidentSeeder extends Seeder
 {
     public function run()
     {
-        DB::table('incidents')->insert([
+        $incidents = [
             [
                 'name' => 'Falla en iluminación',
                 'description' => 'No funcionan las luces del pasillo principal.',
@@ -19,8 +19,6 @@ class IncidentSeeder extends Seeder
                 'category_id' => 3,
                 'locality_id' => 1,
                 'created_by' => 3,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'name' => 'Fuga en baño',
@@ -30,8 +28,6 @@ class IncidentSeeder extends Seeder
                 'category_id' => 4,
                 'locality_id' => 1,
                 'created_by' => 3,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'name' => 'Ventana rota',
@@ -41,8 +37,6 @@ class IncidentSeeder extends Seeder
                 'category_id' => 3,
                 'locality_id' => 1,
                 'created_by' => 3,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'name' => 'Puerta dañada',
@@ -52,9 +46,24 @@ class IncidentSeeder extends Seeder
                 'category_id' => 3,
                 'locality_id' => 1,
                 'created_by' => 3,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
-        ]);
+        ];
+
+        foreach ($incidents as $incident) {
+            Incident::updateOrCreate(
+                [
+                    'name' => $incident['name'],
+                    'locality_id' => $incident['locality_id'],
+                ],
+                [
+                    'description' => $incident['description'],
+                    'status' => $incident['status'],
+                    'start_date' => $incident['start_date'],
+                    'category_id' => $incident['category_id'],
+                    'created_by' => $incident['created_by'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
     }
 }

--- a/database/seeders/IncidentStatusSeeder.php
+++ b/database/seeders/IncidentStatusSeeder.php
@@ -3,37 +3,45 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use App\Models\IncidentStatus; // Asegúrate de tener este modelo
 
 class IncidentStatusSeeder extends Seeder
 {
     public function run()
     {
-        DB::table('incident_statuses')->insert([
+        $statuses = [
             [
                 'status' => 'Pendiente',
                 'description' => 'Incidencia en proceso de ser atendida',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'status' => 'En progreso',
                 'description' => 'Incidencia en proceso de resolución',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
             [
                 'status' => 'Terminada',
                 'description' => 'Incidencia resuelta y cerrada.',
                 'created_by' => 3,
                 'locality_id' => 1,
-                'created_at' => now(),
-                'updated_at' => now(),
             ],
-        ]);
+        ];
+
+        foreach ($statuses as $status) {
+            IncidentStatus::updateOrCreate(
+                [
+                    'status' => $status['status'],
+                    'locality_id' => $status['locality_id'],
+                ],
+                [
+                    'description' => $status['description'],
+                    'created_by' => $status['created_by'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
     }
 }

--- a/database/seeders/LogIncidentTableSeeder.php
+++ b/database/seeders/LogIncidentTableSeeder.php
@@ -3,18 +3,13 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use App\Models\LogIncident;
 
 class LogIncidentTableSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
-        DB::table('log_incidents')->insert([
+        $logs = [
             [
                 'locality_id' => 1,
                 'created_by' => 2,
@@ -50,6 +45,21 @@ class LogIncidentTableSeeder extends Seeder
                 'status' => 'Proceso',
                 'description' => 'Se hacen pruebas',
             ],
-        ]);
+        ];
+
+        foreach ($logs as $log) {
+            LogIncident::updateOrCreate(
+                [
+                    'status' => $log['status'],
+                    'description' => $log['description'],
+                    'locality_id' => $log['locality_id'],
+                ],
+                [
+                    'employee_id' => $log['employee_id'],
+                    'created_by' => $log['created_by'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
     }
 }

--- a/resources/views/localities/generatedTokenModal.blade.php
+++ b/resources/views/localities/generatedTokenModal.blade.php
@@ -1,7 +1,7 @@
 <div class="modal fade" id="generatedTokenModal" tabindex="-1" role="dialog" aria-labelledby="generatedTokenLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
-        <div class="modal-content border-warning">
-            <div class="modal-header bg-warning text-white">
+        <div class="modal-content">
+            <div class="modal-header" style="background-color: #fd7e14; color: white;">
                 <h5 class="modal-title" id="generatedTokenLabel">Token Generado</h5>
                 <button type="button" class="close text-white" data-dismiss="modal">
                     <span>&times;</span>
@@ -14,7 +14,7 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
-                <button class="btn btn-outline-warning" onclick="copyToken()">Copiar Token</button>
+                <button class="btn" style="background-color: #fd7e14; color: white;" onclick="copyToken()">Copiar Token</button>
             </div>
         </div>
     </div>

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -78,8 +78,7 @@
                                             <td class="text-left align-center">
                                                 <span class="badge 
                                                     {{ $locality->getSubscriptionStatus() === Locality::SUBSCRIPTION_ACTIVE ? 'badge-success' : 
-                                                    ($locality->getSubscriptionStatus() === Locality::SUBSCRIPTION_EXPIRED ? 'badge-danger' : 'badge-secondary') }}"
-                                                    style="font-size: 1rem; padding: 2px 6px;">
+                                                    ($locality->getSubscriptionStatus() === Locality::SUBSCRIPTION_EXPIRED ? 'badge-danger' : 'badge-secondary') }}">
                                                     {{ $locality->getSubscriptionStatus() }}
                                                 </span>
                                             </td>


### PR DESCRIPTION
Several seeder files were updated to improve their behavior when executed multiple times. Instead of inserting data blindly, updateOrCreate is now used. This ensures that data is not duplicated each time the seeder runs, and existing records are updated with the latest information. Additionally, the design of a modal and some data in the localities table were fixed.