### PR TITLE
Modify the Payment Controller so that the information obtained from t…

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -67,7 +67,6 @@ class PaymentController extends Controller
         return view('payments.index', compact('payments', 'customers'));
     }
 
-    // Los demás métodos permanecen exactamente igual...
     public function getWaterConnectionsByCustomer(Request $request)
     {
         $authUser = auth()->user();
@@ -196,8 +195,8 @@ class PaymentController extends Controller
     $authUser = auth()->user();
     $year = intval($year);
 
-    $monthlyEarnings = [];
-    $totalEarnings = 0;
+        $monthlyEarnings = [];
+        $totalEarnings = 0;
 
         for ($month = 1; $month <= 12; $month++) {
             $earnings = Payment::whereYear('created_at', $year)
@@ -209,16 +208,15 @@ class PaymentController extends Controller
             $totalEarnings += $earnings;
         }
 
-    // Cargar la relación con el usuario para usar name y last_name desde users
     $payments = Payment::with(['debt.customer.user'])
         ->whereYear('created_at', $year)
         ->where('locality_id', $authUser->locality_id)
         ->get();
 
-    $pdf = PDF::loadView('reports.annualEarnings', compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser', 'payments'))
+        $pdf = PDF::loadView('reports.annualEarnings', compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser', 'payments'))
         ->setPaper('A4', 'portrait');
 
-    return $pdf->stream('annual_earnings_' . $year . '.pdf');
+        return $pdf->stream('annual_earnings_' . $year . '.pdf');
     }
 
     public function weeklyEarningsReport(Request $request)

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -192,8 +192,8 @@ class PaymentController extends Controller
 
     public function annualEarningsReport($year)
     {
-    $authUser = auth()->user();
-    $year = intval($year);
+        $authUser = auth()->user();
+        $year = intval($year);
 
         $monthlyEarnings = [];
         $totalEarnings = 0;
@@ -208,10 +208,10 @@ class PaymentController extends Controller
             $totalEarnings += $earnings;
         }
 
-    $payments = Payment::with(['debt.customer.user'])
-        ->whereYear('created_at', $year)
-        ->where('locality_id', $authUser->locality_id)
-        ->get();
+        $payments = Payment::with(['debt.customer.user'])
+            ->whereYear('created_at', $year)
+            ->where('locality_id', $authUser->locality_id)
+            ->get();
 
         $pdf = PDF::loadView('reports.annualEarnings', compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser', 'payments'))
         ->setPaper('A4', 'portrait');

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Payment;
 use App\Models\Debt;
 use App\Models\Customer;
+use App\Models\User;
 use App\Models\WaterConnection;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Crypt;
@@ -16,13 +17,13 @@ class PaymentController extends Controller
     public function index(Request $request)
     {
         $authUser = auth()->user();
-        $query = Payment::with('debt.customer')->orderBy('id', 'desc')
+        $query = Payment::with(['debt.customer.user'])->orderBy('id', 'desc')
             ->where('locality_id', $authUser->locality_id);
 
         if ($request->filled('name')) {
-            $query->whereHas('debt.customer', function ($q) use ($request) {
-            $q->whereRaw("CONCAT(customers.name, ' ', customers.last_name) LIKE ?", ['%' . $request->name . '%'])
-                ->orWhereRaw("CONCAT(customers.last_name, ' ', customers.name) LIKE ?", ['%' . $request->name . '%']);
+            $query->whereHas('debt.customer.user', function ($q) use ($request) {
+                $q->whereRaw("CONCAT(users.name, ' ', users.last_name) LIKE ?", ['%' . $request->name . '%'])
+                  ->orWhereRaw("CONCAT(users.last_name, ' ', users.name) LIKE ?", ['%' . $request->name . '%']);
             });
         }
 
@@ -61,11 +62,12 @@ class PaymentController extends Controller
         }
 
         $payments = $query->paginate(10);
-        $customers = Customer::where('locality_id', $authUser->locality_id)->get();
+        $customers = Customer::with('user')->where('locality_id', $authUser->locality_id)->get();
 
         return view('payments.index', compact('payments', 'customers'));
     }
 
+    // Los demás métodos permanecen exactamente igual...
     public function getWaterConnectionsByCustomer(Request $request)
     {
         $authUser = auth()->user();
@@ -191,11 +193,11 @@ class PaymentController extends Controller
 
     public function annualEarningsReport($year)
     {
-        $authUser = auth()->user();
-        $year = intval($year);
+    $authUser = auth()->user();
+    $year = intval($year);
 
-        $monthlyEarnings = [];
-        $totalEarnings = 0;
+    $monthlyEarnings = [];
+    $totalEarnings = 0;
 
         for ($month = 1; $month <= 12; $month++) {
             $earnings = Payment::whereYear('created_at', $year)
@@ -207,10 +209,16 @@ class PaymentController extends Controller
             $totalEarnings += $earnings;
         }
 
-        $pdf = PDF::loadView('reports.annualEarnings', compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser'))
-            ->setPaper('A4', 'portrait');
+    // Cargar la relación con el usuario para usar name y last_name desde users
+    $payments = Payment::with(['debt.customer.user'])
+        ->whereYear('created_at', $year)
+        ->where('locality_id', $authUser->locality_id)
+        ->get();
 
-        return $pdf->stream('annual_earnings_' . $year . '.pdf');
+    $pdf = PDF::loadView('reports.annualEarnings', compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser', 'payments'))
+        ->setPaper('A4', 'portrait');
+
+    return $pdf->stream('annual_earnings_' . $year . '.pdf');
     }
 
     public function weeklyEarningsReport(Request $request)
@@ -267,7 +275,7 @@ class PaymentController extends Controller
         $decryptedId = Crypt::decrypt($paymentId);
         $payment = Payment::findOrFail($decryptedId);
         $debt = $payment->debt;
-        $client = $debt->client;
+        $client = $debt->customer;
 
         $startDate = Carbon::parse($debt->start_date);
         $endDate = Carbon::parse($debt->end_date);
@@ -296,7 +304,6 @@ class PaymentController extends Controller
             $months[$monthName]['note'] = $payment->note;
         }
 
-      
         $note = $payment->note;
         $message = $numberOfMonths > 1
             ? "Monto total del pago $" . number_format($payment->amount, 2) . 
@@ -313,7 +320,7 @@ class PaymentController extends Controller
         $customerId = $request->input('customerId');
         $startDate = $request->input('startDate');
         $endDate = $request->input('endDate');
-        $customer = Customer::findOrFail($customerId);
+        $customer = Customer::with('user')->findOrFail($customerId);
         $authUser = auth()->user();
 
         $payments = Payment::whereHas('debt.waterConnection', function ($query) use ($customerId) {
@@ -337,7 +344,7 @@ class PaymentController extends Controller
         $startDate = $request->input('waterStartDate');
         $endDate = $request->input('waterEndDate');
 
-        $customer = Customer::findOrFail($customerId);
+        $customer = Customer::with('user')->findOrFail($customerId);
         $authUser = auth()->user();
 
         $waterConnection = WaterConnection::where('id', $waterConnectionId)

--- a/resources/views/payments/clientPayments.blade.php
+++ b/resources/views/payments/clientPayments.blade.php
@@ -15,7 +15,7 @@
                             <option value="">Selecciona un cliente</option>
                             @foreach($customers as $customer)
                                 <option value="{{ $customer->id }}">
-                                    {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}
+                                    {{ $customer->id }} - {{ $customer->user->name }} {{ $customer->user->last_name }}
                                 </option>
                             @endforeach
                         </select>

--- a/resources/views/payments/create.blade.php
+++ b/resources/views/payments/create.blade.php
@@ -39,7 +39,7 @@
                                                 <option value="">Selecciona un cliente</option>
                                                 @foreach($customers as $customer)
                                                     <option value="{{ $customer->id }}">
-                                                        {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}
+                                                        {{ $customer->id }} - {{ $customer->user->name }} {{ $customer->user->last_name }}
                                                     </option>
                                                 @endforeach
                                             </select>

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -98,7 +98,7 @@
                                                 @foreach($payments as $payment)
                                                     <tr>
                                                         <td>{{ $payment->id }}</td>
-                                                        <td>{{ $payment->debt->customer->name ?? 'Desconocido' }} {{ $payment->debt->customer->last_name ?? 'Desconocido' }}</td>
+                                                        <td>{{ $payment->debt->customer->user->name ?? 'Desconocido' }} {{ $payment->debt->customer->user->last_name ?? 'Desconocido' }}</td>
                                                         <td>
                                                             {{ \Carbon\Carbon::parse($payment->debt->start_date)->locale('es')->isoFormat('MMMM [/] YYYY')}} -
                                                             {{ \Carbon\Carbon::parse($payment->debt->end_date)->locale('es')->isoFormat('MMMM [/] YYYY') }}

--- a/resources/views/payments/waterConnectionPayments.blade.php
+++ b/resources/views/payments/waterConnectionPayments.blade.php
@@ -15,7 +15,7 @@
                             <option value="">Selecciona un cliente</option>
                             @foreach($customers as $customer)
                                 <option value="{{ $customer->id }}">
-                                    {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}
+                                    {{ $customer->id }} - {{ $customer->user->name }} {{ $customer->user->last_name }}
                                 </option>
                             @endforeach
                         </select>


### PR DESCRIPTION
 Refactor PaymentController to use user data associated with customers

 Description
This update refactors the payment controller and related views to use information from the User model associated with each Customer.It ensures that names and last names are correctly displayed using data from the User model instead of Customer.

 Main Changes

- Added the user relationship in payment queries:
Payment::with(['debt.customer.user'])
- Updated name filtering to use users.name and users.last_name.
- Adjusted the following methods to include the user relationship:
   -clientPaymentReport
   -waterConnectionPaymentsReport
   -annualEarningsReport
- Updated Blade views to display:
{{ $customer->user->name }} {{ $customer->user->last_name }}

Modified Files

- app/Http/Controllers/PaymentController.php
- resources/views/payments/index.blade.php
- resources/views/payments/create.blade.php
- resources/views/payments/clientPayments.blade.php
- resources/views/payments/waterConnectionPayments.blade.php

 Expected Result
All payment listings, reports, and searches now correctly display the user information linked to each customer, ensuring consistency across the system.