### PR TITLE
The incident locality id is added to display data for each locality

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -16,7 +16,8 @@ class IncidentController extends Controller
     {
         $authUser = auth()->user();
 
-        $query = Incident::with('incidentCategory', 'getstatusChangeLogs.employee');
+        $query = Incident::with('incidentCategory', 'getstatusChangeLogs.employee')
+        ->where('locality_id', $authUser->locality_id);
 
         if ($request->filled('category')) {
             $query->where('category_id', $request->category);

--- a/app/Http/Controllers/IncidentStatusController.php
+++ b/app/Http/Controllers/IncidentStatusController.php
@@ -11,7 +11,10 @@ class IncidentStatusController extends Controller
 {
     public function index()
     {
-        $statuses = IncidentStatus::paginate(10); 
+        $authUser = auth()->user();
+
+        $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)->paginate(10);
+
         return view('incidentStatuses.index', compact('statuses'));
     }
 


### PR DESCRIPTION
The locality id was added to the code to display only incidents corresponding to the authenticated user's locality. This way, all incidents are no longer displayed globally, but are limited to the assigned locality.
Similarly, this same id was applied to incident statuses.