### PR TITLE
Add Global Incident Status Support and Improve Status Ordering.

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -32,7 +32,10 @@ class IncidentController extends Controller
         })->get();
 
         $employees = Employee::where('locality_id', $authUser->locality_id)->get();
-        $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)->get();
+        $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)
+                  ->orWhereNull('locality_id')
+                  ->orderBy('created_at', 'desc')
+                  ->get();
 
         return view('incidents.index', compact('incidents', 'categories', 'employees', 'statuses'));
     }

--- a/app/Http/Controllers/IncidentStatusController.php
+++ b/app/Http/Controllers/IncidentStatusController.php
@@ -13,7 +13,10 @@ class IncidentStatusController extends Controller
     {
         $authUser = auth()->user();
 
-        $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)->paginate(10);
+        $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)
+                    ->orWhereNull('locality_id')
+                    ->orderBy('created_at', 'desc')
+                    ->paginate(10);
 
         return view('incidentStatuses.index', compact('statuses'));
     }
@@ -72,7 +75,10 @@ class IncidentStatusController extends Controller
     public function generateIncidentStatusListReport()
     {
         $authUser = auth()->user();
-        $incidentStatus = IncidentStatus::where('locality_id', $authUser->locality_id)->get();
+        $incidentStatus = IncidentStatus::where('locality_id', $authUser->locality_id)
+                          ->orWhereNull('locality_id')
+                          ->orderBy('created_at', 'desc')
+                          ->get();
         $pdf = PDF::loadView('reports.generateIncidentStatusListReport', compact('incidentStatus', 'authUser'))
             ->setPaper('A4', 'portrait');
 

--- a/database/migrations/2025_11_18_135946_make_locality_id_nullable_in_incident_statuses_table.php
+++ b/database/migrations/2025_11_18_135946_make_locality_id_nullable_in_incident_statuses_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        DB::statement('ALTER TABLE incident_statuses MODIFY locality_id BIGINT UNSIGNED NULL');
+    }
+
+    public function down()
+    {
+        DB::statement('UPDATE incident_statuses SET locality_id = 1 WHERE locality_id IS NULL');
+        DB::statement('ALTER TABLE incident_statuses MODIFY locality_id BIGINT UNSIGNED NOT NULL');
+    }
+};

--- a/database/seeders/IncidentStatusSeeder.php
+++ b/database/seeders/IncidentStatusSeeder.php
@@ -11,6 +11,13 @@ class IncidentStatusSeeder extends Seeder
     {
         $statuses = [
             [
+                'status' => 'Reportada',
+                'description' => 'Incidencia registrada y en espera de ser evaluada o asignada para su atención.',
+                'color' => '#7900be', 
+                'created_by' => 3,
+                'locality_id' => null,
+            ],
+            [
                 'status' => 'Pendiente',
                 'description' => 'Incidencia en proceso de ser atendida',
                 'color' => '#e74c3c', 

--- a/resources/views/incidentStatuses/index.blade.php
+++ b/resources/views/incidentStatuses/index.blade.php
@@ -58,6 +58,7 @@
                                                         <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#viewIncidentStatus{{ $status->id }}">
                                                             <i class="fas fa-eye"></i>
                                                         </button>
+                                                        @if (!is_null($status->locality_id))
                                                         @can('editIncidentStatuses')
                                                         <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#editIncidentStatus{{ $status->id }}">
                                                             <i class="fas fa-edit"></i>
@@ -69,6 +70,7 @@
                                                         <i class="fas fa-trash-alt"></i>
                                                         </button>
                                                         @endcan
+                                                        @endif
                                                     </div>
                                                 </td>
                                             </tr>


### PR DESCRIPTION
## Description
This PR introduces support for **global incident statuses** by including records with a `null` `locality_id` across listings, reports, and status selection. It also enhances consistency by applying a unified descending `created_at` ordering to all queries.

### Key Improvements
- Updated controllers (`IncidentController`, `IncidentStatusController`) to:
  - Include statuses where `locality_id` is `null`.
  - Apply `orderBy('created_at', 'desc')` consistently.
- Updated report generation to display both local and global statuses.
- Added a new global status **"Reportada"** in the seeder.
- Improved view logic to:
  - Restrict edit/delete actions to statuses belonging to the current locality.
  - Prevent modifications to global statuses.

These changes improve maintainability, ensure consistent status display, and enable system-wide default incident statuses.