### PR TITLE
feat: add membership_id foreign key to localities table

### DIFF
--- a/database/migrations/2025_10_02_115732_add_membership_id_to_localities_table.php
+++ b/database/migrations/2025_10_02_115732_add_membership_id_to_localities_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMembershipIdToLocalitiesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('localities', function (Blueprint $table) {
+            if (!Schema::hasColumn('localities', 'membership_id')) {
+                $table->foreignId('membership_id')
+                    ->nullable()
+                    ->constrained('memberships')
+                    ->onDelete('set null');
+            }
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('localities', function (Blueprint $table) {
+            if (Schema::hasColumn('localities', 'membership_id')) {
+                $table->dropForeign(['membership_id']);
+                $table->dropColumn('membership_id');
+            }
+        });
+    }
+}


### PR DESCRIPTION
- Add membership_id column as nullable foreign key to localities table
- Implement safe migration with Schema::hasColumn checks
- Establish relationship with memberships table with onDelete set null
- Prepare for token duration calculation based on membership term_months