### PR TITLE
Update cash closure PDF to display the full name of the user generating the report.

### DIFF
--- a/resources/views/reports/pdfCashClosures.blade.php
+++ b/resources/views/reports/pdfCashClosures.blade.php
@@ -157,7 +157,7 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
         <div class="fecha_hora">
             <strong>Fecha de cierre:</strong> {{ now()->format('d/m/Y') }} <br>
             <strong>Hora de cierre:</strong> {{ now()->format('h:i:s A') }} <br>
-            <strong>Generado por:</strong> {{ $authUser->name ?? '-' }}
+            <strong>Generado por:</strong> {{ $authUser->name . ' ' . $authUser->last_name }}
         </div>
 
         <div class="section">


### PR DESCRIPTION
### Description of Changes

This update modifies the **pdfCashClosures.blade.php** view so that the cash closure report now displays the **full name** of the user generating the document.

Previously, only the `name` field was shown, which could be incomplete. The update now concatenates `name` + `last_name`, providing a clearer and more accurate identification of the report's responsible user.

###  Improvement Included
- Display the user's full name in the **"Generated by:"** field within the cash closure PDF.