### PR TITLE
feat: add water connections and users limits to memberships

### DIFF
--- a/database/migrations/2025_10_07_190738_add_water_connections_and_users_limits_to_memberships_table.php
+++ b/database/migrations/2025_10_07_190738_add_water_connections_and_users_limits_to_memberships_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWaterConnectionsAndUsersLimitsToMembershipsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('memberships', function (Blueprint $table) {
+            $table->integer('water_connections_number')->default(0)->after('term_months');
+            $table->integer('users_number')->default(0)->after('water_connections_number');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('memberships', function (Blueprint $table) {
+            $table->dropColumn(['water_connections_number', 'users_number']);
+        });
+    }
+}

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -8,11 +8,6 @@ use App\Models\User;
 
 class MembershipsTableSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
         $admin = User::whereHas('roles', function($q) {
@@ -28,16 +23,22 @@ class MembershipsTableSeeder extends Seeder
                 'name' => 'Basic Plan - 3 Months',
                 'price' => 299.00,
                 'term_months' => 3,
+                'water_connections_number' => 1000,
+                'users_number' => 1,
             ],
             [
                 'name' => 'Premium Plan - 6 Months', 
                 'price' => 499.00,
                 'term_months' => 6,
+                'water_connections_number' => 4000,
+                'users_number' => 3,
             ],
             [
                 'name' => 'Enterprise Plan - 12 Months',
                 'price' => 899.00,
                 'term_months' => 12,
+                'water_connections_number' => 10000,
+                'users_number' => 5,
             ]
         ];
 
@@ -46,6 +47,8 @@ class MembershipsTableSeeder extends Seeder
                 'name' => $membership['name'],
                 'price' => $membership['price'],
                 'term_months' => $membership['term_months'],
+                'water_connections_number' => $membership['water_connections_number'],
+                'users_number' => $membership['users_number'],
                 'created_by' => $admin->id,
                 'created_at' => now(),
                 'updated_at' => now(),


### PR DESCRIPTION
- Add water_connections_number and users_number columns to memberships table
- Set specific limits for each membership plan:
  - Basic: 1,000 water connections and 1 users
  - Premium: 4,000 water connections and 3 users
  - Enterprise: 10,000 water connections and 5 users