### PR TITLE
Migration from “Default” records to global records using null locality IDs

### DIFF
--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -12,7 +12,7 @@ class CostController extends Controller
     {
         $authUser = auth()->user();
         $costs = Cost::where('locality_id', $authUser->locality_id)
-            ->orWhere('locality_id', 0)
+            ->orWhereNull('locality_id')
             ->orderBy('created_at', 'desc')
             ->paginate(10);
         return view('costs.index', compact('costs'));
@@ -66,7 +66,7 @@ class CostController extends Controller
     {
         $authUser = auth()->user();
         $costs = cost::where('locality_id', $authUser->locality_id)
-                    ->orWhere('locality_id', 0)
+                    ->orWhereNull('locality_id')
                     ->orderBy('created_at', 'desc')
                     ->get();
         

--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -28,7 +28,7 @@ class IncidentController extends Controller
 
         $categories = IncidentCategory::where(function ($query) use ($authUser) {
             $query->where('locality_id', $authUser->locality_id)
-                  ->orWhere('name', 'Por Defecto');
+                  ->orWhereNull('locality_id');
         })->get();
 
         $employees = Employee::where('locality_id', $authUser->locality_id)->get();

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -13,7 +13,7 @@ class LocalityController extends Controller
 {
     public function index(Request $request)
     {
-        $query = Locality::query()->where('id', '!=', 0)->orderBy('created_at', 'desc');
+        $query = Locality::query()->orderBy('created_at', 'desc');
 
         if ($request->has('search')) {
             $search = $request->input('search');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -17,7 +17,7 @@ class UserController extends Controller
         
         $roles = Role::whereIn('name', ['Supervisor', 'Secretaria'])->get();
         
-        $localities = Locality::where('id', '!=', 0)->get();
+        $localities = Locality::all();
         $users = User::where('id', '!=', $currentUserId)->get();
         return view('users.index', compact('users', 'localities', 'roles'));
     }

--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -39,7 +39,7 @@ class WaterConnectionController extends Controller
         $connections = $query->paginate(10);
         $customers = Customer::where('locality_id', $authUser->locality_id)->get();
         $costs = Cost::where('locality_id', $authUser->locality_id)
-                     ->orWhere('locality_id', 0)
+                     ->orWhereNull('locality_id')
                      ->get();
         $sections = Section::where('locality_id', $authUser->locality_id)->get();
 

--- a/database/migrations/2025_10_27_160701_make_locality_id_nullable_in_costs_and_remove_locality_zero.php
+++ b/database/migrations/2025_10_27_160701_make_locality_id_nullable_in_costs_and_remove_locality_zero.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use App\Models\Cost;
+use App\Models\Locality;
+
+class MakeLocalityIdNullableInCostsAndRemoveLocalityZero extends Migration
+{
+    public function up()
+    {
+        DB::statement('ALTER TABLE costs MODIFY COLUMN locality_id BIGINT UNSIGNED NULL');
+
+        Cost::where('locality_id', 0)->update(['locality_id' => null]);
+
+        Locality::where('id', 0)->delete();
+    }
+
+   public function down()
+    {
+        $locality = Locality::first() ?? throw new \RuntimeException('No hay localidades disponibles para revertir la migración.');
+        
+        Cost::whereNull('locality_id')->update(['locality_id' => $locality->id]);
+
+        DB::statement('ALTER TABLE costs MODIFY COLUMN locality_id BIGINT UNSIGNED NOT NULL');
+    }
+}

--- a/database/seeders/CostsTableSeeder.php
+++ b/database/seeders/CostsTableSeeder.php
@@ -9,28 +9,14 @@ class CostsTableSeeder extends Seeder
 {
     public function run()
     {
-        $defaultCost = [
-            'locality_id' => 0,
-            'created_by' => 1,
-            'category' => 'Por Defecto',
-            'price' => 130.00,
-            'description' => 'Tarifa por defecto para todas las localidades',
-        ];
-
-        Cost::updateOrCreate(
-            [
-                'locality_id' => 0,
-                'category' => $defaultCost['category'],
-            ],
-            [
-                'price' => $defaultCost['price'],
-                'description' => $defaultCost['description'],
-                'created_by' => $defaultCost['created_by'],
-                'updated_at' => now(),
-            ]
-        );
-
         $costs = [
+            [
+                'locality_id' => null,
+                'created_by' => 1,
+                'category' => 'Precio Estándar',
+                'price' => 130.00,
+                'description' => 'Tarifa Estándar',
+            ],
             [
                 'locality_id' => 1,
                 'created_by' => 2,

--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -7,34 +7,11 @@ use Illuminate\Database\Seeder;
 use App\Models\Locality;
 use App\Models\Membership;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\DB;
 
 class LocalitiesTableSeeder extends Seeder
 {
     public function run()
     {
-        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-
-        DB::statement('SET SESSION sql_mode = "NO_AUTO_VALUE_ON_ZERO";');
-
-        DB::table('localities')->updateOrInsert(
-            ['id' => 0],
-            [
-                'name' => 'Global',
-                'municipality' => 'N/A',
-                'state' => 'N/A',
-                'zip_code' => '00000',
-                'membership_id' => null,
-                'token' => null,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]
-        );
-
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-
-        DB::statement('SET SESSION sql_mode = "";');
-
         $memberships = Membership::all();
         
         if ($memberships->isEmpty()) {

--- a/resources/views/costs/index.blade.php
+++ b/resources/views/costs/index.blade.php
@@ -59,14 +59,14 @@
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
                                                             @can('editCost')
-                                                            @if ($cost->locality_id != 0)
+                                                            @if (!is_null($cost->locality_id))
                                                                 <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $cost->id }}">
                                                                     <i class="fas fa-edit"></i>
                                                                 </button>
                                                             @endif
                                                             @endcan
                                                             @can('deleteCost')
-                                                            @if ($cost->locality_id != 0)
+                                                            @if (!is_null($cost->locality_id))
                                                                 <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $cost->id }}">
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>


### PR DESCRIPTION
### 📝 **Description:**  
Updated multiple controllers and seeders to replace the use of `locality_id = 0` with `locality_id = null`, providing a cleaner and more consistent way to handle global or standard records within the system.  

#### **Main Changes:**  
- **Controllers Updated:**  
  - `CostController`, `IncidentController`, and `WaterConnectionController` now query global records using `orWhereNull('locality_id')` instead of `orWhere('locality_id', 0)`.  
  - `LocalityController` and `UserController` remove unnecessary filters such as `id != 0`.  

- **Cost Seeder:**  
  - Replaced the “Default” cost record (`locality_id = 0`) with a new standard cost using `locality_id = null`, simplified description, and category **“Precio Estándar”**.  

- **Locality Seeder:**  
  - Removed the forced creation of a “Global” locality (`id = 0`), since global records are now handled through null values.  

- **View `costs/index.blade.php`:**  
  - Updated edit and delete button conditions to use `is_null($cost->locality_id)` instead of comparing to zero.  

#### **Benefits:**  
This change improves referential integrity and provides a clearer, more scalable way to manage global data across the water management system.