### PR TITLE
Feature/correct migration of the status column

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -27,7 +27,7 @@ class IncidentController extends Controller
 
         $categories = IncidentCategory::all();
         $employees = Employee::where('locality_id', $authUser->locality_id)->get();
-        $statuses = IncidentStatus::pluck('status');
+        $statuses = IncidentStatus::all();
 
         return view('incidents.index', compact('incidents', 'categories', 'employees', 'statuses'));
     }
@@ -46,7 +46,7 @@ class IncidentController extends Controller
             'start_date' => $request->input('startDate'),
             'description' => $request->input('description'),
             'category_id' => $request->input('category'),
-            'status' => $request->input('status'),
+            'status_id' => $request->input('statusUpdate'),
             'locality_id' => $authUser->locality_id,
             'created_by' => $authUser->id,
         ];
@@ -80,7 +80,7 @@ class IncidentController extends Controller
             $incident->start_date = $request->input('startDateUpdate');
             $incident->description = $request->input('descriptionUpdate');
             $incident->category_id = $request->input('categoryUpdate');
-            $incident->status = $request->input('statusUpdate');
+            $incident->status_id = $request->input('statusUpdate');
 
             $incident->save();
 

--- a/app/Http/Controllers/InventoryController.php
+++ b/app/Http/Controllers/InventoryController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Inventory;
+use App\Models\Locality;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class InventoryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->input('search');
+        $user = Auth::user();
+        $userLocalityId = $user->locality_id;
+
+        $components = Inventory::with(['locality', 'creator'])
+            ->when($search, function ($query, $search) {
+                return $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('category', 'like', "%{$search}%")
+                    ->orWhereHas('locality', function ($q) use ($search) {
+                        $q->where('name', 'like', "%{$search}%");
+                    })
+                    ->orWhereHas('creator', function ($q) use ($search) {
+                        $q->where('name', 'like', "%{$search}%");
+                    });
+            })
+            ->when($userLocalityId, function ($query) use ($userLocalityId) {
+                return $query->where('locality_id', $userLocalityId);
+            })
+            ->whereNull('deleted_at')
+            ->paginate(10);
+
+        $localities = Locality::select('id', 'name')->get();
+        $users = User::select('id', 'name')->get();
+
+        return view('inventory.index', compact('components', 'localities', 'users'));
+    }
+
+    public function create()
+    {
+        $localities = Locality::select('id', 'name')->get();
+        $users = User::select('id', 'name')->get();
+        $user = Auth::user();
+        return view('inventory.create', compact('localities', 'users', 'user'));
+    }
+
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+        $request->merge([
+            'locality_id' => $user->locality_id,
+            'created_by' => $user->id,
+        ]);
+
+        $request->validate([
+            'name' => 'required|string|max:100',
+            'description' => 'nullable|string',
+            'amount' => 'required|integer|min:0',
+            'category' => 'required|string|max:50',
+            'material' => 'nullable|string|max:50',
+            'dimensions' => 'nullable|string|max:50',
+        ]);
+
+        Inventory::create($request->all());
+
+        return redirect()->route('inventory.index')->with('success', 'Componente creado con éxito.');
+    }
+
+    public function show($id)
+    {
+        $component = Inventory::with(['locality', 'creator'])->findOrFail($id);
+        return view('inventory.show', compact('component'));
+    }
+
+    public function edit($id)
+    {
+        $component = Inventory::findOrFail($id);
+        $localities = Locality::select('id', 'name')->get();
+        $users = User::select('id', 'name')->get();
+        $user = Auth::user();
+        return view('inventory.edit', compact('component', 'localities', 'users', 'user'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $user = Auth::user();
+        $request->merge([
+            'locality_id' => $user->locality_id,
+            'created_by' => $user->id,
+        ]);
+
+        $request->validate([
+            'name' => 'required|string|max:100',
+            'description' => 'nullable|string',
+            'amount' => 'required|integer|min:0',
+            'category' => 'required|string|max:50',
+            'material' => 'nullable|string|max:50',
+            'dimensions' => 'nullable|string|max:50',
+        ]);
+
+        $component = Inventory::findOrFail($id);
+        $component->update($request->all());
+
+        return redirect()->route('inventory.index')->with('success', 'Componente actualizado con éxito.');
+    }
+
+    public function destroy($id)
+    {
+        $component = Inventory::findOrFail($id);
+        $component->delete();
+
+        return redirect()->route('inventory.index')->with('success', 'Componente eliminado con éxito.');
+    }
+}

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -19,7 +19,7 @@ class Incident extends Model implements HasMedia
         'start_date',
         'description',
         'category_id',
-        'status',
+        'status_id',
     ];
 
     public function locality()
@@ -59,16 +59,17 @@ class Incident extends Model implements HasMedia
 
     public function getLatestStatus()
     {
-        $incidentStatus = $this->status;
-        $incidentUpdatedAt = $this->updated_at;
-        $lastLog = $this->getstatusChangeLogs->first();
+       $incidentStatus = $this->status ? $this->status->status : null; 
+       $incidentUpdatedAt = $this->updated_at;
+       $lastLog = $this->getstatusChangeLogs->first();
 
-        if ($lastLog && !empty($lastLog->status)) {
-            $logUpdatedAt = $lastLog->updated_at;
-            if ($logUpdatedAt > $incidentUpdatedAt) {
-                return $lastLog->status;
-            }
+    if ($lastLog && !empty($lastLog->status)) {
+        $logUpdatedAt = $lastLog->updated_at;
+
+        if ($logUpdatedAt > $incidentUpdatedAt) {
+            return $lastLog->status;
         }
+    }
 
         return $incidentStatus;
     }
@@ -86,5 +87,10 @@ class Incident extends Model implements HasMedia
         }
 
         return $uniqueEmployees;
+    }
+
+    public function status()
+    {
+        return $this->belongsTo(IncidentStatus::class, 'status_id');
     }
 }

--- a/app/Models/IncidentStatus.php
+++ b/app/Models/IncidentStatus.php
@@ -28,12 +28,12 @@ class IncidentStatus extends Model
 
     public function incidents()
     {
-        return $this->hasMany(Incident::class, 'status', 'status');
+        return $this->hasMany(Incident::class, 'status_id', 'id');
     }
 
     public function hasDependencies()
     {
-       return $this->incidents()->exists();
+        return $this->incidents()->exists();
     }
 
 }

--- a/app/Models/Inventory.php
+++ b/app/Models/Inventory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Inventory extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'inventory';
+
+    protected $fillable = [
+        'locality_id',
+        'created_by',
+        'name',
+        'description',
+        'amount',
+        'category',
+        'material',
+        'dimensions',
+    ];
+
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function setAmountAttribute($value)
+    {
+        $this->attributes['amount'] = max(0, $value);
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -412,6 +412,24 @@ return [
         'url'  => '/expiredSubscriptions/expired',
         'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
     ],
+    [
+        'text' => 'Mis Pagos',
+        'url' => '/viewMyPayments',
+        'can' => 'viewCustomerPayments',
+        'icon' => 'fas fa-fw fa-dollar-sign text-white',
+    ],
+    [
+        'text' => 'Mis Deudas',
+        'url' => '/viewMyDebts',
+        'can'  => 'viewCustomerDebts',
+        'icon' => 'fas fa-fw fa-exclamation-circle text-white',
+    ],
+    [
+        'text' => 'Mis Tomas de Agua',
+        'url' => '/viewMyWaterConnections',
+        'can' => 'viewWaterConnections',
+        'icon' => 'fas fa-fw fa-water text-white',
+    ],
 ],
 
     /*

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -413,6 +413,12 @@ return [
         'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
     ],
     [
+        'text' => 'Inventario',
+        'url' => '/inventory',
+        'icon' => 'fas fa-fw fa-boxes',
+        'can'  => 'viewInventory'
+    ],
+    [
         'text' => 'Mis Pagos',
         'url' => '/viewMyPayments',
         'can' => 'viewCustomerPayments',

--- a/database/migrations/2025_09_15_135308_create_localities_notices_table.php
+++ b/database/migrations/2025_09_15_135308_create_localities_notices_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLocalitiesNoticesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+       Schema::create('locality_notices', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('created_by');
+            $table->unsignedBigInteger('locality_id');
+            $table->string('title', 100);
+            $table->text('description');
+            $table->dateTime('start_date');
+            $table->dateTime('end_date');
+            $table->boolean('is_active')->default(true);
+            $table->string('attachment_url')->nullable();
+            $table->timestamps();
+
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+            
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('locality_notices');
+    }
+}

--- a/database/migrations/2025_09_22_181633_change_status_in_incidents_table.php
+++ b/database/migrations/2025_09_22_181633_change_status_in_incidents_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->unsignedBigInteger('status_id')->nullable()->after('category_id');
+        });
+
+        DB::table('incidents')->get()->each(function ($incident) {
+            $statusId = DB::table('incident_statuses')->where('status', $incident->status)->value('id');
+
+            if (!$statusId && $incident->status) {
+                $statusId = DB::table('incident_statuses')->insertGetId([
+                    'status' => $incident->status,
+                    'description' => null,
+                    'created_by' => $incident->created_by,   
+                    'locality_id' => $incident->locality_id, 
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            if ($statusId) {
+                DB::table('incidents')
+                    ->where('id', $incident->id)
+                    ->update(['status_id' => $statusId]);
+            }
+        });
+
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->dropColumn('status');
+            $table->foreign('status_id')->references('id')->on('incident_statuses')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->string('status')->nullable();
+
+            DB::table('incidents')->get()->each(function ($incident) {
+                $statusName = DB::table('incident_statuses')->where('id', $incident->status_id)->value('status');
+
+                if ($statusName) {
+                    DB::table('incidents')->where('id', $incident->id)->update(['status' => $statusName]);
+                }
+            });
+
+            $table->dropForeign(['status_id']);
+            $table->dropColumn('status_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,6 +30,7 @@ class DatabaseSeeder extends Seeder
         $this->call(EmployeesTableSeeder::class);
         $this->call(LocalitiesTableSeeder::class);
         $this->call(AdvancePaymentsSeeder::class);
+        $this->call(LocalityNoticesSeeder::class);
         $this->call(FaultReportSeeder::class);
         $this->call(InventoryTableSeeder::class);
     }

--- a/database/seeders/IncidentSeeder.php
+++ b/database/seeders/IncidentSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Incident;
+use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 
 class IncidentSeeder extends Seeder
@@ -50,6 +51,19 @@ class IncidentSeeder extends Seeder
         ];
 
         foreach ($incidents as $incident) {
+            $statusId = DB::table('incident_statuses')->where('status', $incident['status'])->value('id');
+
+            if (!$statusId) {
+                $statusId = DB::table('incident_statuses')->insertGetId([
+                    'status' => $incident['status'],
+                    'description' => null,
+                    'created_by' => $incident['created_by'],
+                    'locality_id' => $incident['locality_id'],
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
             Incident::updateOrCreate(
                 [
                     'name' => $incident['name'],
@@ -57,7 +71,7 @@ class IncidentSeeder extends Seeder
                 ],
                 [
                     'description' => $incident['description'],
-                    'status' => $incident['status'],
+                    'status_id' => $statusId, 
                     'start_date' => $incident['start_date'],
                     'category_id' => $incident['category_id'],
                     'created_by' => $incident['created_by'],

--- a/database/seeders/LocalityNoticesSeeder.php
+++ b/database/seeders/LocalityNoticesSeeder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class LocalityNoticesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $today = Carbon::today();
+
+        $localityIds = DB::table('localities')->pluck('id')->toArray();
+        $userIds = DB::table('users')->pluck('id')->toArray();
+
+        $notices = [
+            [
+                'title' => 'Mantenimiento de agua programado',
+                'description' => 'Se suspenderá temporalmente el suministro de agua en varias zonas por mantenimiento de la red principal.',
+                'start_date' => $today->copy()->addDays(2),
+                'end_date' => $today->copy()->addDays(3),
+            ],
+            [
+                'title' => 'Revisión de medidores',
+                'description' => 'Personal autorizado realizará la revisión anual de medidores en todas las localidades durante esta semana.',
+                'start_date' => $today->copy()->addDays(1),
+                'end_date' => $today->copy()->addDays(2),
+            ],
+            [
+                'title' => 'Corte de energía en zona norte',
+                'description' => 'Debido a trabajos de la CFE, habrá interrupción del suministro eléctrico que puede afectar la presión del agua.',
+                'start_date' => $today->copy()->addDays(3),
+                'end_date' => $today->copy()->addDays(4),
+            ],
+            [
+                'title' => 'Aviso de limpieza de cisternas',
+                'description' => 'Se realizará limpieza de cisternas comunitarias en varias localidades. Se recomienda almacenamiento previo de agua.',
+                'start_date' => $today->copy()->addDays(1),
+                'end_date' => $today->copy()->addDays(3),
+            ],
+            [
+                'title' => 'Restablecimiento de servicio',
+                'description' => 'El servicio de agua ha sido restablecido tras los trabajos de mantenimiento en la red principal.',
+                'start_date' => $today->copy()->subDay(),
+                'end_date' => $today->copy()->addDay(),
+            ],
+        ];
+
+        foreach ($notices as $notice) {
+            DB::table('locality_notices')->insert([
+                'title' => $notice['title'],
+                'description' => $notice['description'],
+                'start_date' => $notice['start_date'],
+                'end_date' => $notice['end_date'],
+                'is_active' => true,
+                'locality_id' => $localityIds[array_rand($localityIds)],
+                'created_by' => $userIds[array_rand($userIds)],
+                'attachment_url' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -179,5 +179,17 @@ class RolesAndPermissionsSeeder extends Seeder
             'name' => 'viewWaterConnections',
             'description' => 'El cliente puede ver sus tomas de agua'
         ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
+            'name' => 'viewInventory',
+            'description' => 'Permite ver el Inventario.'
+        ])->assignRole([$roleSupervisor]);
+        Permission::firstOrCreate([
+            'name' => 'updateInventory',
+            'description' => 'Permite editar el Inventario.'
+        ])->assignRole([$roleSupervisor]);
+        Permission::firstOrCreate([
+            'name' => 'deleteInventory',
+            'description' => 'Permite eliminar el Inventario.'
+        ])->assignRole([$roleSupervisor]);
     }
 }

--- a/resources/views/incidents/changeStatusModal.blade.php
+++ b/resources/views/incidents/changeStatusModal.blade.php
@@ -51,7 +51,7 @@
                                             <select class="form-control select2" name="status" required>
                                                 <option value="">Selecciona una opción</option>
                                                 @foreach ($statuses as $status)
-                                                    <option value="{{ $status }}">{{ $status }}</option>
+                                                    <option value="{{ $status->id }}">{{ $status->status }}</option>
                                                 @endforeach
                                             </select>
                                         </div>

--- a/resources/views/incidents/create.blade.php
+++ b/resources/views/incidents/create.blade.php
@@ -49,11 +49,13 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="status" class="form-label">Estatus(*)</label>
-                                            <select class="form-control select2" name="status" required>
+                                            <label for="status_id" class="form-label">Estatus(*)</label>
+                                            <select class="form-control select2" name="statusUpdate" required>
                                                 <option value="">Selecciona una opción</option>
                                                 @foreach ($statuses as $status)
-                                                    <option value="{{ $status }}">{{ $status }}</option>
+                                                    <option value="{{ $status->id }}">
+                                                {{ $status->status }}
+                                                    </option>
                                                 @endforeach
                                             </select>
                                         </div>

--- a/resources/views/incidents/edit.blade.php
+++ b/resources/views/incidents/edit.blade.php
@@ -50,11 +50,13 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="status" class="form-label">Estatus(*)</label>
+                                            <label for="status_id" class="form-label">Estatus(*)</label>
                                             <select class="form-control select2" name="statusUpdate" required>
                                                 <option value="">Selecciona una opción</option>
-                                                @foreach ($statuses as $status)
-                                                    <option value="{{ $status }}" {{ $incident->getLatestStatus() == $status ? 'selected' : '' }}> {{ $status }} </option>
+                                                @foreach($statuses as $status)
+                                                    <option value="{{ $status->id }}">
+                                                        {{ $status->status }}
+                                                    </option>
                                                 @endforeach
                                             </select>
                                         </div>

--- a/resources/views/incidents/show.blade.php
+++ b/resources/views/incidents/show.blade.php
@@ -41,7 +41,7 @@
                                 <div class="col-lg-4">
                                     <div class="form-group">
                                         <label for="status" class="form-label">Estatus(*)</label>
-                                        <input type="text" disabled class="form-control" value="{{ $incident->getLatestStatus() }}" />
+                                        <input type="text" disabled class="form-control" value="{{ $incident->status->status ?? 'Sin estado' }}" />
                                     </div>
                                 </div>
                                 <div class="col-lg-12">

--- a/resources/views/inventory/create.blade.php
+++ b/resources/views/inventory/create.blade.php
@@ -1,0 +1,75 @@
+<div class="modal fade" id="createInventory" tabindex="-1" role="dialog" aria-labelledby="createInventoryLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Ingrese los Datos del Componente <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <form action="{{ route('inventory.store') }}" method="post">
+                    @csrf
+                    <div class="card-body">
+                        <div class="card">
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="name" class="form-label">Nombre del Componente(*)</label>
+                                            <input type="text" class="form-control" id="name" name="name" placeholder="Ingresa nombre del componente" value="{{ old('name') }}" required />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="amount" class="form-label">Cantidad(*)</label>
+                                            <input type="number" min="0" class="form-control" id="amount" name="amount" placeholder="Ingresa cantidad" value="{{ old('amount') }}" required />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="category" class="form-label">Categoría(*)</label>
+                                            <input type="text" class="form-control" id="category" name="category" placeholder="Ingresa categoría" value="{{ old('category') }}" required />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="material" class="form-label">Material</label>
+                                            <input type="text" class="form-control" id="material" name="material" placeholder="Ingresa material" value="{{ old('material') }}" />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="dimensions" class="form-label">Dimensiones</label>
+                                            <input type="text" class="form-control" id="dimensions" name="dimensions" placeholder="Ingresa dimensiones" value="{{ old('dimensions') }}" />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="description" class="form-label">Descripción</label>
+                                            <textarea class="form-control" id="description" name="description" placeholder="Ingresa una descripción">{{ old('description') }}</textarea>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                        <button type="submit" class="btn btn-success">Guardar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .select2-container .select2-selection--single {
+        height: 40px;
+        display: flex;
+        align-items: center;
+    }
+</style>

--- a/resources/views/inventory/delete.blade.php
+++ b/resources/views/inventory/delete.blade.php
@@ -1,0 +1,23 @@
+<div class="modal fade" id="delete{{ $component->id }}" tabindex="-1" role="dialog" aria-labelledby="deleteInventoryLabel{{ $component->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger">
+                <h5 class="modal-title" id="deleteInventoryLabel{{ $component->id }}">Eliminar Componente</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <form action="{{ route('inventory.destroy', $component->id) }}" method="post">
+                @csrf
+                @method('DELETE')
+                <div class="modal-body text-center text-danger">
+                    ¿Estás seguro de eliminar el Componente <strong>{{ $component->name }}</strong>?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-danger">Confirmar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/inventory/edit.blade.php
+++ b/resources/views/inventory/edit.blade.php
@@ -1,0 +1,76 @@
+<div class="modal fade" id="edit{{ $component->id }}" tabindex="-1" role="dialog" aria-labelledby="editInventoryLabel{{ $component->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-warning">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Editar Componente <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <form action="{{ route('inventory.update', $component->id) }}" method="post">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="card">
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="nameUpdate{{ $component->id }}" class="form-label">Nombre del Componente(*)</label>
+                                            <input type="text" class="form-control" name="name" id="nameUpdate{{ $component->id }}" value="{{ $component->name }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="amountUpdate{{ $component->id }}" class="form-label">Cantidad(*)</label>
+                                            <input type="number" min="0" class="form-control" name="amount" id="amountUpdate{{ $component->id }}" value="{{ $component->amount }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="categoryUpdate{{ $component->id }}" class="form-label">Categoría(*)</label>
+                                            <input type="text" class="form-control" name="category" id="categoryUpdate{{ $component->id }}" value="{{ $component->category }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="materialUpdate{{ $component->id }}" class="form-label">Material</label>
+                                            <input type="text" class="form-control" name="material" id="materialUpdate{{ $component->id }}" value="{{ $component->material }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="dimensionsUpdate{{ $component->id }}" class="form-label">Dimensiones</label>
+                                            <input type="text" class="form-control" name="dimensions" id="dimensionsUpdate{{ $component->id }}" value="{{ $component->dimensions }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="descriptionUpdate{{ $component->id }}" class="form-label">Descripción</label>
+                                            <textarea class="form-control" name="description" id="descriptionUpdate{{ $component->id }}">{{ $component->description }}</textarea>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                        <button type="submit" class="btn btn-warning">Actualizar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .select2-container .select2-selection--single {
+        height: 40px;
+        display: flex;
+        align-items: center;
+    }
+</style>

--- a/resources/views/inventory/index.blade.php
+++ b/resources/views/inventory/index.blade.php
@@ -1,0 +1,157 @@
+@extends('adminlte::page')
+
+@section('title', config('adminlte.title') . ' | Inventario')
+
+@section('content')
+<section class="content">
+    <div class="right_col" role="main">
+        <div class="col-md-12 col-sm-12">
+            <div class="x_panel">
+                <div class="x_title">
+                    <h2>Inventario de Componentes</h2>
+                    <div class="row mb-2">
+                        <div class="col-lg-12">
+                            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-center gap-3">
+                                <form method="GET" action="{{ route('inventory.index') }}" class="flex-grow-1 mt-2" style="min-width: 328px; max-width: 40%;">
+                                    <div class="input-group">
+                                        <input type="text" name="search" class="form-control" placeholder="Buscar por ID, Nombre, Categoría" value="{{ request('search') }}">
+                                        <div class="input-group-append">
+                                            <button type="submit" class="btn btn-primary" title="Buscar Componente">
+                                                <i class="fas fa-search d-lg-none"></i>
+                                                <span class="d-none d-lg-inline">Buscar</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </form>
+                                <button class="btn btn-success flex-grow-1 flex-lg-grow-0 mt-2" data-toggle="modal" data-target="#createInventory" title="Registrar Componente">
+                                    <i class="fa fa-plus"></i>
+                                    <span class="d-none d-lg-inline">Registrar Componente</span>
+                                    <span class="d-inline d-lg-none">Nuevo Componente</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="clearfix"></div>
+                </div>
+                <div class="x_content">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="card-box table-responsive">
+                                <table id="inventory" class="table table-striped display responsive nowrap" style="width:100%">
+                                    <thead>
+                                        <tr>
+                                            <th>ID</th>
+                                            <th>NOMBRE</th>
+                                            <th>CANTIDAD</th>
+                                            <th>CATEGORÍA</th>
+                                            <th>MATERIAL</th>
+                                            <th>DIMENSIONES</th>
+                                            <th>OPCIONES</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @if(count($components) <= 0)
+                                            <tr>
+                                                <td colspan="7">No hay resultados</td>
+                                            </tr>
+                                        @else
+                                            @foreach($components as $component)
+                                                <tr>
+                                                    <td scope="row">{{ $component->id }}</td>
+                                                    <td>{{ $component->name }}</td>
+                                                    <td>{{ $component->amount }}</td>
+                                                    <td>{{ $component->category }}</td>
+                                                    <td>{{ $component->material ?? 'N/A' }}</td>
+                                                    <td>{{ $component->dimensions ?? 'N/A' }}</td>
+                                                    <td>
+                                                        <div class="btn-group" role="group" aria-label="Opciones">
+                                                            <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $component->id }}">
+                                                                <i class="fas fa-eye"></i>
+                                                            </button>
+                                                            @can('updateInventory')
+                                                                <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Datos" data-target="#edit{{ $component->id }}">
+                                                                    <i class="fas fa-edit"></i>
+                                                                </button>
+                                                            @endcan
+                                                            @can('deleteInventory')
+                                                                <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $component->id }}">
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
+                                                            @endcan
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                                @include('inventory.show', ['component' => $component])
+                                                @include('inventory.edit', ['component' => $component, 'localities' => $localities, 'users' => $users])
+                                                @include('inventory.delete', ['component' => $component])
+                                            @endforeach
+                                        @endif
+                                    </tbody>
+                                </table>
+                                @include('inventory.create', ['localities' => $localities, 'users' => $users])
+                                <div class="d-flex justify-content-center">
+                                    {!! $components->links('pagination::bootstrap-4') !!}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+
+@section('js')
+<script>
+    $(document).ready(function() {
+        $('#inventory').DataTable({
+            responsive: true,
+            buttons: ['csv', 'excel', 'print'],
+            dom: 'Bfrtip',
+            paging: false,
+            info: false,
+            searching: false
+        });
+
+        var successMessage = "{{ session('success') }}";
+        var errorMessage = "{{ session('error') }}";
+
+        if (successMessage) {
+            Swal.fire({
+                icon: 'success',
+                title: 'Éxito',
+                text: successMessage,
+                confirmButtonText: 'Aceptar'
+            });
+        }
+
+        if (errorMessage) {
+            Swal.fire({
+                icon: 'error',
+                title: 'Error',
+                text: errorMessage,
+                confirmButtonText: 'Aceptar'
+            });
+        }
+    });
+
+    $('#createInventory').on('shown.bs.modal', function() {
+        $('.select2').select2({
+            dropdownParent: $('#createInventory')
+        });
+    });
+
+    $('[id^="edit"]').on('shown.bs.modal', function() {
+        $(this).find('.select2').select2({
+            dropdownParent: $(this)
+        });
+    });
+
+    $(document).on('shown.bs.modal', '.modal', function() {
+        $(this).find('.select2').select2({
+            dropdownParent: $(this)
+        });
+    });
+</script>
+@endsection

--- a/resources/views/inventory/show.blade.php
+++ b/resources/views/inventory/show.blade.php
@@ -1,0 +1,75 @@
+<div class="modal fade" id="view{{ $component->id }}" tabindex="-1" role="dialog" aria-labelledby="viewInventoryLabel{{ $component->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-info">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Información del Componente</h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="modal-body">
+                    <div class="card">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-lg-2">
+                                    <div class="form-group">
+                                        <label>ID</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->id }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-5">
+                                    <div class="form-group">
+                                        <label>Nombre del Componente</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->name }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-5">
+                                    <div class="form-group">
+                                        <label>Creado por</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->creator->name ?? 'Sin creador' }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Cantidad</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->amount }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Categoría</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->category }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Material</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->material ?? 'No especificado' }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Dimensiones</label>
+                                        <input type="text" disabled class="form-control" value="{{ $component->dimensions ?? 'No especificado' }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-12">
+                                    <div class="form-group">
+                                        <label>Descripción</label>
+                                        <textarea disabled class="form-control">{{ $component->description ?? 'No especificado' }}</textarea>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\GeneralExpenseController;
 use App\Http\Controllers\LocalityController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WaterConnectionController;
+use App\Http\Controllers\InventoryController;
 use App\Http\Controllers\AdvancePaymentController;
 use App\Http\Controllers\IncidentCategoriesController;
 use App\Http\Controllers\IncidentController;
@@ -117,6 +118,11 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::resource('waterConnections', WaterConnectionController::class);
         Route::patch('/waterConnections/{id}/cancel', [WaterConnectionController::class, 'cancel'])->name('waterConnections.cancel');
         Route::patch('/waterConnections/{id}/reactivate', [WaterConnectionController::class, 'reactivate'])->name('waterConnections.reactivate');
+    });
+
+    Route::group(['middleware' => ['can:viewInventory']], function () {
+        Route::get('/inventory', [InventoryController::class, 'index'])->name('inventory.index');
+        Route::resource('inventory', InventoryController::class);
     });
 
     Route::group(['middleware' => ['can:viewGeneralExpense']], function () {


### PR DESCRIPTION
Updated the seeder to use status_id instead of status.

Added use of Illuminate\Support\Facades\DB to query the incident_statuses table.

Before creating or updating an incident, the corresponding status_id is searched based on the status name.

If the status doesn't exist, it is inserted into the incident_statuses table and its new ID is obtained.

Replaced the 'status' => $incident['status'] field with 'status_id' => $statusId when saving the incident.