### PR TITLE
Corrects differences in icons between menus

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -309,7 +309,7 @@ return [
     [
         'text' => 'Panel',
         'url' => '/dashboard',
-        'icon' => 'fas fa-fw fa-home',
+        'icon' => 'fa fa-fw fa-home',
     ],
     [
         'text' => 'Usuarios',
@@ -404,13 +404,13 @@ return [
     [
         'text' => 'Empleados',
         'url' => '/employees',
-        'icon' => 'fas fa-fw fa-users',
+        'icon' => 'fas fa-solid fa-users',
         'can' => 'viewEmployee'
     ],
     [
         'text' => 'Falta de pago',
         'url'  => '/expiredSubscriptions/expired',
-        'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
+        'icon' => 'fas fa-exclamation-circle text-warning',
     ],
 ],
 

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -309,7 +309,7 @@ return [
     [
         'text' => 'Panel',
         'url' => '/dashboard',
-        'icon' => 'fa fa-home',
+        'icon' => 'fas fa-fw fa-home',
     ],
     [
         'text' => 'Usuarios',
@@ -404,13 +404,13 @@ return [
     [
         'text' => 'Empleados',
         'url' => '/employees',
-        'icon' => 'fas fa-solid fa-users',
+        'icon' => 'fas fa-fw fa-users',
         'can' => 'viewEmployee'
     ],
     [
         'text' => 'Falta de pago',
         'url'  => '/expiredSubscriptions/expired',
-        'icon' => 'fas fa-exclamation-circle text-warning',
+        'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
     ],
 ],
 


### PR DESCRIPTION
In this PR, the width of all side menu icons was standardized to better display the text in a linear fashion, since the blank spaces left by the icons are different, but the text was aligned.