### PR TITLE
Enhance Incident Management with Default Category and Locality-Based Filtering

### DIFF
--- a/app/Http/Controllers/IncidentCategoriesController.php
+++ b/app/Http/Controllers/IncidentCategoriesController.php
@@ -33,14 +33,12 @@ class IncidentCategoriesController extends Controller
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'locality_id' => 'nullable|exists:localities,id',
         ]);
-        $locality_id = $request->input('locality_id') !== null ? $request->input('locality_id') : $authUser->locality_id;
 
         IncidentCategory::create([
             'name' => $validated['name'],
             'description' => $validated['description'],
-            'locality_id' => $locality_id,
+            'locality_id' => $authUser->locality_id,
             'created_by' => $authUser->id,
         ]);
 

--- a/app/Http/Controllers/IncidentCategoriesController.php
+++ b/app/Http/Controllers/IncidentCategoriesController.php
@@ -11,7 +11,10 @@ class IncidentCategoriesController extends Controller
     public function index()
     {
         $authUser = auth()->user();
-        $categories = IncidentCategory::where('locality_id', $authUser->locality_id)
+        $categories = IncidentCategory::where(function ($query) use ($authUser) {
+            $query->where('locality_id', $authUser->locality_id)
+                  ->orWhereNull('locality_id');
+        })
             ->orderBy('created_at', 'desc')
             ->paginate(10);
 
@@ -27,13 +30,19 @@ class IncidentCategoriesController extends Controller
     {
         $authUser = auth()->user();
 
-        IncidentCategory::create(array_merge(
-            $request->only(['name', 'description']),
-            [
-                'locality_id' => $authUser->locality_id,
-                'created_by' => $authUser->id
-            ]
-        ));
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'locality_id' => 'nullable|exists:localities,id',
+        ]);
+        $locality_id = $request->input('locality_id') !== null ? $request->input('locality_id') : $authUser->locality_id;
+
+        IncidentCategory::create([
+            'name' => $validated['name'],
+            'description' => $validated['description'],
+            'locality_id' => $locality_id,
+            'created_by' => $authUser->id,
+        ]);
 
         return redirect()->route('incidentCategories.index')->with('success', 'Categoría de incidencia creada exitosamente.');
     }
@@ -50,7 +59,12 @@ class IncidentCategoriesController extends Controller
 
     public function update(Request $request, IncidentCategory $incidentCategory)
     {
-        $incidentCategory->update($request->only(['name', 'description']));
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        $incidentCategory->update($validated);
 
         return redirect()->route('incidentCategories.index')->with('success', 'Categoría de incidencia actualizada exitosamente.');
     }
@@ -65,7 +79,11 @@ class IncidentCategoriesController extends Controller
     public function generateIncidentCategoyListReport()
     {
         $authUser = auth()->user();
-        $incidentCategories = IncidentCategory::all();
+        $incidentCategories = IncidentCategory::where(function ($query) use ($authUser) {
+            $query->where('locality_id', $authUser->locality_id)
+                  ->orWhereNull('locality_id');
+        })->get();
+
         $pdf = PDF::loadView('reports.generateIncidentCategoyListReport', compact('incidentCategories', 'authUser'))
             ->setPaper('A4', 'portrait');
 

--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -26,9 +26,13 @@ class IncidentController extends Controller
 
         $incidents = $query->paginate(10);
 
-        $categories = IncidentCategory::all();
+        $categories = IncidentCategory::where(function ($query) use ($authUser) {
+            $query->where('locality_id', $authUser->locality_id)
+                  ->orWhere('name', 'Por Defecto');
+        })->get();
+
         $employees = Employee::where('locality_id', $authUser->locality_id)->get();
-        $statuses = IncidentStatus::all();
+        $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)->get();
 
         return view('incidents.index', compact('incidents', 'categories', 'employees', 'statuses'));
     }
@@ -75,7 +79,7 @@ class IncidentController extends Controller
 
     public function update(Request $request, $id)
     {
-        $incident = incident::find($id);
+        $incident = Incident::find($id);
         if ($incident) {
             $incident->name = $request->input('nameUpdate');
             $incident->start_date = $request->input('startDateUpdate');
@@ -108,13 +112,13 @@ class IncidentController extends Controller
     public function generateIncidentListReport()
     {
         $authUser = auth()->user();
-        $incidents = Incident::all();
+        $incidents = Incident::where('locality_id', $authUser->locality_id)->get();
         $pdf = PDF::loadView('reports.generateIncidentListReport', compact('incidents', 'authUser'))
             ->setPaper('A4', 'portrait');
 
         return $pdf->stream('incidents.pdf');
     }
-    
+
     public function updateStatus(Request $request)
     {
         try {

--- a/app/Http/Controllers/IncidentStatusController.php
+++ b/app/Http/Controllers/IncidentStatusController.php
@@ -30,12 +30,10 @@ class IncidentStatusController extends Controller
         $request->validate([
             'status' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'color' => 'required|string', 
+            'color' => 'required|string',
         ]);
 
-        IncidentStatus::create(
-            array_merge(
-                $request->only(['status', 'description', 'color']), 
+        IncidentStatus::create(array_merge($request->only(['status', 'description', 'color']),
                 [
                     'locality_id' => $authUser->locality_id,
                     'created_by' => $authUser->id,
@@ -56,10 +54,10 @@ class IncidentStatusController extends Controller
         $request->validate([
             'status' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'color' => 'required|string', 
+            'color' => 'required|string',
         ]);
 
-        $incidentStatus->update($request->only('status', 'description', 'color')); 
+        $incidentStatus->update($request->only('status', 'description', 'color'));
         return redirect()->route('incidentStatuses.index')
             ->with('success', 'Estatus actualizado correctamente.');
     }
@@ -74,7 +72,7 @@ class IncidentStatusController extends Controller
     public function generateIncidentStatusListReport()
     {
         $authUser = auth()->user();
-        $incidentStatus = IncidentStatus::all();
+        $incidentStatus = IncidentStatus::where('locality_id', $authUser->locality_id)->get();
         $pdf = PDF::loadView('reports.generateIncidentStatusListReport', compact('incidentStatus', 'authUser'))
             ->setPaper('A4', 'portrait');
 

--- a/database/migrations/2025_10_24_113324_make_locality_id_nullable_in_incident_categories.php
+++ b/database/migrations/2025_10_24_113324_make_locality_id_nullable_in_incident_categories.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class MakeLocalityIdNullableInIncidentCategories extends Migration
+{
+    public function up()
+    {
+        DB::statement('ALTER TABLE incident_categories MODIFY COLUMN locality_id BIGINT UNSIGNED NULL');
+    }
+
+    public function down()
+    {
+        DB::table('incident_categories')
+            ->whereNull('locality_id')
+            ->update(['locality_id' => 1]);
+
+        DB::statement('ALTER TABLE incident_categories MODIFY COLUMN locality_id BIGINT UNSIGNED NOT NULL');
+    }
+}

--- a/database/seeders/IncidentCategorySeeder.php
+++ b/database/seeders/IncidentCategorySeeder.php
@@ -11,6 +11,12 @@ class IncidentCategorySeeder extends Seeder
     {
         $categories = [
             [
+                'name' => 'Por Defecto',
+                'description' => 'Categoría por defecto para incidencias.',
+                'created_by' => 3,
+                'locality_id' => null,
+            ],
+            [
                 'name' => 'Eléctrica',
                 'description' => 'Problemas con instalación o alumbrado eléctrico.',
                 'created_by' => 3,

--- a/database/seeders/IncidentCategorySeeder.php
+++ b/database/seeders/IncidentCategorySeeder.php
@@ -11,8 +11,8 @@ class IncidentCategorySeeder extends Seeder
     {
         $categories = [
             [
-                'name' => 'Por Defecto',
-                'description' => 'Categoría por defecto para incidencias.',
+                'name' => 'Mantenimiento  General',
+                'description' => 'Trabajos generales de reparación o conservación del sistema de agua.',
                 'created_by' => 3,
                 'locality_id' => null,
             ],

--- a/resources/views/incidentCategories/index.blade.php
+++ b/resources/views/incidentCategories/index.blade.php
@@ -59,7 +59,7 @@
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $category->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
-                                                            @if ($category->name !== 'Por Defecto')
+                                                            @if ($category->name !== 'Mantenimiento  General')
                                                                 @can('editIncidentCategories')
                                                                     <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $category->id }}">
                                                                         <i class="fas fa-edit"></i>

--- a/resources/views/incidentCategories/index.blade.php
+++ b/resources/views/incidentCategories/index.blade.php
@@ -59,21 +59,23 @@
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $category->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
-                                                            @can('editIncidentCategories')
-                                                                <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $category->id }}">
-                                                                    <i class="fas fa-edit"></i>
-                                                                </button>
-                                                            @endcan
-                                                            @can('deleteIncidentCategories')
-                                                                <button
-                                                                    type="button"
-                                                                    class="btn {{ $category->hasDependencies() ? 'btn-secondary' : 'btn-danger' }} mr-2"
-                                                                    title="{{ $category->hasDependencies() ? 'Eliminación no permitida: Existen incidencias asociadas a esta categoría.' : 'Eliminar Registro' }}"
-                                                                    {{ $category->hasDependencies() ? 'disabled' : 'data-toggle=modal data-target=#delete' . $category->id }}
-                                                                >
-                                                                    <i class="fas fa-trash-alt"></i>
-                                                                </button>
-                                                            @endcan
+                                                            @if ($category->name !== 'Por Defecto')
+                                                                @can('editIncidentCategories')
+                                                                    <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $category->id }}">
+                                                                        <i class="fas fa-edit"></i>
+                                                                    </button>
+                                                                @endcan
+                                                                @can('deleteIncidentCategories')
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn {{ $category->hasDependencies() ? 'btn-secondary' : 'btn-danger' }} mr-2"
+                                                                        title="{{ $category->hasDependencies() ? 'Eliminación no permitida: Existen incidencias asociadas a esta categoría.' : 'Eliminar Registro' }}"
+                                                                        {{ $category->hasDependencies() ? 'disabled' : 'data-toggle=modal data-target=#delete' . $category->id }}
+                                                                    >
+                                                                        <i class="fas fa-trash-alt"></i>
+                                                                    </button>
+                                                                @endcan
+                                                            @endif
                                                         </div>
                                                     </td>
                                                 </tr>


### PR DESCRIPTION
Description
This update improves the incident management module by introducing validation, refining locality-based data filtering, and adding a default incident category.

Key changes include:

Incident Categories:
o	Added validation for name, description, and locality_id fields.
o	Allowed categories with null locality to be visible across all localities.
o	Introduced a "Por Defecto" (Default) category available globally.
o	Restricted edit and delete actions for the default category in the UI.

Incidents:
o	Limited categories and statuses to the authenticated user’s locality.
o	Corrected a naming inconsistency (incident → Incident).
o	Adjusted PDF report generation to respect locality filtering.

Incident Statuses:
o	Applied locality filters for data listing and PDF reports.
o	Cleaned up code formatting and validation rules.

Seeder:
o	Added the new default “Por Defecto” incident category.

These enhancements ensure better data integrity, cleaner code, and improved multi-locality support across the incident management system.