### PR TITLE
Fix employee report filtering and remove unused expense type button

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -128,7 +128,11 @@ class EmployeeController extends Controller
     public function generateEmployeeListReport()
     {
         $authUser = auth()->user();
-        $employees = Employee::all();
+        
+        $employees = Employee::where('locality_id', $authUser->locality_id)
+            ->orderBy('created_at', 'desc')
+            ->get();
+        
         $pdf = PDF::loadView('reports.generateEmployeeListReport', compact('employees', 'authUser'))
             ->setPaper('A4', 'landscape');
 

--- a/resources/views/expenseTypes/index.blade.php
+++ b/resources/views/expenseTypes/index.blade.php
@@ -18,13 +18,6 @@
                                     <span class="d-none d-md-inline">Registrar Tipo</span>
                                     <span class="d-inline d-md-none">Tipo</span>
                                 </button>
-                                <a type="button" class="btn btn-secondary flex-grow-1 flex-md-grow-0 mt-2 ml-1"
-                                target="_blank" title="Generar Lista"
-                                href="#">
-                                    <i class="fas fa-file-pdf"></i>
-                                    <span class="d-none d-md-inline">Generar Lista</span>
-                                    <span class="d-inline d-md-none">Lista PDF</span>
-                                </a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Changes Made:

### Employee Controller
- **Fixed**: generateEmployeeListReport() method now properly filters employees by user's locality
- **Before**: Employee::all() returned all employees regardless of locality
- **After**: Added locality filter: Employee::where('locality_id', ->locality_id)->orderBy('created_at', 'desc')->get()
- **Impact**: PDF report now only shows employees from the authenticated user's locality

### Expense Types View
- **Removed**: Unused 'Generate List' button from expense types section
- **Location**: Lines 21-27 in 
esources/views/expenseTypes/index.blade.php
- **Reason**: Button was non-functional (href='#') and had no backend implementation
- **UI Cleanup**: Improved interface by removing confusing placeholder element

## Technical Details:
- Employee report now maintains data consistency with main employee list
- Removed dead code and unused UI elements
- No breaking changes introduced