### PR TITLE
Add global default costs for all locations

### DIFF
--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -12,6 +12,7 @@ class CostController extends Controller
     {
         $authUser = auth()->user();
         $costs = Cost::where('locality_id', $authUser->locality_id)
+            ->orWhere('locality_id', 0)
             ->orderBy('created_at', 'desc')
             ->paginate(10);
         return view('costs.index', compact('costs'));
@@ -65,6 +66,7 @@ class CostController extends Controller
     {
         $authUser = auth()->user();
         $costs = cost::where('locality_id', $authUser->locality_id)
+                    ->orWhere('locality_id', 0)
                     ->orderBy('created_at', 'desc')
                     ->get();
         

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -13,7 +13,7 @@ class LocalityController extends Controller
 {
     public function index(Request $request)
     {
-        $query = Locality::query()->orderBy('created_at', 'desc');
+        $query = Locality::query()->where('id', '!=', 0)->orderBy('created_at', 'desc');
 
         if ($request->has('search')) {
             $search = $request->input('search');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -17,7 +17,7 @@ class UserController extends Controller
         
         $roles = Role::whereIn('name', ['Supervisor', 'Secretaria'])->get();
         
-        $localities = Locality::all();
+        $localities = Locality::where('id', '!=', 0)->get();
         $users = User::where('id', '!=', $currentUserId)->get();
         return view('users.index', compact('users', 'localities', 'roles'));
     }

--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -38,7 +38,9 @@ class WaterConnectionController extends Controller
 
         $connections = $query->paginate(10);
         $customers = Customer::where('locality_id', $authUser->locality_id)->get();
-        $costs = Cost::where('locality_id', $authUser->locality_id)->get();
+        $costs = Cost::where('locality_id', $authUser->locality_id)
+                     ->orWhere('locality_id', 0)
+                     ->get();
         $sections = Section::where('locality_id', $authUser->locality_id)->get();
 
         return view('waterConnections.index', compact('connections', 'customers', 'costs', 'sections'));

--- a/database/seeders/CostsTableSeeder.php
+++ b/database/seeders/CostsTableSeeder.php
@@ -9,6 +9,27 @@ class CostsTableSeeder extends Seeder
 {
     public function run()
     {
+        $defaultCost = [
+            'locality_id' => 0,
+            'created_by' => 1,
+            'category' => 'Por Defecto',
+            'price' => 130.00,
+            'description' => 'Tarifa por defecto para todas las localidades',
+        ];
+
+        Cost::updateOrCreate(
+            [
+                'locality_id' => 0,
+                'category' => $defaultCost['category'],
+            ],
+            [
+                'price' => $defaultCost['price'],
+                'description' => $defaultCost['description'],
+                'created_by' => $defaultCost['created_by'],
+                'updated_at' => now(),
+            ]
+        );
+
         $costs = [
             [
                 'locality_id' => 1,

--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -7,11 +7,34 @@ use Illuminate\Database\Seeder;
 use App\Models\Locality;
 use App\Models\Membership;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class LocalitiesTableSeeder extends Seeder
 {
     public function run()
     {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        DB::statement('SET SESSION sql_mode = "NO_AUTO_VALUE_ON_ZERO";');
+
+        DB::table('localities')->updateOrInsert(
+            ['id' => 0],
+            [
+                'name' => 'Global',
+                'municipality' => 'N/A',
+                'state' => 'N/A',
+                'zip_code' => '00000',
+                'membership_id' => null,
+                'token' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        DB::statement('SET SESSION sql_mode = "";');
+
         $memberships = Membership::all();
         
         if ($memberships->isEmpty()) {
@@ -80,6 +103,6 @@ class LocalitiesTableSeeder extends Seeder
             $endDate = Carbon::now()->subDay()->format('Y-m-d');
         }
 
-        return Token::generateTokenForLocality(0, $startDate, $endDate);
+        return Token::generateTokenForLocality($localityId ?? 1, $startDate, $endDate);
     }
 }

--- a/resources/views/costs/index.blade.php
+++ b/resources/views/costs/index.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 <section class="content">
-    <div class="right_col" role="main">
+    <div class="right_col" cost="main">
         <div class="col-md-12 col-sm-12 ">
             <div class="x_panel">
                 <div class="x_title">
@@ -37,7 +37,7 @@
                                     <thead>
                                         <tr>
                                             <th>ID</th>
-                                            <th>CATEGORÍA</th>
+                                            <th>CATEGORIA</th>
                                             <th>PRECIO</th>
                                             <th>OPCIONES</th>
                                         </tr>
@@ -54,7 +54,7 @@
                                                     <td>{{ $cost->category }}</td>
                                                     <td>${{ number_format($cost->price, 2) }}</td>
                                                     <td>
-                                                        <div class="btn-group" role="group" aria-label="Opciones">
+                                                        <div class="btn-group" cost="group" aria-label="Opciones">
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $cost->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>

--- a/resources/views/costs/index.blade.php
+++ b/resources/views/costs/index.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 <section class="content">
-    <div class="right_col" cost="main">
+    <div class="right_col" role="main">
         <div class="col-md-12 col-sm-12 ">
             <div class="x_panel">
                 <div class="x_title">
@@ -37,7 +37,7 @@
                                     <thead>
                                         <tr>
                                             <th>ID</th>
-                                            <th>CATEGORIA</th>
+                                            <th>CATEGORÍA</th>
                                             <th>PRECIO</th>
                                             <th>OPCIONES</th>
                                         </tr>
@@ -54,19 +54,23 @@
                                                     <td>{{ $cost->category }}</td>
                                                     <td>${{ number_format($cost->price, 2) }}</td>
                                                     <td>
-                                                        <div class="btn-group" cost="group" aria-label="Opciones">
+                                                        <div class="btn-group" role="group" aria-label="Opciones">
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $cost->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
                                                             @can('editCost')
-                                                            <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $cost->id }}">
-                                                                <i class="fas fa-edit"></i>
-                                                            </button>
+                                                            @if ($cost->locality_id != 0)
+                                                                <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $cost->id }}">
+                                                                    <i class="fas fa-edit"></i>
+                                                                </button>
+                                                            @endif
                                                             @endcan
                                                             @can('deleteCost')
-                                                            <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $cost->id }}">
-                                                                <i class="fas fa-trash-alt"></i>
-                                                            </button>
+                                                            @if ($cost->locality_id != 0)
+                                                                <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $cost->id }}">
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
+                                                            @endif
                                                             @endcan
                                                         </div>
                                                     </td>


### PR DESCRIPTION
### 📝 **Description:**  
This update introduces a **global locality and default cost** (`locality_id = 0`) to provide fallback values applicable to all localities.

#### **Key Changes:**
- **LocalitiesTableSeeder:**  
  - Added a "Global" locality with `id = 0`.
  - Adjusted SQL modes and foreign key checks to allow zero IDs.  
- **CostsTableSeeder:**  
  - Created a default cost entry linked to the global locality.  
- **Controllers:**  
  - Updated `CostController` and `WaterConnectionController` to include global (`locality_id = 0`) costs.  
  - Modified `LocalityController` and `UserController` to exclude the global locality from standard listings.  
- **View (`costs/index.blade.php`):**  
  - Restricted edit/delete actions for global costs.  
  - Corrected accessibility attributes (`role` instead of `cost`).  

These enhancements ensure the system supports **universal default configurations** for costs and localities while maintaining **data consistency and UI clarity**.