### PR TITLE
### 🚀 Update: Remove 'created_by' column and fix related logic

### DIFF
--- a/app/Http/Controllers/MembershipController.php
+++ b/app/Http/Controllers/MembershipController.php
@@ -38,8 +38,7 @@ class MembershipController extends Controller
             'price' => $request->price,
             'term_months' => $request->term_months,
             'water_connections_number' => $request->water_connections_number, 
-            'users_number' => $request->users_number, 
-            'created_by' => auth()->id()
+            'users_number' => $request->users_number
         ]);
 
         return redirect()->route('memberships.index')->with('success', 'Membresía creada exitosamente.');

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -34,6 +34,11 @@ class Locality extends Model implements HasMedia
         return $this->belongsTo(Membership::class);
     }
 
+    public function waterConnections()
+    {
+        return $this->hasMany(WaterConnection::class);
+    }
+
     public function hasDependencies()
     {
         return $this->customers()->exists() || $this->users()->exists() || $this->costs()->exists();

--- a/database/migrations/2025_10_22_180619_remove_created_by_from_memberships_table.php
+++ b/database/migrations/2025_10_22_180619_remove_created_by_from_memberships_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('memberships', function (Blueprint $table) {
+            $table->dropForeign(['created_by']);
+            $table->dropColumn('created_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('memberships', function (Blueprint $table) {
+            $table->unsignedBigInteger('created_by')->nullable()->after('users_number');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+};

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -49,7 +49,6 @@ class MembershipsTableSeeder extends Seeder
                 'term_months' => $membership['term_months'],
                 'water_connections_number' => $membership['water_connections_number'],
                 'users_number' => $membership['users_number'],
-                'created_by' => $admin->id,
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -134,6 +134,84 @@
                             </div>
                         </div>
                     </div>
+                    @can('viewDashboardCards')
+                    <div class="col-md-12">
+                        <div class="card card-info">
+                            <div class="card-header">
+                                <h3 class="card-title">Información de Membresía</h3>
+                            </div>
+                            <div class="card-body">
+                                @if($authUser->locality && $authUser->locality->membership)
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="info-box bg-light">
+                                                <span class="info-box-icon bg-info"><i class="fas fa-users"></i></span>
+                                                <div class="info-box-content">
+                                                    <span class="info-box-text">Usuarios</span>
+                                                    <span class="info-box-number">
+                                                        {{ $membershipStats['users_count'] }} / {{ $membershipStats['users_limit'] }}
+                                                    </span>
+                                                    <div class="progress">
+                                                        <div class="progress-bar bg-info" style="width: {{ $membershipStats['users_limit'] > 0 ? ($membershipStats['users_count'] / $membershipStats['users_limit']) * 100 : 0 }}%"></div>
+                                                    </div>
+                                                    <span class="progress-description">
+                                                        {{ $membershipStats['users_count'] }} de {{ $membershipStats['users_limit'] }} usuarios utilizados
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <div class="info-box bg-light">
+                                                <span class="info-box-icon bg-success"><i class="fas fa-faucet"></i></span>
+                                                <div class="info-box-content">
+                                                    <span class="info-box-text">Tomas de Agua</span>
+                                                    <span class="info-box-number">
+                                                        {{ $membershipStats['water_connections_count'] }} / {{ $membershipStats['water_connections_limit'] }}
+                                                    </span>
+                                                    <div class="progress">
+                                                        <div class="progress-bar bg-success" style="width: {{ $membershipStats['water_connections_limit'] > 0 ? ($membershipStats['water_connections_count'] / $membershipStats['water_connections_limit']) * 100 : 0 }}%"></div>
+                                                    </div>
+                                                    <span class="progress-description">
+                                                        {{ $membershipStats['water_connections_count'] }} de {{ $membershipStats['water_connections_limit'] }} tomas utilizadas
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row mt-3">
+                                        <div class="col-md-6">
+                                            <strong>Plan de Membresía:</strong>
+                                            <p class="text-muted">{{ $membershipStats['membership_name'] }}</p>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <strong>Estado de Suscripción:</strong>
+                                            <p class="text-muted">
+                                                @if($membershipStats['subscription_status'] == 'Activa')
+                                                    <span class="badge badge-success">Activa</span>
+                                                @elseif($membershipStats['subscription_status'] == 'Caducada')
+                                                    <span class="badge badge-danger">Caducada</span>
+                                                @else
+                                                    <span class="badge badge-warning">Sin token</span>
+                                                @endif
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div class="row mt-2">
+                                        <div class="col-md-12">
+                                            <strong>Localidad:</strong>
+                                            <p class="text-muted">{{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}</p>
+                                        </div>
+                                    </div>
+                                @else
+                                    <div class="alert alert-warning">
+                                        <h5><i class="icon fas fa-exclamation-triangle"></i> Sin membresía asignada</h5>
+                                        No tienes una membresía asignada a tu localidad. Contacta al administrador del sistema.
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                    @endcan
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Summary:**
- Added migration \2025_10_22_180619_remove_created_by_from_memberships_table\ to remove the \created_by\ foreign key and column from the **memberships** table.
- This change resolves seeder execution issues caused by the previous foreign key dependency.

**Changes made:**
- **Migration:** Removed \created_by\ column and foreign key in the *up()* method, restored them in *down()*.
- **MembershipsTableSeeder:** Removed the line \'created_by' => \->id,\ to prevent seeding errors.
- **MembershipController:** Removed the line \'created_by' => auth()->id()\ for the same reason.
- **ProfileController:** Updated the \index()\ method to display membership statistics only for *supervisor* and *secretary* roles.
- **Locality Model:** Ensured proper relationship with \waterConnections()\ for retrieving non-canceled water connections.
- **Profile Index View:** Updated layout and logic to conditionally render membership info, with improved UX and role-based visibility.

**Purpose:**
These adjustments ensure data integrity, fix seeder errors, and enhance the profile view for authorized roles only.