### PR TITLE
Add sections table migration and seeder with 5 fixed sections

### DIFF
--- a/app/Models/Section.php
+++ b/app/Models/Section.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Section extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'locality_id',
+        'created_by',
+        'name',
+        'zip_code',
+        'color',
+    ];
+
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
+}

--- a/database/migrations/2025_10_13_101537_create_sections_table.php
+++ b/database/migrations/2025_10_13_101537_create_sections_table.php
@@ -20,9 +20,11 @@ class CreateSectionsTable extends Migration
             $table->string('name', 100); 
             $table->string('zip_code', 5);
             $table->string('color', 20);
+            $table->timestamps();
 
             $table->foreign('locality_id')->references('id')->on('localities');
             $table->foreign('created_by')->references('id')->on('users');
+
         });
     }
 

--- a/database/migrations/2025_10_13_101537_create_sections_table.php
+++ b/database/migrations/2025_10_13_101537_create_sections_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSectionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sections', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('locality_id'); 
+            $table->unsignedBigInteger('created_by');
+            $table->string('name', 100); 
+            $table->string('zip_code', 5);
+            $table->string('color', 20);
+
+            $table->foreign('locality_id')->references('id')->on('localities');
+            $table->foreign('created_by')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sections');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,5 +34,6 @@ class DatabaseSeeder extends Seeder
         $this->call(FaultReportSeeder::class);
         $this->call(InventoryTableSeeder::class);
         $this->call(MembershipsTableSeeder::class);
+        $this->call(SectionsSeeder::class);
     }
 }

--- a/database/seeders/SectionsSeeder.php
+++ b/database/seeders/SectionsSeeder.php
@@ -4,62 +4,31 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Section;
+use App\Models\Locality;
 
-class SectionsTableSeeder extends Seeder
+class SectionsSeeder extends Seeder
 {
     public function run()
     {
-        $sections = [
-            [
-                'locality_id' => 1,
-                'created_by' => 1,
-                'name' => 'Sección A',
-                'zip_code' => '55001',
-                'color' => 'indigo',
-            ],
-            [
-                'locality_id' => 1,
-                'created_by' => 1,
-                'name' => 'Sección B',
-                'zip_code' => '55002',
-                'color' => 'light-blue',
-            ],
-            [
-                'locality_id' => 2,
-                'created_by' => 1,
-                'name' => 'Zona Sur',
-                'zip_code' => '55003',
-                'color' => 'navy',
-            ],
-            [
-                'locality_id' => 3,
-                'created_by' => 1,
-                'name' => 'Zona Centro',
-                'zip_code' => '55004',
-                'color' => 'lime',
-            ],
-            [
-                'locality_id' => 4,
-                'created_by' => 1,
-                'name' => 'Zona Norte',
-                'zip_code' => '55005',
-                'color' => 'teal',
-            ],
-        ];
+        $colors = ['purple', 'light-blue', 'orange', 'lime', 'navy', 'olive', 'secondary'];
 
-        foreach ($sections as $section) {
-            Section::updateOrCreate(
-                [
-                    'locality_id' => $section['locality_id'],
-                    'name' => $section['name'],
-                ],
-                [
-                    'created_by' => $section['created_by'],
-                    'zip_code' => $section['zip_code'],
-                    'color' => $section['color'],
-                    'updated_at' => now(),
-                ]
-            );
+        $localities = Locality::all(); 
+
+        foreach ($localities as $locality) {
+            for ($i = 1; $i <= 4; $i++) {
+                Section::updateOrCreate(
+                    [
+                        'locality_id' => $locality->id,
+                        'name' => 'Sección ' . $i . ' - Localidad ' . $locality->id,
+                    ],
+                    [
+                        'created_by' => 1,
+                        'zip_code' => str_pad(55000 + ($locality->id * 10) + $i, 5, '0', STR_PAD_LEFT),
+                        'color' => $colors[$i % count($colors)],
+                        'updated_at' => now(),
+                    ]
+                );
+            }
         }
     }
 }

--- a/database/seeders/SectionsSeeder.php
+++ b/database/seeders/SectionsSeeder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Section;
+
+class SectionsTableSeeder extends Seeder
+{
+    public function run()
+    {
+        $sections = [
+            [
+                'locality_id' => 1,
+                'created_by' => 1,
+                'name' => 'Sección A',
+                'zip_code' => '55001',
+                'color' => 'indigo',
+            ],
+            [
+                'locality_id' => 1,
+                'created_by' => 1,
+                'name' => 'Sección B',
+                'zip_code' => '55002',
+                'color' => 'light-blue',
+            ],
+            [
+                'locality_id' => 2,
+                'created_by' => 1,
+                'name' => 'Zona Sur',
+                'zip_code' => '55003',
+                'color' => 'navy',
+            ],
+            [
+                'locality_id' => 3,
+                'created_by' => 1,
+                'name' => 'Zona Centro',
+                'zip_code' => '55004',
+                'color' => 'lime',
+            ],
+            [
+                'locality_id' => 4,
+                'created_by' => 1,
+                'name' => 'Zona Norte',
+                'zip_code' => '55005',
+                'color' => 'teal',
+            ],
+        ];
+
+        foreach ($sections as $section) {
+            Section::updateOrCreate(
+                [
+                    'locality_id' => $section['locality_id'],
+                    'name' => $section['name'],
+                ],
+                [
+                    'created_by' => $section['created_by'],
+                    'zip_code' => $section['zip_code'],
+                    'color' => $section['color'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new module for managing "Sections" in the system.

Changes included:
- Created the `sections` table migration with the following fields:
- `locality_id` (foreign key to localities)
- `created_by` (foreign key to users)
- `name`
- `zip_code`
- `color` (for UI display)
- Added `SectionsTableSeeder` to create 5 fixed sections with vibrant colors.

These changes will allow the system to categorize addresses by sections 