### PR TITLE
Adjustments in forms, buttons and date format

### DIFF
--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -71,8 +71,8 @@
                                     </div>
                                     <div class="col-lg-12">
                                         <div class="form-group">
-                                            <label for="email" class="form-label">Correo electrónico</label>
-                                            <input type="email" class="form-control" id="email" name="email" placeholder="Ingresa correo electronico" value="{{ old('email') }}" />
+                                            <label for="email" class="form-label">Correo electrónico(*)</label>
+                                            <input type="email" class="form-control" id="email" name="email" placeholder="Ingresa correo electronico" value="{{ old('email') }}" required />
                                         </div>
                                     </div>
                                     <div class="col-lg-4">
@@ -83,7 +83,7 @@
                                     </div>
                                     <div class="col-lg-4">
                                         <div class="form-group">
-                                            <label for="exterior_number" class="form-label">Número Exterior</label>
+                                            <label for="exterior_number" class="form-label">Número Exterior(*)</label>
                                             <input type="text" pattern=".*\S.*" class="form-control" id="exterior_number" name="exterior_number" placeholder="Ingresa número exterior" value="{{ old('exterior_number') }}" />
                                         </div>
                                     </div>

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -72,7 +72,7 @@
                                     <div class="col-lg-12">
                                         <div class="form-group">
                                             <label for="emailUpdate" class="form-label">Correo electrónico</label>
-                                            <input type="email" class="form-control" id="emailUpdate" name="emailUpdate"  value="{{ $customer->email }}">
+                                            <input type="email" class="form-control" id="emailUpdate" name="emailUpdate"  value="{{ $customer->email }}" readonly>
                                         </div>
                                     </div>
                                     <div class="col-lg-4">
@@ -83,7 +83,7 @@
                                     </div>
                                     <div class="col-lg-4">
                                         <div class="form-group">
-                                            <label for="exteriorNumberUpdate" class="form-label">Manzana</label>
+                                            <label for="exteriorNumberUpdate" class="form-label">Número Exterior(*)</label>
                                             <input type="text" class="form-control" name="exteriorNumberUpdate" id="exteriorNumberUpdate" value="{{ $customer->exterior_number }}" >
                                         </div>
                                     </div>

--- a/resources/views/inventory/index.blade.php
+++ b/resources/views/inventory/index.blade.php
@@ -23,14 +23,18 @@
                                         </div>
                                     </div>
                                 </form>
-                                <button class="btn btn-success flex-grow-1 flex-lg-grow-0 mt-2" data-toggle="modal" data-target="#createInventory" title="Registrar Componente">
-                                    <i class="fa fa-plus"></i>
-                                    <span class="d-none d-lg-inline">Registrar Componente</span>
-                                    <span class="d-inline d-lg-none">Nuevo Componente</span>
-                                </button>
-                                <a class="btn btn-secondary" target="_blank"href="{{ route('inventory.pdfInventory', ['search' => request()->query('search')]) }}" title="Generar Lista">
-                                    <i class="fas fa-file-pdf"></i> Generar Lista
-                                </a>
+                                <div class="d-flex flex-wrap justify-content-end gap-2 w-100 w-md-auto">
+                                    <button class="btn btn-success flex-grow-1 flex-md-grow-0 mr-1 mt-2" data-toggle="modal" data-target="#createInventory" title="Registrar Componente">
+                                        <i class="fa fa-plus"></i>
+                                        <span class="d-none d-md-inline">Registrar Componente</span>
+                                        <span class="d-inline d-md-none">Nuevo Componente</span>
+                                    </button>
+                                    <a class="btn btn-secondary flex-grow-1 flex-md-grow-0 ml-1 mt-2" target="_blank" 
+                                    href="{{ route('inventory.pdfInventory', ['search' => request()->query('search')]) }}" 
+                                    title="Generar Lista">
+                                        <i class="fas fa-file-pdf"></i> Generar Lista
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -105,7 +105,7 @@
                                                             | Deuda: ${{ number_format($payment->debt->amount, 2) }}
                                                         </td>
                                                         <td>
-                                                            {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('MMMM [/] YYYY')}}
+                                                            {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('DD [/] MMMM [/] YYYY HH:mm:ss')}}
                                                         </td>
                                                         <td>${{ number_format($payment->amount, 2) }}</td>
                                                         <td>


### PR DESCRIPTION
Includes the following improvements and fixes:

- Added the (*) indicator in required fields: Email (registration and update forms) and Exterior Number (registration and update forms).
- Email field was set as mandatory in registration and made readonly in editing.
- Corrected the label "Manzana" to "Número Exterior (*)" in the update form.
- Refactored the buttons section in the Inventory module: "Register Component" and "Generate List" are now grouped in the same container with better alignment.
- Updated the date format in payments to display day, month, year, and full time.