### PR TITLE
Fix: Updated cash closure report button color, route, and added to reports list

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -161,9 +161,11 @@
                                             data-target="#weeklyGains" title="Ganancias Semanales">
                                                 <i class="fa fa-dollar-sign"></i> Ganancias Semanales
                                             </button>
-                                            <button type="button" class="btn btn-info w-100 w-md-auto m-1" title="Corte de caja"
-                                            onclick="window.open('{{ route('cash-closures.generate.latest') }}', '_blank', 'noopener,noreferrer')">
-                                            <i class="fa fa-dollar-sign"></i> Corte de caja
+                                            <button type="button" class="btn w-100 w-md-auto m-1" 
+                                            style="background-color: #ff7f00; color: white; border: none;" title="Corte de caja"
+                                            onclick="window.open('{{ route('cash-closures.report') }}', '_blank', 'noopener,noreferrer')">
+                                                <i class="fa fa-dollar-sign"></i> Corte de caja
+                                            </button>
                                             </button>
                                         </div>
                                     </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -161,9 +161,9 @@
                                             data-target="#weeklyGains" title="Ganancias Semanales">
                                                 <i class="fa fa-dollar-sign"></i> Ganancias Semanales
                                             </button>
-                                            <button type="button" class="btn w-100 w-md-auto m-1" 
-                                            style="background-color: #ff7f00; color: white; border: none;" title="Corte de caja"
-                                            onclick="window.open('{{ route('cash-closures.report') }}', '_blank', 'noopener,noreferrer')">
+                                            <button type="button" class="btn bg-orange w-100 w-md-auto m-1" 
+                                            style="color: white !important;" title="Corte de caja"
+                                            onclick="window.open('{{ route('cash-closures.report') }}', '_blank')">
                                                 <i class="fa fa-dollar-sign"></i> Corte de caja
                                             </button>
                                             </button>

--- a/resources/views/reportList/index.blade.php
+++ b/resources/views/reportList/index.blade.php
@@ -93,7 +93,7 @@
                                                             <button type="button" class="btn bg-olive report-btn" data-toggle="modal" data-target="#weeklyGains" title="Ganancias Semanales">
                                                                 <i class="fa fa-dollar-sign"></i> <span class="d-none d-md-inline">Ganancias Semanales</span><span class="d-inline d-md-none">Ganancias Semanales</span>
                                                             <button type="button" class="btn report-btn btn-orange" title="Corte de caja"
-                                                            onclick="window.open('{{ route('cash-closures.report') }}', '_blank', 'noopener,noreferrer')">
+                                                            onclick="window.open('{{ route('cash-closures.report') }}', '_blank')">
                                                                 <i class="fa fa-dollar-sign"></i> <span class="d-none d-md-inline">Corte de caja</span><span class="d-inline d-md-none">Corte</span>
                                                             </button>
                                                             </button>

--- a/resources/views/reportList/index.blade.php
+++ b/resources/views/reportList/index.blade.php
@@ -92,6 +92,10 @@
                                                             </button>
                                                             <button type="button" class="btn bg-olive report-btn" data-toggle="modal" data-target="#weeklyGains" title="Ganancias Semanales">
                                                                 <i class="fa fa-dollar-sign"></i> <span class="d-none d-md-inline">Ganancias Semanales</span><span class="d-inline d-md-none">Ganancias Semanales</span>
+                                                            <button type="button" class="btn report-btn btn-orange" title="Corte de caja"
+                                                            onclick="window.open('{{ route('cash-closures.report') }}', '_blank', 'noopener,noreferrer')">
+                                                                <i class="fa fa-dollar-sign"></i> <span class="d-none d-md-inline">Corte de caja</span><span class="d-inline d-md-none">Corte</span>
+                                                            </button>
                                                             </button>
                                                         </div>
                                                     </div>
@@ -179,6 +183,8 @@
     .btn.bg-teal { background-color: #20c997; color: #fff !important; }
     .btn.btn-success { background-color: #28a745; color: #fff !important; }
     .btn.bg-olive { background-color: #3d9970; color: #fff !important; }
+    .btn-orange {background-color: #ff7f00; color: white !important; border: none; }
+    .btn-orange:hover {background-color: #e67300; color: white !important; }
     table.dataTable thead th {
         position: relative;
         cursor: pointer;

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,9 +189,9 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('localityNotices/{id}/download', [LocalityNoticeController::class, 'downloadAttachment'])->name('localityNotices.download');
     });
     
-    Route::get('/cash-closures/generate-latest', [PaymentController::class, 'cashClosurePaymentsReport'])
-    ->name('cash-closures.generate.latest');
-
+    Route::get('/cash-closures-report', [PaymentController::class, 'cashClosurePaymentsReport'])
+    ->name('cash-closures.report');
+    
     Route::group(['middleware' => ['can:viewCustomerNotices']], function (){
     Route::get('customer/notices/{id}/file', [LocalityNoticeController::class, 'downloadAttachment'])->name('customer.notices.file');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -191,7 +191,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
     
     Route::get('/cash-closures-report', [PaymentController::class, 'cashClosurePaymentsReport'])
     ->name('cash-closures.report');
-    
+
     Route::group(['middleware' => ['can:viewCustomerNotices']], function (){
     Route::get('customer/notices/{id}/file', [LocalityNoticeController::class, 'downloadAttachment'])->name('customer.notices.file');
     });


### PR DESCRIPTION
This pull request includes the following improvements:

- Changed the cash closure button color from Bootstrap’s default blue (btn-info) to a custom orange style for better visual consistency.
- Updated the route URL from /cash-closures/generate-latest to /cash-closures-report for cleaner and more intuitive access.
- Added the cash closure button to the reports list
