### PR TITLE
Fix: Resolve notices variable error and merge conflicts in Dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -71,6 +71,13 @@ class DashboardController extends Controller
         return $debt->amount - $debt->debt_current;
         });
 
+        $notices = \App\Models\LocalityNotice::with(['creator', 'locality'])
+            ->where('locality_id', $authUser->locality_id)
+            ->where('is_active', true)
+            ->where('end_date', '>=', now())
+            ->orderBy('created_at', 'desc')
+            ->get();
+
         $data = [
             'customersByLocality' => $customersByLocality,
             'customersWithDebts' => $customersWithDebts,

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -187,10 +187,6 @@
                                     <a href="{{ route('viewCustomerDebts.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
                                 </div>
                             </div>
-<<<<<<< HEAD
-=======
-
->>>>>>> 9aa44b9d2a131d1404153117fc55b0fc43de6bd5
                             <div class="col-lg-4 col-xs-12">
                                 <div class="small-box bg-info">
                                     <div class="inner">
@@ -203,11 +199,7 @@
                                     <a href="{{ route('viewCustomerWaterConnections.index') }}" class="small-box-footer">Más información <i class="fa fa-arrow-circle-right"></i></a>
                                 </div>
                             </div>
-<<<<<<< HEAD
                             
-=======
-
->>>>>>> 9aa44b9d2a131d1404153117fc55b0fc43de6bd5
                             <div class="col-lg-4 col-xs-12">
                                 <div class="small-box bg-danger">
                                     <div class="inner">
@@ -261,10 +253,7 @@
                             </div>
                             </div>
                         </div>
-<<<<<<< HEAD
                     </div>
-=======
->>>>>>> 9aa44b9d2a131d1404153117fc55b0fc43de6bd5
                     @endcan
                     @can('viewDashboardCards')
                     <div class="card">


### PR DESCRIPTION
## 📋 Summary
This PR fixes a critical error in the Dashboard that prevented proper display of notices and removes residual merge conflicts in the view.

## 🚨 Issues Solved
- **ErrorException**: Undefined variable `$notices` in `DashboardController`
- **Git Conflicts**: Residual markers (`<<<<<<< HEAD`, `=======`, `>>>>>>>`) in `dashboard.blade.php`
- **Broken functionality**: Notices section wasn't displaying due to undefined variable

## 🔧 Changes Made

### `app/Http/Controllers/DashboardController.php`
```php
// Added query to fetch notices
$notices = \App\Models\LocalityNotice::with(['creator', 'locality'])
    ->where('locality_id', $authUser->locality_id)
    ->where('is_active', true)
    ->where('end_date', '>=', now())
    ->orderBy('created_at', 'desc')
    ->get();