### PR TITLE
Update roles and permissions for fault report client

### DIFF
--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -174,11 +174,11 @@ class RolesAndPermissionsSeeder extends Seeder
         Permission::firstOrCreate([
             'name' => 'editFaultReport',
             'description' => 'Permite editar el reporte de fallas.'
-        ])->assignRole([$roleSupervisor, $roleCliente]);
+        ])->assignRole([$roleSupervisor]);
         Permission::firstOrCreate([
             'name' => 'deleteFaultReport',
             'description' => 'Permite eliminar el reporte de fallas.'
-        ])->assignRole([$roleSupervisor, $roleCliente]);
+        ])->assignRole([$roleSupervisor]);
         Permission::firstOrCreate([ 
             'name' => 'viewNotice',
             'description' => 'Permite ver los Avisos de Localidades.'
@@ -214,6 +214,14 @@ class RolesAndPermissionsSeeder extends Seeder
         Permission::firstOrCreate([
             'name' => 'createCustomerFaultReports',
             'description' => 'Permite crear nuevos reportes de fallas.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
+            'name' => 'editFaultReports',
+            'description' => 'El cliente permite editar el reporte de fallas.'
+        ])->assignRole([$roleCliente]);
+        Permission::firstOrCreate([
+            'name' => 'deleteFaultReports',
+            'description' => 'El cliente permite eliminar el reporte de fallas.'
         ])->assignRole([$roleCliente]);
         Permission::firstOrCreate([
             'name' => 'viewInventory',


### PR DESCRIPTION
### Changes Made
- Updated role assignments in the `RolesAndPermissionsSeeder`.  
- Now only **supervisors** can **edit** and **delete** general fault reports.  
- Added new permissions allowing **clients** to:
  - Edit their own fault reports.  
  - Delete their own fault reports.  

### Motivation
These changes improve access control within the fault report module by clearly separating supervisor and client permissions, ensuring better security and consistency.

### Expected Result
- Supervisors retain full control over all reports.  
- Clients can only modify or delete the reports they created.