### PR TITLE
fix: update MembershipsTableSeeder to handle existing records with zero values

### DIFF
--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -42,16 +42,31 @@ class MembershipsTableSeeder extends Seeder
             ]
         ];
 
-        foreach ($memberships as $membership) {
-            DB::table('memberships')->insert([
-                'name' => $membership['name'],
-                'price' => $membership['price'],
-                'term_months' => $membership['term_months'],
-                'water_connections_number' => $membership['water_connections_number'],
-                'users_number' => $membership['users_number'],
-                'created_at' => now(),
+        DB::table('memberships')
+            ->where('water_connections_number', 0)
+            ->orWhere('users_number', 0)
+            ->update([
+                'water_connections_number' => 1000,
+                'users_number' => 1,
                 'updated_at' => now(),
             ]);
+
+        foreach ($memberships as $membership) {
+            $existing = DB::table('memberships')
+                ->where('name', $membership['name'])
+                ->first();
+            
+            if (!$existing) {
+                DB::table('memberships')->insert([
+                    'name' => $membership['name'],
+                    'price' => $membership['price'],
+                    'term_months' => $membership['term_months'],
+                    'water_connections_number' => $membership['water_connections_number'],
+                    'users_number' => $membership['users_number'],
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
         }
     }
 }


### PR DESCRIPTION
- Update existing records with water_connections_number = 0 or users_number = 0
- Set default values for missing fields
- Insert new membership plans only if they don't exist