### PR TITLE
Addition of General Sections and Locality Filter Enhancements in the Water Connections System

### DIFF
--- a/app/Http/Controllers/SectionController.php
+++ b/app/Http/Controllers/SectionController.php
@@ -13,6 +13,7 @@ class SectionController extends Controller
     {
         $authUser = auth()->user();
         $query = Section::where('sections.locality_id', $authUser->locality_id)
+            ->orWhereNull('locality_id')
             ->orderBy('sections.created_at', 'desc')
             ->select('sections.*');
 
@@ -118,6 +119,7 @@ class SectionController extends Controller
     
         $section = Section::where('id', $sectionId)
             ->where('locality_id', $authUser->locality_id) 
+            ->orWhereNull('locality_id')
             ->with(['waterConnections.customer', 'waterConnections.cost', 'locality']) 
             ->firstOrFail();
     

--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -41,7 +41,9 @@ class WaterConnectionController extends Controller
         $costs = Cost::where('locality_id', $authUser->locality_id)
                      ->orWhereNull('locality_id')
                      ->get();
-        $sections = Section::where('locality_id', $authUser->locality_id)->get();
+        $sections = Section::where('locality_id', $authUser->locality_id)
+                     ->orWhereNull('locality_id')
+                     ->get();
 
         return view('waterConnections.index', compact('connections', 'customers', 'costs', 'sections'));
     }
@@ -83,14 +85,18 @@ class WaterConnectionController extends Controller
     public function show($id)
     {
         $connections = WaterConnection::findOrFail($id);
-        $sections = Section::where('locality_id', $connection->locality_id)->get();
+        $sections = Section::where('locality_id', $connection->locality_id)
+                    ->orWhereNull('locality_id')
+                    ->get();
         return view('waterConnections.show', compact('connections', 'sections'));
     }
 
     public function update(Request $request, $id)
     {
         $connection = WaterConnection::find($id);
-        $sections = Section::where('locality_id', $connection->locality_id)->get(); 
+        $sections = Section::where('locality_id', $connection->locality_id)
+                    ->orWhereNull('locality_id')
+                    ->get(); 
 
         if (!$connection) {
             return redirect()->back()->with('error', 'Toma de Agua no encontrada.');

--- a/database/migrations/2025_10_28_202453_make_locality_id_nullable_in_sections.php
+++ b/database/migrations/2025_10_28_202453_make_locality_id_nullable_in_sections.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        DB::statement('ALTER TABLE sections MODIFY locality_id BIGINT UNSIGNED NULL');
+    }
+
+    public function down()
+    {
+        DB::statement('UPDATE sections SET locality_id = 1 WHERE locality_id IS NULL');
+
+        DB::statement('ALTER TABLE sections MODIFY locality_id BIGINT UNSIGNED NOT NULL');
+    }
+};

--- a/database/seeders/SectionsSeeder.php
+++ b/database/seeders/SectionsSeeder.php
@@ -12,6 +12,19 @@ class SectionsSeeder extends Seeder
     {
         $colors = ['purple', 'maroon', 'orange', 'lime', 'navy', 'olive', 'secondary'];
 
+        Section::updateOrCreate(
+            [
+                'locality_id' => null,
+                'name' => 'Sección General',
+            ],
+            [
+                'created_by' => 1,
+                'zip_code' => '00010',
+                'color' => $colors[0],
+                'updated_at' => now(),
+            ]
+        );
+
         $localities = Locality::all(); 
 
         foreach ($localities as $locality) {

--- a/resources/views/sections/index.blade.php
+++ b/resources/views/sections/index.blade.php
@@ -74,6 +74,7 @@
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
                                                         @endcan
+                                                        @if (!is_null($section->locality_id))
                                                         @can('editSections')
                                                             <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Sección" data-target="#edit{{ $section->id }}">
                                                                 <i class="fas fa-edit"></i>
@@ -87,6 +88,7 @@
                                                                 <i class="fas fa-trash-alt"></i>
                                                             </button>
                                                         @endcan
+                                                        @endif
                                                     </div>
                                                     @include('sections.create')
                                                     @include('sections.show')


### PR DESCRIPTION
### 📝 **Description:**  
This update introduces support for **global sections (without a specific locality)** in the water connections system, allowing certain records to be accessible from any locality.  

The changes include:  
- Updates in the `SectionController` and `WaterConnectionController` to include records with a null `locality_id` (`orWhereNull('locality_id')`) in listings and specific queries.  
- Automatic creation of a **“General Section”** in the `SectionsSeeder`, serving as a default and shared section across all localities.  
- Adjustments in the `sections/index.blade.php` view to **restrict editing and deletion** of global sections to maintain data integrity.  

With these modifications, the system now supports **shared configurations and sections** across all localities, improving flexibility and reducing data duplication.