### PR TITLE
correction of non-indented icons

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -309,7 +309,7 @@ return [
     [
         'text' => 'Panel',
         'url' => '/dashboard',
-        'icon' => 'fa fa-fw fa-home',
+        'icon' => 'fas fa-fw fa-home',
     ],
     [
         'text' => 'Usuarios',
@@ -404,13 +404,13 @@ return [
     [
         'text' => 'Empleados',
         'url' => '/employees',
-        'icon' => 'fas fa-solid fa-users',
+        'icon' => 'fas fa-fw fa-users',
         'can' => 'viewEmployee'
     ],
     [
         'text' => 'Falta de pago',
         'url'  => '/expiredSubscriptions/expired',
-        'icon' => 'fas fa-exclamation-circle text-warning',
+        'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
     ],
 ],
 


### PR DESCRIPTION
In this PR, the same configuration was added to the icons that were missing from the menu and are indented.