### PR TITLE
Add image dimension and size validation for report backgrounds 

### DIFF
--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -138,44 +138,12 @@ class LocalityController extends Controller
             return redirect()->back()->with('error', 'Localidad no encontrada.');
         }
 
-        $maxVertical = ['width' => 1600, 'height' => 2000];
-        $maxHorizontal = ['width' => 2000, 'height' => 1600];
-        $maxFileSize = 2 * 1024 * 1024;
-
         if ($request->hasFile('pdf_background_vertical')) {
-            $file = $request->file('pdf_background_vertical');
-
-            if ($file->getSize() > $maxFileSize) {
-                return redirect()->back()->with('error', 'El fondo vertical no debe exceder los 2 MB.');
-            }
-
-            $size = getimagesize($file);
-            $width = $size[0];
-            $height = $size[1];
-
-            if ($width > $maxVertical['width'] || $height > $maxVertical['height']) {
-                return redirect()->back()->with('error', "El fondo vertical no debe exceder los {$maxVertical['width']}x{$maxVertical['height']} píxeles. Imagen cargada: {$width}x{$height}px");
-            }
-
             $locality->clearMediaCollection('pdfBackgroundVertical');
             $locality->addMediaFromRequest('pdf_background_vertical')->toMediaCollection('pdfBackgroundVertical');
         }
 
         if ($request->hasFile('pdf_background_horizontal')) {
-            $file = $request->file('pdf_background_horizontal');
-
-            if ($file->getSize() > $maxFileSize) {
-                return redirect()->back()->with('error', 'El fondo horizontal no debe exceder los 2 MB.');
-            }
-
-            $size = getimagesize($file);
-            $width = $size[0];
-            $height = $size[1];
-
-            if ($width > $maxHorizontal['width'] || $height > $maxHorizontal['height']) {
-                return redirect()->back()->with('error', "El fondo horizontal no debe exceder los {$maxHorizontal['width']}x{$maxHorizontal['height']} píxeles. Imagen cargada: {$width}x{$height}px");
-            }
-
             $locality->clearMediaCollection('pdfBackgroundHorizontal');
             $locality->addMediaFromRequest('pdf_background_horizontal')->toMediaCollection('pdfBackgroundHorizontal');
         }

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -182,5 +182,4 @@ class LocalityController extends Controller
 
         return redirect()->route('localities.index')->with('success', 'Fondos de reportes actualizados correctamente.');
     }
-
 }

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -138,16 +138,49 @@ class LocalityController extends Controller
             return redirect()->back()->with('error', 'Localidad no encontrada.');
         }
 
+        $maxVertical = ['width' => 1600, 'height' => 2000];
+        $maxHorizontal = ['width' => 2000, 'height' => 1600];
+        $maxFileSize = 2 * 1024 * 1024;
+
         if ($request->hasFile('pdf_background_vertical')) {
+            $file = $request->file('pdf_background_vertical');
+
+            if ($file->getSize() > $maxFileSize) {
+                return redirect()->back()->with('error', 'El fondo vertical no debe exceder los 2 MB.');
+            }
+
+            $size = getimagesize($file);
+            $width = $size[0];
+            $height = $size[1];
+
+            if ($width > $maxVertical['width'] || $height > $maxVertical['height']) {
+                return redirect()->back()->with('error', "El fondo vertical no debe exceder los {$maxVertical['width']}x{$maxVertical['height']} píxeles. Imagen cargada: {$width}x{$height}px");
+            }
+
             $locality->clearMediaCollection('pdfBackgroundVertical');
             $locality->addMediaFromRequest('pdf_background_vertical')->toMediaCollection('pdfBackgroundVertical');
         }
 
         if ($request->hasFile('pdf_background_horizontal')) {
+            $file = $request->file('pdf_background_horizontal');
+
+            if ($file->getSize() > $maxFileSize) {
+                return redirect()->back()->with('error', 'El fondo horizontal no debe exceder los 2 MB.');
+            }
+
+            $size = getimagesize($file);
+            $width = $size[0];
+            $height = $size[1];
+
+            if ($width > $maxHorizontal['width'] || $height > $maxHorizontal['height']) {
+                return redirect()->back()->with('error', "El fondo horizontal no debe exceder los {$maxHorizontal['width']}x{$maxHorizontal['height']} píxeles. Imagen cargada: {$width}x{$height}px");
+            }
+
             $locality->clearMediaCollection('pdfBackgroundHorizontal');
             $locality->addMediaFromRequest('pdf_background_horizontal')->toMediaCollection('pdfBackgroundHorizontal');
         }
 
         return redirect()->route('localities.index')->with('success', 'Fondos de reportes actualizados correctamente.');
     }
+
 }

--- a/resources/views/localities/editLogo.blade.php
+++ b/resources/views/localities/editLogo.blade.php
@@ -1,7 +1,7 @@
 <div class="modal fade" id="editLogo{{ $locality->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
-            <div class="card-warning">
+            <div class="card-primary">
                 <div class="card-header">
                     <div class="d-sm-flex align-items-center justify-content-between">
                         <h4 class="card-title">Editar Logo de Localidad <small> &nbsp;(*) Campos requeridos</small></h4>
@@ -39,7 +39,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="resetForm({{ $locality->id }})">Cancelar</button>
-                        <button type="submit" class="btn btn-warning">Actualizar</button>
+                        <button type="submit" class="btn btn-primary">Actualizar</button>
                     </div>
                 </form>
             </div>

--- a/resources/views/localities/editPdfBackground.blade.php
+++ b/resources/views/localities/editPdfBackground.blade.php
@@ -15,7 +15,9 @@
                         <div class="card mb-3">
                             <div class="card-header py-2 bg-secondary">
                                 <h3 class="card-title">Fondo Reporte Vertical</h3><br>
-                                <small class="text-light">Formato sugerido</small>
+                                <small class="text-light">Formato sugerido: 2MB<br>
+                            Dimensión recomendada: No mayor a 1600 x 2000
+                                </small>
                             </div>
                             <div class="card-body text-center">
                                 <img id="preview-vertical-{{ $locality->id }}"
@@ -28,7 +30,9 @@
                         <div class="card">
                             <div class="card-header py-2 bg-secondary">
                                 <h3 class="card-title">Fondo Reporte Horizontal </h3><br>
-                                <small class="text-light">Formato sugerido</small>
+                                <small class="text-light">Formato sugerido: 2MB<br>
+                            Dimensión recomendada: No mayor a 2000 x 1600
+                                </small>
                             </div>
                             <div class="card-body text-center">
                                 <img id="preview-horizontal-{{ $locality->id }}"

--- a/resources/views/localities/editPdfBackground.blade.php
+++ b/resources/views/localities/editPdfBackground.blade.php
@@ -15,8 +15,8 @@
                         <div class="card mb-3">
                             <div class="card-header py-2 bg-secondary">
                                 <h3 class="card-title">Fondo Reporte Vertical</h3><br>
-                                <small class="text-light">Formato sugerido: 2MB<br>
-                            Dimensión recomendada: No mayor a 1600 x 2000
+                                <small class="text-light">Peso máximo: 2MB<br>
+                            Dimensiones máximas: No mayor a 1600 x 2000
                                 </small>
                             </div>
                             <div class="card-body text-center">
@@ -30,8 +30,8 @@
                         <div class="card">
                             <div class="card-header py-2 bg-secondary">
                                 <h3 class="card-title">Fondo Reporte Horizontal </h3><br>
-                                <small class="text-light">Formato sugerido: 2MB<br>
-                            Dimensión recomendada: No mayor a 2000 x 1600
+                                <small class="text-light">Peso máximo: 2MB<br>
+                            Dimensiones máximas: No mayor a 2000 x 1600
                                 </small>
                             </div>
                             <div class="card-body text-center">
@@ -54,23 +54,73 @@
 </div>
 <script>
 function previewImageEdit(event, type, id) {
-    var input = event.target;
-    var file = input.files[0];
-    var reader = new FileReader();
+    const input = event.target;
+    const file = input.files[0];
+
+    if (!file) return;
+
+    const maxSize = 2 * 1024 * 1024;
+    const maxVertical = { width: 1600, height: 2000 };
+    const maxHorizontal = { width: 2000, height: 1600 };
 
     if (!file.type.startsWith('image/')) {
         Swal.fire({
             icon: 'error',
-            title: 'Error',
-            text: 'Por favor, sube un archivo de imagen',
+            title: 'Archivo no válido',
+            text: 'Por favor, sube un archivo de imagen (JPG, PNG, etc.)',
             confirmButtonText: 'Aceptar'
         });
         input.value = '';
         return;
     }
 
-    reader.onload = function() {
-        document.getElementById('preview-' + type + '-' + id).src = reader.result;
+    if (file.size > maxSize) {
+        Swal.fire({
+            icon: 'error',
+            title: 'Tamaño excedido',
+            text: 'El archivo no debe superar los 2 MB.',
+            confirmButtonText: 'Aceptar'
+        });
+        input.value = '';
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        const img = new Image();
+        img.onload = function() {
+            const width = img.width;
+            const height = img.height;
+
+            if (type === 'vertical') {
+                if (width > maxVertical.width || height > maxVertical.height) {
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Dimensiones inválidas',
+                        text: `El fondo vertical no debe exceder ${maxVertical.width}x${maxVertical.height}px. Imagen cargada: ${width}x${height}px.`,
+                        confirmButtonText: 'Aceptar'
+                    });
+                    input.value = '';
+                    return;
+                }
+            }
+
+            if (type === 'horizontal') {
+                if (width > maxHorizontal.width || height > maxHorizontal.height) {
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Dimensiones inválidas',
+                        text: `El fondo horizontal no debe exceder ${maxHorizontal.width}x${maxHorizontal.height}px. Imagen cargada: ${width}x${height}px.`,
+                        confirmButtonText: 'Aceptar'
+                    });
+                    input.value = '';
+                    return;
+                }
+            }
+
+            document.getElementById('preview-' + type + '-' + id).src = e.target.result;
+        };
+        img.src = e.target.result;
     };
     reader.readAsDataURL(file);
 }

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -106,7 +106,7 @@
                                                         </td>
                                                         <td>
                                                             {{ str_replace(['am', 'pm'], ['a.m.', 'p.m.'], \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('DD[/]MMMM[/]YYYY hh:mm:ss a')) }}
-                                                        </td>                                         
+                                                        </td>
                                                         <td>${{ number_format($payment->amount, 2) }}</td>
                                                         <td>
                                                             <div class="btn-group" payment="group" aria-label="Opciones">

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -105,8 +105,8 @@
                                                             | Deuda: ${{ number_format($payment->debt->amount, 2) }}
                                                         </td>
                                                         <td>
-                                                            {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('DD [/] MMMM [/] YYYY HH:mm:ss')}}
-                                                        </td>
+                                                            {{ str_replace(['am', 'pm'], ['a.m.', 'p.m.'], \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('DD[/]MMMM[/]YYYY hh:mm:ss a')) }}
+                                                        </td>                                         
                                                         <td>${{ number_format($payment->amount, 2) }}</td>
                                                         <td>
                                                             <div class="btn-group" payment="group" aria-label="Opciones">

--- a/resources/views/reports/advancePaymentGraphReport.blade.php
+++ b/resources/views/reports/advancePaymentGraphReport.blade.php
@@ -1,3 +1,13 @@
+@php
+$locality = Auth::user()->locality ?? null;
+$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+    : public_path('img/backgroundReport.png');
+
+$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
+    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
+    : public_path('img/customersBackgroundHorizontal.png');
+@endphp
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -12,7 +22,7 @@
             }
 
             body{
-                background-image: url('img/backgroundReport.png');
+                background-image: url('file://{{ $verticalBgPath }}');
                 background-size: cover;
                 background-position: center;
                 background-repeat: no-repeat;


### PR DESCRIPTION
## Changes Made

- Added validations for report backgrounds in **`LocalityController`**:
  - Maximum file size: **2 MB** per image.  
  - Maximum dimensions:
    - **Vertical:** 1600 × 2000 pixels.  
    - **Horizontal:** 2000 × 1600 pixels.  
- Updated views to display the **recommended size and dimensions**.  
- Improved the **date format display** in payments (`payments/index.blade.php`) to show “**a.m.**” / “**p.m.**” 
- In **`advancePaymentGraphReport.blade.php`**, added support to **dynamically load vertical and horizontal backgrounds** based on the authenticated user's locality.  


##  Result

Improves the **validation**, **consistency**, and **customization** of PDF report backgrounds according to the user's locality.
