### PR TITLE
Fix down() method in change_status_in_incidents_table migration

### DIFF
--- a/database/migrations/2025_09_22_181633_change_status_in_incidents_table.php
+++ b/database/migrations/2025_09_22_181633_change_status_in_incidents_table.php
@@ -44,16 +44,22 @@ return new class extends Migration
     {
         Schema::table('incidents', function (Blueprint $table) {
             $table->string('status')->nullable();
-
-            DB::table('incidents')->get()->each(function ($incident) {
-                $statusName = DB::table('incident_statuses')->where('id', $incident->status_id)->value('status');
-
-                if ($statusName) {
-                    DB::table('incidents')->where('id', $incident->id)->update(['status' => $statusName]);
-                }
-            });
-
             $table->dropForeign(['status_id']);
+        });
+
+        DB::table('incidents')->get()->each(function ($incident) {
+            $statusName = DB::table('incident_statuses')
+                ->where('id', $incident->status_id)
+                ->value('status');
+
+            if ($statusName) {
+                DB::table('incidents')
+                    ->where('id', $incident->id)
+                    ->update(['status' => $statusName]);
+            }
+        });
+
+        Schema::table('incidents', function (Blueprint $table) {
             $table->dropColumn('status_id');
         });
     }


### PR DESCRIPTION
### Summary
This update fixes the `down()` method in the `change_status_in_incidents_table` migration, which previously caused rollback failures due to column order issues and the use of database queries inside a `Schema::table()` closure.

### What was changed
- Re-added the `status` column before attempting to restore its values.
- Moved all `DB::table()` operations *outside* of the `Schema::table()` closure.
- Properly restored the original data from `status_id` back into the `status` field.
- Dropped the foreign key and the `status_id` column in a clean and valid sequence.

### Why this change was necessary
The previous implementation triggered errors during `php artisan migrate:reset`, specifically:


This happened because the `status` column had already been dropped in a later migration, yet the rollback attempted to update it before recreating it.

### Result
Migration rollbacks now execute correctly, preventing column-not-found and invalid schema operation errors.
