### PR TITLE
Remove state column from customer view

### DIFF
--- a/resources/views/customers/index.blade.php
+++ b/resources/views/customers/index.blade.php
@@ -67,14 +67,13 @@
                                             <th>FOTO</th>
                                             <th>NOMBRE</th>
                                             <th>DIRECCION</th>
-                                            <th>ESTADO</th>
                                             <th>OPCIONES</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         @if(count($customers) <= 0)
                                         <tr>
-                                            <td colspan="7">No hay resultados</td>
+                                            <td colspan="5">No hay resultados</td>
                                         </tr>
                                         @else
                                         @foreach($customers as $customer)
@@ -91,19 +90,6 @@
                                             </td>
                                             <td>{{$customer->name}} {{$customer->last_name}}</td>
                                             <td>{{$customer->state}}, {{$customer->locality}}</td>
-                                            <td>
-                                                @switch($customer->status)
-                                                    @case(0)
-                                                        Fallecido
-                                                        @break
-                                                    @case(1)
-                                                        Con Vida
-                                                        @break
-                                                    @default
-                                                        Desconocido
-                                                        @break
-                                                @endswitch
-                                            </td>
                                             <td>
                                                 <div class="btn-group" role="group" aria-label="Opciones">
                                                     <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{$customer->id}}">


### PR DESCRIPTION
File Modified
resources/views/customers/index.blade.php

Changes Implemented
1. Table Structure Update
Removed the "ESTADO" (Status) column from the table header

Adjusted the colspan from 7 to 5 in the "No results" message to reflect the reduced number of columns

2. Data Removal
Completely eliminated the status display logic for each customer record

Removed the entire table cell that contained the customer status information (Deceased/Alive/Unknown)

3. Final Result
The table now displays 5 columns instead of 6

Customer status information is no longer visible in the main listing view

All other functionalities remain fully intact:

Action buttons (view, edit, water connections, debts, delete)

Search functionality

Pagination

PDF generation features

The interface is now cleaner and more focused on essential customer information

These changes streamline the main view by removing redundant status information while preserving all existing system functionality and maintaining data integrity.