### PR TITLE
Implement display of notices by location for customers

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -84,7 +84,7 @@ class DashboardController extends Controller
 
         return view('dashboard', compact('data', 'authUser', 'hasMailConfig', 'notices'));
     }
-    
+
     public function getEarningsByLocality(Request $request)
     {
         $localityId = $request->input('locality_id');

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -64,6 +64,13 @@ class DashboardController extends Controller
         $mailConfig = $authUser->locality?->mailConfiguration;
         $hasMailConfig = $mailConfig && $mailConfig->isComplete();
 
+        $notices = \App\Models\LocalityNotice::with(['creator', 'locality'])
+            ->where('locality_id', $authUser->locality_id)
+            ->where('is_active', true)
+            ->where('end_date', '>=', now())
+            ->orderBy('created_at', 'desc')
+            ->get();
+
         $data = [
             'customersByLocality' => $customersByLocality,
             'customersWithDebts' => $customersWithDebts,
@@ -75,9 +82,9 @@ class DashboardController extends Controller
             'paidDebtsExpiringSoon' => $this->getPaidDebtsExpiringSoon($authUser->locality_id),
         ];
 
-        return view('dashboard', compact('data', 'authUser', 'hasMailConfig'));
+        return view('dashboard', compact('data', 'authUser', 'hasMailConfig', 'notices'));
     }
-
+    
     public function getEarningsByLocality(Request $request)
     {
         $localityId = $request->input('locality_id');

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -204,6 +204,10 @@ class RolesAndPermissionsSeeder extends Seeder
             'description' => 'El cliente puede ver sus tomas de agua'
         ])->assignRole([$roleCliente]);
         Permission::firstOrCreate([
+            'name' => 'viewCustomerNotices',
+            'description' => 'Permite ver los avisos por localidad a los clientes.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
             'name' => 'viewInventory',
             'description' => 'Permite ver el Inventario.'
         ])->assignRole([$roleSupervisor]);

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -193,15 +193,15 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-md-6">
-                                <div class="card">
-                                    <div class="card-header">
-                                        <h3 class="card-title">Ingresos Anuales por Mes<span id="localityInfoAnnual"></h3>
-                                    </div>
-                                    <div class="card-body">
-                                        <canvas id="annualEarningsChart" width="400" height="200"></canvas>
-                                    </div>
+                    <div class="col-md-6">
+                            <div class="card">
+                                <div class="card-header">
+                                    <h3 class="card-title">Ingresos Anuales por Mes<span id="localityInfoAnnual"></h3>
                                 </div>
+                                <div class="card-body">
+                                    <canvas id="annualEarningsChart" width="400" height="200"></canvas>
+                                </div>
+                            </div>
                             </div>
                         </div>
                     @endcan

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -27,6 +27,56 @@
                             </div>
                         </div>
                     </div>
+                    @can ('viewCustomerNotices')
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <div class="card">
+                                    <div class="card-header bg-danger">
+                                        <h3 class="card-title mb-0">
+                                            <i class="fas fa-bullhorn mr-2"></i>Avisos de {{ $authUser->locality->name }}
+                                        </h3>
+                                    </div>
+                                    <div class="card-body">
+                                        @if($notices && $notices->count() > 0)
+                                            <div class="row">
+                                                @foreach($notices->take(3) as $notice)
+                                                    <div class="col-md-4 mb-3">
+                                                        <div class="card h-100 border-left-{{ $notice->is_active ? 'success' : 'secondary' }} border-left-3">
+                                                            <div class="card-body">
+                                                                <h5 class="card-title text-dark">{{ $notice->title }}</h5>
+                                                                <p class="card-text text-muted small">{{ Str::limit($notice->description, 100) }}</p>
+                                                                <div class="form-group mb-2">
+                                                                    @if ($notice->hasMedia('notice_attachments'))
+                                                                        <a href="{{ route('customer.notices.file', $notice->id) }}" class="btn btn-primary btn-sm" target="_blank">
+                                                                            <i class="fas fa-eye"></i> Ver archivo
+                                                                        </a>
+                                                                    @else
+                                                                        <button class="btn btn-secondary btn-sm" disabled>
+                                                                            <i class="fas fa-eye-slash"></i> Sin archivo adjunto
+                                                                        </button>
+                                                                    @endif
+                                                                </div>
+                                                                <div class="d-flex justify-content-between align-items-center">
+                                                                    <small class="text-muted">
+                                                                        <i class="far fa-calendar-alt mr-1"></i>Este anuncio expira el {{ $notice->end_date->format('d/m/Y') }}
+                                                                    </small>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        @else
+                                            <div class="text-center py-4">
+                                                <i class="fas fa-info-circle fa-2x text-muted mb-2"></i>
+                                                <p class="text-muted mb-0">No hay avisos disponibles para tu localidad</p>
+                                            </div>
+                                        @endif
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @endcan
                     @can('viewDashboardCards')
                         @if ($data['noDebtsForCurrentMonth'])
                             <div class="alert alert-warning" role="alert">
@@ -132,30 +182,30 @@
                                 </select>
                             </div>
                         </div>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="card">
+                                    <div class="card-header">
+                                        <h3 class="card-title">Ingresos Mensuales<span id="localityInfoMonthly"></h3>
+                                    </div>
+                                    <div class="card-body">
+                                        <canvas id="earningsChart" width="400" height="200"></canvas>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="card">
+                                    <div class="card-header">
+                                        <h3 class="card-title">Ingresos Anuales por Mes<span id="localityInfoAnnual"></h3>
+                                    </div>
+                                    <div class="card-body">
+                                        <canvas id="annualEarningsChart" width="400" height="200"></canvas>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     @endcan
-
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="card">
-                                <div class="card-header">
-                                    <h3 class="card-title">Ingresos Mensuales<span id="localityInfoMonthly"></h3>
-                                </div>
-                                <div class="card-body">
-                                    <canvas id="earningsChart" width="400" height="200"></canvas>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="card">
-                                <div class="card-header">
-                                    <h3 class="card-title">Ingresos Anuales por Mes<span id="localityInfoAnnual"></h3>
-                                </div>
-                                <div class="card-body">
-                                    <canvas id="annualEarningsChart" width="400" height="200"></canvas>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    
                     @can('viewDashboardCards')
                     <div class="card">
                         <div class="card-header">

--- a/routes/web.php
+++ b/routes/web.php
@@ -178,6 +178,11 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('/api/localities/{localityId}/active-notices', [LocalityNoticeController::class, 'getActiveByLocality'])->name('localityNotices.active-by-locality');
         Route::get('localityNotices/{id}/download', [LocalityNoticeController::class, 'downloadAttachment'])->name('localityNotices.download');
     });
+
+    Route::group(['middleware' => ['can:viewCustomerNotices']], function (){
+        Route::get('customer/notices/{id}/file', [LocalityNoticeController::class, 'downloadAttachment'])->name('customer.notices.file');
+    });
+
 });
     Route::get('/expiredSubscriptions/expired', [TokenController::class, 'showExpired'])->name('expiredSubscriptions.expired');
     Route::post('/expiredSubscriptions/expired', [TokenController::class, 'validateNewToken'])->name('validatetoken');

--- a/routes/web.php
+++ b/routes/web.php
@@ -180,7 +180,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
     });
 
     Route::group(['middleware' => ['can:viewCustomerNotices']], function (){
-        Route::get('customer/notices/{id}/file', [LocalityNoticeController::class, 'downloadAttachment'])->name('customer.notices.file');
+    Route::get('customer/notices/{id}/file', [LocalityNoticeController::class, 'downloadAttachment'])->name('customer.notices.file');
     });
 
 });


### PR DESCRIPTION
Add a new section to the dashboard where customers can view local-specific announcements. Administrators can post important announcements, and customers will automatically see them on their main dashboard.