### PR TITLE
Add fault_report migration and seeder

### DIFF
--- a/database/migrations/2025_09_18_112726_create_fault_report_table.php
+++ b/database/migrations/2025_09_18_112726_create_fault_report_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFaultReportTable extends Migration
+{
+    private const STATUS = ['earring', 'in_process', 'resolved', 'closed'];
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('fault_report', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('customer_id');
+            $table->unsignedBigInteger('created_by');
+            $table->unsignedBigInteger('locality_id')->nullable();
+            $table->string('title');
+            $table->text('description');
+            $table->enum('status', self::STATUS)->default('earring');
+            $table->timestamp('date_report')->useCurrent();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('customer_id')->references('id')->on('customers')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('fault_report');
+    }
+}

--- a/database/migrations/2025_09_18_112726_create_fault_report_table.php
+++ b/database/migrations/2025_09_18_112726_create_fault_report_table.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateFaultReportTable extends Migration
 {
-    private const STATUS = ['earring', 'in_process', 'resolved', 'closed'];
     /**
      * Run the migrations.
      *
@@ -21,7 +20,7 @@ class CreateFaultReportTable extends Migration
             $table->unsignedBigInteger('locality_id')->nullable();
             $table->string('title');
             $table->text('description');
-            $table->enum('status', self::STATUS)->default('earring');
+            $table->string('status');
             $table->timestamp('date_report')->useCurrent();
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2025_09_18_112726_create_fault_report_table.php
+++ b/database/migrations/2025_09_18_112726_create_fault_report_table.php
@@ -42,3 +42,4 @@ class CreateFaultReportTable extends Migration
         Schema::dropIfExists('fault_report');
     }
 }
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,5 +30,6 @@ class DatabaseSeeder extends Seeder
         $this->call(EmployeesTableSeeder::class);
         $this->call(LocalitiesTableSeeder::class);
         $this->call(AdvancePaymentsSeeder::class);
+        $this->call(FaultReportSeeder::class);
     }
 }

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Faker\Factory as Faker;
+
+class FaultReportSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $faker = Faker::create();
+
+        // Estados posibles definidos en la migración
+        $statuses = ['earring', 'in_process', 'resolved', 'closed'];
+
+        foreach (range(1, 20) as $i) { // Genera 20 registros de prueba
+            DB::table('fault_report')->insert([
+                'customer_id'   => $faker->numberBetween(1, 10), // Debe coincidir con IDs reales en 'customers'
+                'created_by'    => $faker->numberBetween(1, 5),  // Debe coincidir con IDs reales en 'users'
+                'locality_id'   => $faker->optional()->numberBetween(1, 10), // Puede ser null
+                'title'         => $faker->sentence(6),
+                'description'   => $faker->paragraph(3),
+                'status'        => $faker->randomElement($statuses),
+                'date_report'   => $faker->dateTimeBetween('-6 months', 'now'),
+                'created_at'    => now(),
+                'updated_at'    => now(),
+                'deleted_at'    => null,
+            ]);
+        }
+    }
+}

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -17,7 +17,7 @@ class FaultReportSeeder extends Seeder
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
         $userIds = DB::table('users')->pluck('id')->toArray();
-        $statuses = ['earring', 'inprocess', 'resolved', 'closed'];
+        $statuses = ['Earring', 'In process', 'Resolved', 'Closed'];
 
         foreach (range(1, 20) as $i) {
             DB::table('fault_report')->insert([

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -15,14 +15,13 @@ class FaultReportSeeder extends Seeder
     {
         $faker = Faker::create();
 
-        // Estados posibles definidos en la migración
         $statuses = ['earring', 'in_process', 'resolved', 'closed'];
 
-        foreach (range(1, 20) as $i) { // Genera 20 registros de prueba
+        foreach (range(1, 20) as $i) {
             DB::table('fault_report')->insert([
-                'customer_id'   => $faker->numberBetween(1, 10), // Debe coincidir con IDs reales en 'customers'
-                'created_by'    => $faker->numberBetween(1, 5),  // Debe coincidir con IDs reales en 'users'
-                'locality_id'   => $faker->optional()->numberBetween(1, 10), // Puede ser null
+                'customer_id'   => $faker->numberBetween(1, 10), 
+                'created_by'    => $faker->numberBetween(1, 5),  
+                'locality_id'   => $faker->optional()->numberBetween(1, 10), 
                 'title'         => $faker->sentence(6),
                 'description'   => $faker->paragraph(3),
                 'status'        => $faker->randomElement($statuses),
@@ -34,3 +33,4 @@ class FaultReportSeeder extends Seeder
         }
     }
 }
+

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -15,13 +15,15 @@ class FaultReportSeeder extends Seeder
     {
         $faker = Faker::create();
 
+        $localityIds = DB::table('localities')->pluck('id')->toArray();
+        $userIds = DB::table('users')->pluck('id')->toArray();
         $statuses = ['earring', 'in_process', 'resolved', 'closed'];
 
         foreach (range(1, 20) as $i) {
             DB::table('fault_report')->insert([
                 'customer_id'   => $faker->numberBetween(1, 10), 
-                'created_by'    => $faker->numberBetween(1, 5),  
-                'locality_id'   => $faker->optional()->numberBetween(1, 10), 
+                'created_by'    => $faker->randomElement($userIds),  
+                'locality_id'   => $faker->randomElement($localityIds),
                 'title'         => $faker->sentence(6),
                 'description'   => $faker->paragraph(3),
                 'status'        => $faker->randomElement($statuses),

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -17,7 +17,7 @@ class FaultReportSeeder extends Seeder
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
         $userIds = DB::table('users')->pluck('id')->toArray();
-        $statuses = ['earring', 'in_process', 'resolved', 'closed'];
+        $statuses = ['earring', 'inprocess', 'resolved', 'closed'];
 
         foreach (range(1, 20) as $i) {
             DB::table('fault_report')->insert([


### PR DESCRIPTION
The migration and seeder for the fault_report table have been added, which will allow managing fault reports within the application.
- The fault_report table is created with relationships to customers, users, and localities.
- It includes fields for title, description, status, and date_report, with timestamps and soft deletes.
- The FaultReportSeeder has been added to generate test data using Faker.