### PR TITLE
feat: Automate token start date and integrate membership plans

### DIFF
--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -3,14 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Models\Locality;
-use Illuminate\Http\Request;
+use App\Models\Membership;
 use App\Models\Token;
 use App\Models\MailConfiguration;
+use Illuminate\Http\Request; 
 use Illuminate\Support\Facades\Crypt;
 
 class LocalityController extends Controller
 {
-
     public function index(Request $request)
     {
         $query = Locality::query()->orderBy('created_at', 'desc');
@@ -21,7 +21,7 @@ class LocalityController extends Controller
         }
 
         $localities = $query->paginate(10);
-        $memberships = \App\Models\Membership::all();
+        $memberships = Membership::all();
 
         $mailExamples = [
             'mailer'  => MailConfiguration::EXAMPLE_MAILER,
@@ -33,7 +33,7 @@ class LocalityController extends Controller
             'from_name'  => MailConfiguration::EXAMPLE_FROM_NAME,
         ];
 
-        return view('localities.index', compact('localities','mailExamples', 'memberships')); // Agregar memberships aquí
+        return view('localities.index', compact('localities','mailExamples', 'memberships'));
     }
 
     public function store(Request $request)
@@ -101,7 +101,7 @@ class LocalityController extends Controller
         $startDate = $request->input('startDate');
         $membershipId = $request->input('membership_id');
 
-        $membership = \App\Models\Membership::find($membershipId);
+        $membership = Membership::find($membershipId);
         $endDate = \Carbon\Carbon::parse($startDate)->addMonths($membership->term_months);
 
         $token = Token::generateTokenForLocality($id, $startDate, $endDate->toDateString());

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -21,6 +21,7 @@ class LocalityController extends Controller
         }
 
         $localities = $query->paginate(10);
+        $memberships = \App\Models\Membership::all();
 
         $mailExamples = [
             'mailer'  => MailConfiguration::EXAMPLE_MAILER,
@@ -31,8 +32,8 @@ class LocalityController extends Controller
             'encryption'  => MailConfiguration::EXAMPLE_ENCRYPTION,
             'from_name'  => MailConfiguration::EXAMPLE_FROM_NAME,
         ];
-        
-        return view('localities.index', compact('localities','mailExamples'));
+
+        return view('localities.index', compact('localities','mailExamples', 'memberships')); // Agregar memberships aquí
     }
 
     public function store(Request $request)
@@ -93,14 +94,17 @@ class LocalityController extends Controller
     {
         $request->validate([
             'startDate' => 'required|date',
-            'endDate' => 'required|date|after_or_equal:startDate',
+            'membership_id' => 'required|exists:memberships,id',
         ]);
 
         $id = $request->input('idLocality');
         $startDate = $request->input('startDate');
-        $endDate = $request->input('endDate');
-      
-        $token = Token::generateTokenForLocality($id, $startDate, $endDate);
+        $membershipId = $request->input('membership_id');
+
+        $membership = \App\Models\Membership::find($membershipId);
+        $endDate = \Carbon\Carbon::parse($startDate)->addMonths($membership->term_months);
+
+        $token = Token::generateTokenForLocality($id, $startDate, $endDate->toDateString());
 
         $locality = Locality::find($id);
 

--- a/resources/views/localities/tokenModal.blade.php
+++ b/resources/views/localities/tokenModal.blade.php
@@ -13,11 +13,18 @@
                 <div class="modal-body">
                     <div class="form-group">
                         <label>Fecha de Inicio</label>
-                        <input type="date" name="startDate" class="form-control" required>
+                        <input type="date" name="startDate" class="form-control" value="{{ date('Y-m-d') }}" required readonly>
                     </div>
                     <div class="form-group">
-                        <label>Fecha de Término</label>
-                        <input type="date" name="endDate" class="form-control" required>
+                        <label>Plan de Membresía</label>
+                        <select name="membership_id" class="form-control" required>
+                            <option value="">Seleccionar plan</option>
+                            @foreach($memberships as $membership)
+                                <option value="{{ $membership->id }}">
+                                    {{ $membership->name }} - {{ $membership->term_months }} meses
+                                </option>
+                            @endforeach
+                        </select>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\ExpiredSubscriptionController;
 use App\Http\Controllers\LocalityNoticeController;
 use App\Http\Controllers\TokenController;
 use App\Http\Middleware\CheckSubscription;
+use App\Http\Controllers\MembershipController;
 
 /*
 |--------------------------------------------------------------------------
@@ -171,7 +172,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('/faultReport', [FaultReportController::class, 'index'])->name('faultReport.index');
         Route::resource('faultReport', FaultReportController::class);
     });
-  
+
     Route::group(['middleware' => ['can:viewNotice']], function () {
         Route::get('/localityNotices', [LocalityNoticeController::class, 'index'])->name('localityNotices.index');
         Route::resource('localityNotices', LocalityNoticeController::class);
@@ -184,6 +185,9 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
     Route::get('customer/notices/{id}/file', [LocalityNoticeController::class, 'downloadAttachment'])->name('customer.notices.file');
     });
 
+    Route::group(['middleware' => ['can:viewMemberships']], function () {
+        Route::resource('memberships', MembershipController::class);
+    });
 });
     Route::get('/expiredSubscriptions/expired', [TokenController::class, 'showExpired'])->name('expiredSubscriptions.expired');
     Route::post('/expiredSubscriptions/expired', [TokenController::class, 'validateNewToken'])->name('validatetoken');


### PR DESCRIPTION
- Set the default start date to the current date in token generation mode
- Add a membership selection dropdown, replacing the manual end date
- Automatically calculate the end date based on the selected membership term_months
- Pass membership data to the location index view
- Update the generateToken method to handle membership_id and automatically calculate the end date
- Remove the manual end date from the token generation form
- Fix the 404 error on the membership page by placing the path in the web.php file