### PR TITLE
Correction of labels from Apple to Exterior Number in customer views

### DIFF
--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -83,7 +83,7 @@
                                     </div>
                                     <div class="col-lg-4">
                                         <div class="form-group">
-                                            <label for="exteriorNumberUpdate" class="form-label">Manzana(*)</label>
+                                            <label for="exteriorNumberUpdate" class="form-label">Número Exterior(*)</label>
                                             <input type="text" class="form-control" name="exteriorNumberUpdate" id="exteriorNumberUpdate" value="{{ $customer->exterior_number }}" required>
                                         </div>
                                     </div>

--- a/resources/views/customers/show.blade.php
+++ b/resources/views/customers/show.blade.php
@@ -75,7 +75,7 @@
                                 </div>
                                 <div class="col-lg-4">
                                     <div class="form-group">
-                                        <label>Manzana</label>
+                                        <label>Número Exterior</label>
                                         <input type="text" disabled class="form-control" value="{{ $customer->exterior_number }}" />
                                     </div>
                                 </div>

--- a/resources/views/reports/pdfCustomers.blade.php
+++ b/resources/views/reports/pdfCustomers.blade.php
@@ -166,7 +166,7 @@
                     <tr>
                         <th class="textable">ID</th>
                         <th class="textable">NOMBRE</th>
-                        <th class="textable">MANZANA</th>
+                        <th class="textable">NUM. EXTERIOR</th>
                         <th class="textable">CALLE</th>
                         <th class="textable">NUM. INTERIOR</th>
                         <th class="textable">ESTADO CIVIL</th>


### PR DESCRIPTION
The field label was updated in the different customer views. Previously, it was displayed as 'Apple', but it has now been corrected to 'Exterior Number'. This modification was also applied in the detail view and in the reports.