### PR TITLE
Add module and permissions for fault reports for the customer user

### DIFF
--- a/app/Http/Controllers/CustomerFaultReportController.php
+++ b/app/Http/Controllers/CustomerFaultReportController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\FaultReport;
+use Illuminate\Support\Facades\Auth;
+
+class CustomerFaultReportController extends Controller
+{
+    public function index(Request $request)
+    {
+        $authUser = Auth::user();
+
+        $query = FaultReport::where('customer_id', $authUser->id)
+            ->orderBy('created_at', 'desc');
+
+        if ($request->has('search')) {
+            $search = $request->input('search');
+
+            $query->where(function ($q) use ($search) {
+                $q->where('title', 'LIKE', "%{$search}%")
+                    ->orWhere('id', 'LIKE', "%{$search}%")
+                    ->orWhere('status', 'LIKE', "%{$search}%");
+            });
+        }
+
+        $reports = $query->paginate(10);
+
+        return view('customerFaultReports.index', compact('reports'));
+    }
+
+    public function create()
+    {
+        return view('customerFaultReports.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+            'location' => 'nullable|string|max:255',
+        ]);
+
+        $report = new FaultReport();
+        $report->title = $request->title;
+        $report->description = $request->description;
+        $report->status = 'Earring';
+        $report->date_report = now();
+        $report->customer_id = Auth::id();
+        $report->created_by = Auth::id();
+        $report->save();
+
+        return redirect()->route('customerFaultReports.index')
+                        ->with('success', 'Reporte de falla registrado correctamente.');
+    }
+
+    public function show($id)
+    {
+        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+        return view('customerFaultReports.show', compact('report'));
+    }
+
+    public function edit($id)
+    {
+        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+        return view('customerFaultReports.edit', compact('report'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+
+        $report->update([
+            'title' => $request->input('titleUpdate'),
+            'description' => $request->input('descriptionUpdate'),
+            'date_report' => $request->input('dateReportUpdate'),
+        ]);
+
+        return redirect()->route('customerFaultReports.index')
+            ->with('success', 'Reporte de falla actualizado correctamente.');
+    }
+
+    public function destroy($id)
+    {
+        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+        $report->delete();
+
+        return redirect()->route('customerFaultReports.index')
+            ->with('success', 'Reporte de falla eliminado correctamente.');
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -449,6 +449,12 @@ return [
         'icon' => 'fas fa-fw fa-water text-white',
     ],
     [
+        'text' => 'Mis Reportes de Fallas',
+        'url' => '/viewMyFaultReports',
+        'can' => 'viewCustomerFaultReports',
+        'icon' => 'fa fa-clipboard-list',
+    ],
+    [
         'text' => 'Avisos',
         'url' => '/localityNotices',
         'can' => 'viewNotice',

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -208,6 +208,22 @@ class RolesAndPermissionsSeeder extends Seeder
             'description' => 'Permite ver los avisos por localidad a los clientes.'
         ])->assignRole([$roleCliente]);
         Permission::firstOrCreate([
+            'name' => 'viewCustomerFaultReports',
+            'description' => 'Permite ver sus reportes de fallas.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
+            'name' => 'editFaultReports',
+            'description' => 'Permite editar el reporte de fallas.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
+            'name' => 'deleteFaultReports',
+            'description' => 'Permite eliminar el reporte de fallas.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
+            'name' => 'createFaultReports',
+            'description' => 'Permite crear nuevos reportes de fallas.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
             'name' => 'viewInventory',
             'description' => 'Permite ver el Inventario.'
         ])->assignRole([$roleSupervisor]);

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -174,11 +174,11 @@ class RolesAndPermissionsSeeder extends Seeder
         Permission::firstOrCreate([
             'name' => 'editFaultReport',
             'description' => 'Permite editar el reporte de fallas.'
-        ])->assignRole([$roleSupervisor]);
+        ])->assignRole([$roleSupervisor, $roleCliente]);
         Permission::firstOrCreate([
             'name' => 'deleteFaultReport',
             'description' => 'Permite eliminar el reporte de fallas.'
-        ])->assignRole([$roleSupervisor]);
+        ])->assignRole([$roleSupervisor, $roleCliente]);
         Permission::firstOrCreate([ 
             'name' => 'viewNotice',
             'description' => 'Permite ver los Avisos de Localidades.'
@@ -212,15 +212,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'description' => 'Permite ver sus reportes de fallas.'
         ])->assignRole([$roleCliente]);
         Permission::firstOrCreate([
-            'name' => 'editFaultReports',
-            'description' => 'Permite editar el reporte de fallas.'
-        ])->assignRole([$roleCliente]);
-        Permission::firstOrCreate([
-            'name' => 'deleteFaultReports',
-            'description' => 'Permite eliminar el reporte de fallas.'
-        ])->assignRole([$roleCliente]);
-        Permission::firstOrCreate([
-            'name' => 'createFaultReports',
+            'name' => 'createCustomerFaultReports',
             'description' => 'Permite crear nuevos reportes de fallas.'
         ])->assignRole([$roleCliente]);
         Permission::firstOrCreate([

--- a/resources/views/customerFaultReports/create.blade.php
+++ b/resources/views/customerFaultReports/create.blade.php
@@ -1,4 +1,4 @@
-<div class="modal fade" id="createFaultReports" tabindex="-1" role="dialog" aria-labelledby="createFaultReportsLabel" aria-hidden="true">
+<div class="modal fade" id="createCustomerFaultReports" tabindex="-1" role="dialog" aria-labelledby="createCustomerFaultReportsLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="card-success">

--- a/resources/views/customerFaultReports/create.blade.php
+++ b/resources/views/customerFaultReports/create.blade.php
@@ -1,0 +1,73 @@
+<div class="modal fade" id="createFaultReports" tabindex="-1" role="dialog" aria-labelledby="createFaultReportsLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Crear Reporte de Fallas <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <form action="{{ route('customerFaultReports.store') }}" method="POST">
+                @csrf
+                    <div class="card-body">
+                        <div class="card">
+                            <div class="card-header py-2 bg-secondary">
+                                <h3 class="card-title">Ingrese Datos del Reporte</h3>
+                                <div class="card-tools">
+                                    <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                                        <i class="fa fa-minus"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="modal-body">
+                                <div class="card">
+                                    <div class="card-body">
+                                        <div class="row">
+                                            <div class="col-lg-12">
+                                                <div class="form-group">
+                                                    <label for="title">Título</label>
+                                                    <input type="text" name="title" id="title" class="form-control" placeholder="Ingrese un título" required>
+                                                </div>
+                                            </div>
+                                            <div class="col-lg-12">
+                                                <div class="form-group">
+                                                    <label for="description">Descripción de la Falla</label>
+                                                    <textarea name="description" id="description" class="form-control" rows="4" placeholder="Describa la falla" required></textarea>
+                                                </div>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <div class="form-group">
+                                                    <label for="date_report">Fecha de Reporte</label>
+                                                    <input type="date" name="date_report" id="date_report" class="form-control" value="{{ date('Y-m-d') }}" required readonly>
+                                                </div>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <div class="form-group">
+                                                    <label for="status">Estado</label>
+                                                    <input type="text" name="status" id="status" class="form-control" value="Pendiente" readonly>
+                                                </div>
+                                            </div>
+                                            <div class="col-lg-12">
+                                                <div class="form-group">
+                                                    <label>Reportado por</label>
+                                                    <input type="text" class="form-control" value="{{ Auth::user()->name }} {{ Auth::user()->last_name ?? '' }}" disabled>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                        <button type="submit" id="save" class="btn btn-success">Guardar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/customerFaultReports/delete.blade.php
+++ b/resources/views/customerFaultReports/delete.blade.php
@@ -1,0 +1,24 @@
+<div class="modal fade" id="delete{{ $report->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel"
+    aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger">
+                <h5 class="modal-title" id="exampleModalLabel">Eliminar Reporte de Falla</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <form action="{{ route('customerFaultReports.destroy', $report->id) }}" method="POST" enctype="multipart/form-data">
+                @csrf
+                @method('DELETE')
+                <div class="modal-body text-center text-danger">
+                    ¿Estás seguro de eliminar el reporte de falla <strong>{{ $report->title }}?</strong>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-danger">Confirmar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/customerFaultReports/edit.blade.php
+++ b/resources/views/customerFaultReports/edit.blade.php
@@ -1,0 +1,64 @@
+<div class="modal fade" id="edit{{ $report->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-warning">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Editar Reporte de Falla <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <form action="{{ route('customerFaultReports.update', $report->id) }}" method="POST" id="edit-customerFaultReports-form-{{ $report->id }}">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="card">
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="titleUpdate" class="form-label">Título(*)</label>
+                                            <input type="text" class="form-control" name="titleUpdate" placeholder="Título del reporte" value="{{ $report->title }}" required/>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="descriptionUpdate" class="form-label">Descripción(*)</label>
+                                            <textarea class="form-control" name="descriptionUpdate" placeholder="Descripción del reporte" required>{{ $report->description }}</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Estado</label>
+                                            <input type="text" disabled class="form-control"
+                                                value="@switch($report->status)
+                                                            @case('Earring') Pendiente @break
+                                                            @case('In process') En proceso @break
+                                                            @case('Resolved') Resuelto @break
+                                                            @case('Closed') Cerrado @break
+                                                            @default {{ $report->status }} @break
+                                                        @endswitch" />
+                                    </div>
+                                </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="dateReportUpdate" class="form-label">Fecha del reporte(*)</label>
+                                            <input type="date" class="form-control" name="dateReportUpdate" 
+                                                   value="{{ old('dateReportUpdate', \Carbon\Carbon::parse($report->date_report)->format('Y-m-d')) }}" required readonly/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                        <button type="submit" class="btn btn-warning">Actualizar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/customerFaultReports/index.blade.php
+++ b/resources/views/customerFaultReports/index.blade.php
@@ -24,7 +24,7 @@
                                     </div>
                                 </form>
                                 <button class="btn btn-success flex-grow-1 flex-lg-grow-0 mt-2" data-toggle='modal' 
-                                    data-target="#createFaultReports" title="Registrar Reporte">
+                                    data-target="#createCustomerFaultReports" title="Registrar Reporte">
                                     <i class="fa fa-plus"></i>
                                     <span class="d-none d-md-inline">Registrar Reporte</span>
                                     <span class="d-inline d-md-none">Registrar Reporte</span>
@@ -34,7 +34,6 @@
                     </div>
                     <div class="clearfix"></div>
                 </div>
-
                 <div class="x_content">
                     <div class="row">
                         <div class="col-sm-12">
@@ -116,7 +115,6 @@
                         </div>
                     </div>
                 </div>
-
             </div>
         </div>
     </div>

--- a/resources/views/customerFaultReports/index.blade.php
+++ b/resources/views/customerFaultReports/index.blade.php
@@ -1,0 +1,160 @@
+@extends('adminlte::page')
+
+@section('title', config('adminlte.title') . ' | Mis Reportes de Fallas')
+
+@section('content')
+<section class="content">
+    <div class="right_col" role="main">
+        <div class="col-md-12 col-sm-12">
+            <div class="x_panel">
+                <div class="x_title">
+                    <h2>Mis Reportes de Fallas</h2>
+                    <div class="row mb-2">
+                        <div class="col-lg-12">
+                            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-center gap-3">
+                                <form method="GET" action="{{ route('customerFaultReports.index') }}" class="flex-grow-1 mt-2" style="min-width: 330px; max-width: 30%;">
+                                    <div class="input-group">
+                                        <input type="text" name="search" class="form-control" placeholder="Buscar por ID o Título" value="{{ request('search') }}">
+                                        <div class="input-group-append">
+                                            <button type="submit" class="btn btn-primary" title="Buscar Falla">
+                                                <i class="fas fa-search"></i>
+                                                <span class="d-none d-md-inline">Buscar</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </form>
+                                <button class="btn btn-success flex-grow-1 flex-lg-grow-0 mt-2" data-toggle='modal' 
+                                    data-target="#createFaultReports" title="Registrar Reporte">
+                                    <i class="fa fa-plus"></i>
+                                    <span class="d-none d-md-inline">Registrar Reporte</span>
+                                    <span class="d-inline d-md-none">Registrar Reporte</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="clearfix"></div>
+                </div>
+
+                <div class="x_content">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="card-box table-responsive">
+                                <table id="customerFaultReports" class="table table-striped display responsive nowrap" style="width:100%">
+                                    <thead>
+                                        <tr>
+                                            <th>ID</th>
+                                            <th>TÍTULO</th>
+                                            <th>ESTADO</th>
+                                            <th>FECHA DEL REPORTE</th>
+                                            <th>OPCIONES</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @if(count($reports) <= 0)
+                                            <tr>
+                                                <td colspan="6">No hay resultados</td>
+                                            </tr>
+                                        @else
+                                            @foreach($reports as $report)
+                                                <tr>
+                                                    <td>{{ $report->id }}</td>
+                                                    <td>{{ $report->title }}</td>
+                                                    <td>
+                                                        @switch($report->status)
+                                                            @case('Earring')
+                                                                Pendiente
+                                                                @break
+                                                            @case('In process')
+                                                                En proceso
+                                                                @break
+                                                            @case('Resolved')
+                                                                Resuelto
+                                                                @break
+                                                            @case('Closed')
+                                                                Cerrado
+                                                                @break
+                                                            @default
+                                                                {{ $report->status }}
+                                                                @break
+                                                        @endswitch
+                                                    </td>
+                                                    <td>{{ \Carbon\Carbon::parse($report->date_report)->format('d/m/Y') }}</td>
+                                                    <td>
+                                                        <div class="btn-group" role="group">
+                                                            @can('viewCustomerFaultReports')
+                                                            <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $report->id }}">
+                                                                <i class="fas fa-eye"></i>
+                                                            </button>
+                                                            @endcan
+
+                                                            @can('editFaultReports')
+                                                            <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Datos" data-target="#edit{{ $report->id }}">
+                                                                <i class="fas fa-edit"></i>
+                                                            </button>
+                                                            @endcan
+
+                                                            @can('deleteFaultReports')
+                                                            <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $report->id }}">
+                                                                <i class="fas fa-trash-alt"></i>
+                                                            </button>
+                                                            @endcan
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                                @include('customerFaultReports.show')
+                                                @include('customerFaultReports.edit')
+                                                @include('customerFaultReports.delete')
+                                            @endforeach
+                                        @endif
+                                    </tbody>
+                                </table>
+                                @include('customerFaultReports.create')
+                                <div class="d-flex justify-content-center">
+                                    {!! $reports->links('pagination::bootstrap-4') !!}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+
+@section('js')
+<script>
+    $(document).ready(function () {
+        $('#customerFaultReports').DataTable({
+            responsive: true,
+            buttons: ['csv', 'excel', 'print'],
+            dom: 'Bfrtip',
+            paging: false,
+            info: false,
+            searching: false
+        });
+
+        var successMessage = "{{ session('success') }}";
+        var errorMessage = "{{ session('error') }}";
+
+        if (successMessage) {
+            Swal.fire({
+                icon: 'success',
+                title: 'Éxito',
+                text: successMessage,
+                confirmButtonText: 'Aceptar'
+            });
+        }
+
+        if (errorMessage) {
+            Swal.fire({
+                icon: 'error',
+                title: 'Error',
+                text: errorMessage,
+                confirmButtonText: 'Aceptar'
+            });
+        }
+    });
+</script>
+@endsection

--- a/resources/views/customerFaultReports/show.blade.php
+++ b/resources/views/customerFaultReports/show.blade.php
@@ -1,0 +1,70 @@
+<div class="modal fade" id="view{{ $report->id }}" tabindex="-1" role="dialog" aria-labelledby="viewModalLabel{{ $report->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-info">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Información del Reporte de Falla</h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Cerrar">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="modal-body">
+                    <div class="card">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-lg-2">
+                                    <div class="form-group">
+                                        <label>ID</label>
+                                        <input type="text" disabled class="form-control" value="{{ $report->id }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-10">
+                                    <div class="form-group">
+                                        <label>Título</label>
+                                        <input type="text" disabled class="form-control" value="{{ $report->title }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-12">
+                                    <div class="form-group">
+                                        <label>Descripción de la Falla</label>
+                                        <textarea disabled class="form-control">{{ $report->description }}</textarea>
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Fecha de Reporte</label>
+                                        <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($report->date_report)->format('Y-m-d') }}" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label>Estado</label>
+                                        <input type="text" disabled class="form-control"
+                                            value="@switch($report->status)
+                                                        @case('Earring') Pendiente @break
+                                                        @case('In process') En proceso @break
+                                                        @case('Resolved') Resuelto @break
+                                                        @case('Closed') Cerrado @break
+                                                        @default {{ $report->status }} @break
+                                                    @endswitch" />
+                                    </div>
+                                </div>
+                                <div class="col-lg-12">
+                                    <div class="form-group">
+                                        <label>Reportado por</label>
+                                        <input type="text" disabled class="form-control" value="{{ $report->creator->name ?? 'Desconocido' }} {{ $faultReport->creator->last_name ?? '' }}" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\TokenController;
 use App\Http\Middleware\CheckSubscription;
 use App\Http\Controllers\MembershipController;
 use App\Http\Controllers\SectionController;
+use App\Http\Controllers\CustomerFaultReportController;
 
 /*
 |--------------------------------------------------------------------------
@@ -181,6 +182,11 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
     Route::group(['middleware' => ['can:viewFaultReport']], function () {
         Route::get('/faultReport', [FaultReportController::class, 'index'])->name('faultReport.index');
         Route::resource('faultReport', FaultReportController::class);
+    });
+
+    Route::group(['middleware' => ['can:viewCustomerFaultReports']], function () {
+        Route::get('/viewMyFaultReports', [CustomerFaultReportController::class, 'index'])->name('customerFaultReports.index');
+        Route::resource('customerFaultReports', CustomerFaultReportController::class);
     });
 
     Route::group(['middleware' => ['can:viewNotice']], function () {


### PR DESCRIPTION
# Add module and permissions for customer fault reports

This PR introduces the fault reports functionality for users with the Customer role.

## Main Changes

1. **AdminLTE Menu**
   - Added the **"My Fault Reports"** link in the sidebar menu, visible only to users with the `viewCustomerFaultReports` permission.

2. **Roles and Permissions Seeder**
   - Created specific permissions for customers:
     - `viewCustomerFaultReports` → view their fault reports.
     - `createFaultReports` → create new fault reports.
     - `editFaultReports` → edit existing fault reports.
     - `deleteFaultReports` → delete fault reports.

3. **Web Routes**
   - Added routes protected by the `viewCustomerFaultReports` permission:
     - `/viewMyFaultReports` → list view of a customer's fault reports.
     - Resource controller `customerFaultReports` for full CRUD of fault reports.

## Modified Files
- `config/adminlte.php`
- `database/seeders/RolesAndPermissionsSeeder.php`
- `routes/web.php`

