### PR TITLE
Custom backgrounds in reports by location, in both vertical and horizontal

### DIFF
--- a/app/Http/Controllers/InventoryController.php
+++ b/app/Http/Controllers/InventoryController.php
@@ -118,6 +118,7 @@ class InventoryController extends Controller
 
     public function generateInventoryPdf(Request $request)
     {
+        set_time_limit(300);
         $authUser = Auth::user();
         $query = Inventory::where('locality_id', $authUser->locality_id);
         if ($request->has('search')) {

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -108,4 +108,25 @@ class LocalityController extends Controller
             ->with('createdToken', $token)
             ->with('localityName', $locality->name);
     }
+
+    public function updatePdfBackground(Request $request, $id)
+    {
+        $locality = Locality::find($id);
+
+        if (!$locality) {
+            return redirect()->back()->with('error', 'Localidad no encontrada.');
+        }
+
+        if ($request->hasFile('pdf_background_vertical')) {
+            $locality->clearMediaCollection('pdfBackgroundVertical');
+            $locality->addMediaFromRequest('pdf_background_vertical')->toMediaCollection('pdfBackgroundVertical');
+        }
+
+        if ($request->hasFile('pdf_background_horizontal')) {
+            $locality->clearMediaCollection('pdfBackgroundHorizontal');
+            $locality->addMediaFromRequest('pdf_background_horizontal')->toMediaCollection('pdfBackgroundHorizontal');
+        }
+
+        return redirect()->route('localities.index')->with('success', 'Fondos de reportes actualizados correctamente.');
+    }
 }

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -65,4 +65,17 @@ class Locality extends Model implements HasMedia
 
         return $today->lte($endDate) ? self::SUBSCRIPTION_ACTIVE : self::SUBSCRIPTION_EXPIRED;
     }
+
+    public function registerMediaCollections(): void
+    {
+        $this
+            ->addMediaCollection('pdfBackgroundVertical')
+            ->useDisk('public')
+            ->singleFile();
+
+        $this
+            ->addMediaCollection('pdfBackgroundHorizontal')
+            ->useDisk('public')
+            ->singleFile();
+    }
 }

--- a/resources/views/localities/editPdfBackground.blade.php
+++ b/resources/views/localities/editPdfBackground.blade.php
@@ -1,0 +1,79 @@
+<div class="modal fade" id="editPdfBackground{{ $locality->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-navy">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Editar Fondos de Reportes <small> &nbsp;</small></h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    </div>
+                </div>
+                <form action="{{ route('localities.updatePdfBackground', $locality->id) }}" enctype="multipart/form-data" method="POST" id="edit-locality-form-{{ $locality->id }}">
+                    @csrf
+                    @method('POST')
+                    <div class="card-body">
+                        <div class="card mb-3">
+                            <div class="card-header py-2 bg-secondary">
+                                <h3 class="card-title">Fondo Reporte Vertical</h3><br>
+                                <small class="text-light">Formato sugerido</small>
+                            </div>
+                            <div class="card-body text-center">
+                                <img id="preview-vertical-{{ $locality->id }}"
+                                    src="{{ $locality->getFirstMediaUrl('pdfBackgroundVertical') ?: asset('img/backgroundReport.png') }}"
+                                    alt="Fondo Vertical" style="width: 200px; height: 280px; border-radius: 10px; margin-bottom: 10px;">
+                                <input type="file" accept="image/*" name="pdf_background_vertical"
+                                    class="form-control" onchange="previewImageEdit(event, 'vertical', {{ $locality->id }})">
+                            </div>
+                        </div>
+                        <div class="card">
+                            <div class="card-header py-2 bg-secondary">
+                                <h3 class="card-title">Fondo Reporte Horizontal </h3><br>
+                                <small class="text-light">Formato sugerido</small>
+                            </div>
+                            <div class="card-body text-center">
+                                <img id="preview-horizontal-{{ $locality->id }}"
+                                    src="{{ $locality->getFirstMediaUrl('pdfBackgroundHorizontal') ?: asset('img/customersBackground.png') }}"
+                                    alt="Fondo Horizontal" style="width: 280px; height: 200px; border-radius: 10px; margin-bottom: 10px;">
+                                <input type="file" accept="image/*" name="pdf_background_horizontal"
+                                    class="form-control" onchange="previewImageEdit(event, 'horizontal', {{ $locality->id }})">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="resetForm({{ $locality->id }})">Cancelar</button>
+                        <button type="submit" class="btn bg-navy">Actualizar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+function previewImageEdit(event, type, id) {
+    var input = event.target;
+    var file = input.files[0];
+    var reader = new FileReader();
+
+    if (!file.type.startsWith('image/')) {
+        Swal.fire({
+            icon: 'error',
+            title: 'Error',
+            text: 'Por favor, sube un archivo de imagen',
+            confirmButtonText: 'Aceptar'
+        });
+        input.value = '';
+        return;
+    }
+
+    reader.onload = function() {
+        document.getElementById('preview-' + type + '-' + id).src = reader.result;
+    };
+    reader.readAsDataURL(file);
+}
+
+function resetForm(id) {
+    document.getElementById('edit-locality-form-' + id).reset();
+    document.getElementById('preview-vertical-' + id).src = "{{ asset('img/backgroundReport.png') }}";
+    document.getElementById('preview-horizontal-' + id).src = "{{ asset('img/customersBackground.png') }}";
+}
+</script>

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -100,6 +100,9 @@
                                                     <button type="button" class="btn bg-purple mr-2" data-toggle="modal"  title="Configurar correo" data-target="#mailConfigModal{{$locality->id}}">
                                                         <i class="fas fa-envelope"></i>
                                                     </button>
+                                                    <button type="button" class="btn bg-navy mr-2" data-toggle="modal" title="Fondo de reporte" data-target="#editPdfBackground{{$locality->id}}">
+                                                            <i class="fas fa-fill-drip"></i>
+                                                    </button>
                                                     @can('deleteLocality')
                                                         @if($locality->hasDependencies())
                                                             <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
@@ -126,6 +129,7 @@
                                             @include('localities.show')
                                             @include('localities.editLogo')
                                             @include('localities.mailConfiguration')
+                                            @include('localities.editPdfBackground')
                                             @include('localities.tokenModal')
                                         </tr>
                                         @endforeach

--- a/resources/views/reports/advancePaymentsHistory.blade.php
+++ b/resources/views/reports/advancePaymentsHistory.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -9,10 +19,13 @@
                 margin: 0; padding: 0;
             }
             body {
-                background-image: url('{{ public_path("img/backgroundReport.png") }}');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;
+                height: 100%;
+                margin: 0;
+                padding: 0;
             }
             #pagePdf {
                 margin: 30px;

--- a/resources/views/reports/advancedPayments.blade.php
+++ b/resources/views/reports/advancedPayments.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
 
@@ -13,7 +23,7 @@
         }
 
         body {
-            background-image: url('img/backgroundReport.png');
+            background-image: url('file://{{ $verticalBgPath }}');
             background-size: cover;
             background-position: center;
             background-repeat: no-repeat;

--- a/resources/views/reports/annualEarnings.blade.php
+++ b/resources/views/reports/annualEarnings.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/annualExpenses.blade.php
+++ b/resources/views/reports/annualExpenses.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/annualGains.blade.php
+++ b/resources/views/reports/annualGains.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/clientPayments.blade.php
+++ b/resources/views/reports/clientPayments.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -12,7 +22,7 @@
             }
 
             body{
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/customersWithDebts.blade.php
+++ b/resources/views/reports/customersWithDebts.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/customersBackground.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/generateCostListReport.blade.php
+++ b/resources/views/reports/generateCostListReport.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/customersBackground.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/generateEmployeeListReport.blade.php
+++ b/resources/views/reports/generateEmployeeListReport.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html>
     <head>
@@ -12,7 +22,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/customersBackgroundHorizontal.png');
+                background-image: url('file://{{ $horizontalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/generateIncidentCategoyListReport.blade.php
+++ b/resources/views/reports/generateIncidentCategoyListReport.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -18,7 +28,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/generateIncidentListReport.blade.php
+++ b/resources/views/reports/generateIncidentListReport.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -18,7 +28,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/generateIncidentStatusListReport.blade.php
+++ b/resources/views/reports/generateIncidentStatusListReport.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -18,7 +28,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/paymentHistoryReport.blade.php
+++ b/resources/views/reports/paymentHistoryReport.blade.php
@@ -1,5 +1,13 @@
 @php
     use Carbon\Carbon;
+    $locality = Auth::user()->locality ?? null;
+    $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+        ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+        : public_path('img/backgroundReport.png');
+
+    $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+        ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+        : public_path('img/customersBackground.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">
@@ -11,7 +19,7 @@
             }
 
             body{
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/pdfCashClosures.blade.php
+++ b/resources/views/reports/pdfCashClosures.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -14,7 +24,7 @@
             height: 100%;
             margin: 0;
             padding: 0;
-            background-image: url('img/backgroundReport.png');
+            background-image: url('file://{{ $verticalBgPath }}');
             background-size: cover;
             background-position: center;
             background-repeat: no-repeat;

--- a/resources/views/reports/pdfCustomers.blade.php
+++ b/resources/views/reports/pdfCustomers.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html>
     <head>
@@ -12,7 +22,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/customersBackgroundHorizontal.png');
+                background-image: url('file://{{ $horizontalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/pdfCustomersSummary.blade.php
+++ b/resources/views/reports/pdfCustomersSummary.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html>
     <head>
@@ -16,7 +26,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/pdfInventory.blade.php
+++ b/resources/views/reports/pdfInventory.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -14,7 +24,7 @@
             height: 100%;
             margin: 0;
             padding: 0;
-            background-image: url('img/customersBackground.png');
+            background-image: url('file://{{ $verticalBgPath }}');
             background-size: cover;
             background-position: center;
             background-repeat: no-repeat;

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -13,7 +23,7 @@
         body {
             margin: 0;
             padding: 0;
-            background-image: url('img/receiptBackground.jpg');
+            background-image: url('file://{{ $verticalBgPath }}');
             background-size: cover;
             background-position: center;
             background-repeat: no-repeat;

--- a/resources/views/reports/reportCurrentCustomers.blade.php
+++ b/resources/views/reports/reportCurrentCustomers.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/customersBackground.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/waterConnectionPayments.blade.php
+++ b/resources/views/reports/waterConnectionPayments.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -12,7 +22,7 @@
             }
 
             body{
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/weeklyEarnings.blade.php
+++ b/resources/views/reports/weeklyEarnings.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/weeklyExpenses.blade.php
+++ b/resources/views/reports/weeklyExpenses.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/resources/views/reports/weeklyGains.blade.php
+++ b/resources/views/reports/weeklyGains.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackground.png');
+@endphp
 <!DOCTYPE html>
 <html lang="es">
     <head>
@@ -14,7 +24,7 @@
                 height: 100%;
                 margin: 0;
                 padding: 0;
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,6 +115,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('/locality-earnings', [DashboardController::class, 'getEarningsByLocality'])->name('locality.earnings');
         Route::put('/localities/{locality}/mailConfiguration',[MailConfigurationController::class, 'createOrUpdateMailConfigurations'])->name('mailConfigurations.createOrUpdate');
         Route::post('/localities/generateTeoken', [LocalityController::class, 'generateToken'])->name('localities.generateToken');
+        Route::post('/localities/{locality}/update-pdf-background', [LocalityController::class, 'updatePdfBackground'])->name('localities.updatePdfBackground');
     });
 
     Route::group(['middleware' => ['can:viewWaterConnection']], function () {


### PR DESCRIPTION
#  Add Support for Custom PDF Report Backgrounds per Locality

## Description
This feature allows each locality to have custom backgrounds for PDF reports, both in vertical and horizontal orientation. If no custom background is provided, default backgrounds will be used.

### Key Changes
- Added the `updatePdfBackground` method in `LocalityController` to allow uploading and updating report backgrounds.
- Registered new media collections in the `Locality` model: `pdfBackgroundVertical` and `pdfBackgroundHorizontal`.
- Updated report views to use custom backgrounds when available; otherwise, default backgrounds are used.
- Added a button in the localities list to open the report background configuration modal.
- Created a new route `localities.updatePdfBackground` to handle background updates.

### Benefits
Enables generated reports to reflect the visual identity of each locality, improving personalization and visual consistency in PDF documents.
