### PR TITLE
 Filtre costs by locality in PDF report

### DIFF
--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -64,7 +64,7 @@ class CostController extends Controller
     public function generateCostListReport()
     {
         $authUser = auth()->user();
-        $costs = Cost::where('locality_id', $authUser->locality_id)
+        $costs = cost::where('locality_id', $authUser->locality_id)
                     ->orderBy('created_at', 'desc')
                     ->get();
         

--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -64,8 +64,11 @@ class CostController extends Controller
     public function generateCostListReport()
     {
         $authUser = auth()->user();
-        $costs = cost::all();
-        $pdf = PDF::loadView('reports.generateCostListReport', compact('costs', 'authUser'))
+        $costs = Cost::where('locality_id', $authUser->locality_id)
+                    ->orderBy('created_at', 'desc')
+                    ->get();
+        
+        $pdf = PDF::loadView('reports.generateCostListReport', compact('costs', 'authUser'))      
             ->setPaper('A4', 'portrait');
 
         return $pdf->stream('costs.pdf');


### PR DESCRIPTION
Fix discrepancy between web view and PDF report by applying the same locality filter to PDF generation.