### PR TITLE
Fix/add phone if missing

### DIFF
--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -113,7 +113,7 @@
                                     Telefono
                                 </label>
                                 <div class="col-sm-10">
-                                    <p class="form-control-plaintext">{{ $authUser->phone }}</p>
+                                    <p class="form-control-plaintext">{{ $authUser->phone ?? 'Sin número de teléfono' }}</p>
                                 </div>
                                 <label for="email" class="col-sm-2 col-form-label">
                                     Correo


### PR DESCRIPTION
📝 Title

Display default text when the user's phone number is null in the profile view

📄 Description

Updated the profile/index.blade.php view to improve how the user's phone number is displayed. Now, if the phone field is empty or null, the text "No phone number" will be shown instead of leaving the space blank, providing a clearer and more user-friendly experience.

 modified:   resources/views/profile/index.blade.php