### PR TITLE
The delete button in the incident status list has been disabled when …

### DIFF
--- a/app/Models/IncidentStatus.php
+++ b/app/Models/IncidentStatus.php
@@ -25,4 +25,15 @@ class IncidentStatus extends Model
     {
         return $this->belongsTo(User::class, 'created_by');
     }
+
+    public function incidents()
+    {
+        return $this->hasMany(Incident::class, 'status', 'status');
+    }
+
+    public function hasDependencies()
+    {
+       return $this->incidents()->exists();
+    }
+
 }

--- a/resources/views/incidentStatuses/index.blade.php
+++ b/resources/views/incidentStatuses/index.blade.php
@@ -60,8 +60,9 @@
                                                         </button>
                                                         @endcan
                                                         @can('deleteIncidentStatuses')
-                                                        <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#deleteIncidentStatus{{ $status->id }}">
-                                                            <i class="fas fa-trash-alt"></i>
+                                                        <button type="button" class="btn {{ $status->hasDependencies() ? 'btn-secondary' : 'btn-danger' }} mr-2" title="{{ $status->hasDependencies() ? 'Eliminación no permitida: Existen incidencias asociadas a este estatus.' : 'Eliminar Registro' }}" 
+                                                        {{ $status->hasDependencies() ? 'disabled' : 'data-toggle=modal data-target=#deleteIncidentStatus' . $status->id }}>
+                                                        <i class="fas fa-trash-alt"></i>
                                                         </button>
                                                         @endcan
                                                     </div>


### PR DESCRIPTION
The delete button in the incident status list has been disabled when the status has associated incidents.
To achieve this, the hasDependencies() method was created in the IncidentStatus model, which checks whether the status is in use.
In the view, if there are dependencies, the button is grayed out and disabled; if not, it allows deletion via a modal.
This prevents deleting a status in use and maintains data integrity.