### PR TITLE
Fix/update reports horizontal background

### DIFF
--- a/resources/views/localities/editPdfBackground.blade.php
+++ b/resources/views/localities/editPdfBackground.blade.php
@@ -32,7 +32,7 @@
                             </div>
                             <div class="card-body text-center">
                                 <img id="preview-horizontal-{{ $locality->id }}"
-                                    src="{{ $locality->getFirstMediaUrl('pdfBackgroundHorizontal') ?: asset('img/customersBackground.png') }}"
+                                    src="{{ $locality->getFirstMediaUrl('pdfBackgroundHorizontal') ?: asset('img/customersBackgroundHorizontal.png') }}"
                                     alt="Fondo Horizontal" style="width: 280px; height: 200px; border-radius: 10px; margin-bottom: 10px;">
                                 <input type="file" accept="image/*" name="pdf_background_horizontal"
                                     class="form-control" onchange="previewImageEdit(event, 'horizontal', {{ $locality->id }})">
@@ -74,6 +74,6 @@ function previewImageEdit(event, type, id) {
 function resetForm(id) {
     document.getElementById('edit-locality-form-' + id).reset();
     document.getElementById('preview-vertical-' + id).src = "{{ asset('img/backgroundReport.png') }}";
-    document.getElementById('preview-horizontal-' + id).src = "{{ asset('img/customersBackground.png') }}";
+    document.getElementById('preview-horizontal-' + id).src = "{{ asset('img/customersBackgroundHorizontal.png') }}";
 }
 </script>

--- a/resources/views/reports/advancePaymentsHistory.blade.php
+++ b/resources/views/reports/advancePaymentsHistory.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/advancedPayments.blade.php
+++ b/resources/views/reports/advancedPayments.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/annualEarnings.blade.php
+++ b/resources/views/reports/annualEarnings.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/annualExpenses.blade.php
+++ b/resources/views/reports/annualExpenses.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/annualGains.blade.php
+++ b/resources/views/reports/annualGains.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/clientPayments.blade.php
+++ b/resources/views/reports/clientPayments.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="en">

--- a/resources/views/reports/customersWithDebts.blade.php
+++ b/resources/views/reports/customersWithDebts.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/generateCostListReport.blade.php
+++ b/resources/views/reports/generateCostListReport.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/generateEmployeeListReport.blade.php
+++ b/resources/views/reports/generateEmployeeListReport.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html>

--- a/resources/views/reports/generateIncidentCategoyListReport.blade.php
+++ b/resources/views/reports/generateIncidentCategoyListReport.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/generateIncidentListReport.blade.php
+++ b/resources/views/reports/generateIncidentListReport.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/generateIncidentStatusListReport.blade.php
+++ b/resources/views/reports/generateIncidentStatusListReport.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/paymentHistoryReport.blade.php
+++ b/resources/views/reports/paymentHistoryReport.blade.php
@@ -7,7 +7,7 @@
 
     $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
         ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-        : public_path('img/customersBackground.png');
+        : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/pdfCashClosures.blade.php
+++ b/resources/views/reports/pdfCashClosures.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/pdfCustomers.blade.php
+++ b/resources/views/reports/pdfCustomers.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html>

--- a/resources/views/reports/pdfCustomersSummary.blade.php
+++ b/resources/views/reports/pdfCustomersSummary.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html>

--- a/resources/views/reports/pdfInventory.blade.php
+++ b/resources/views/reports/pdfInventory.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/reportCurrentCustomers.blade.php
+++ b/resources/views/reports/reportCurrentCustomers.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/waterConnectionPayments.blade.php
+++ b/resources/views/reports/waterConnectionPayments.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="en">

--- a/resources/views/reports/weeklyEarnings.blade.php
+++ b/resources/views/reports/weeklyEarnings.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/weeklyExpenses.blade.php
+++ b/resources/views/reports/weeklyExpenses.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">

--- a/resources/views/reports/weeklyGains.blade.php
+++ b/resources/views/reports/weeklyGains.blade.php
@@ -6,7 +6,7 @@ $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
 
 $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
     ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackground.png');
+    : public_path('img/customersBackgroundHorizontal.png');
 @endphp
 <!DOCTYPE html>
 <html lang="es">


### PR DESCRIPTION
This update replaces the default horizontal background image used in all PDF reports.
The previous reference to img/customersBackground.png was replaced with the correct version img/customersBackgroundHorizontal.png.

With this change, when a locality does not have a custom horizontal background configured, reports will correctly display the horizontal layout image instead of the generic one.

Additionally, the same adjustment was applied to the Edit PDF Background view to ensure consistency between the preview and the report background behavior.