### PR TITLE
Improved Locality-Based Ordering and Menu Restructuring.

### DIFF
--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -15,11 +15,8 @@ class CostController extends Controller
                 $q->where('locality_id', $authUser->locality_id)
                     ->orWhereNull('locality_id');
             })
-            ->whereHas('creator', function ($query) use ($authUser) {
-                $query->where('locality_id', $authUser->locality_id);
-            
-            })
             ->with('creator')
+            ->orderByRaw('locality_id IS NULL DESC')
             ->orderBy('created_at', 'desc')
             ->paginate(10);
         
@@ -75,6 +72,7 @@ class CostController extends Controller
         $authUser = auth()->user();
         $costs = cost::where('locality_id', $authUser->locality_id)
                     ->orWhereNull('locality_id')
+                    ->orderByRaw('locality_id IS NULL DESC')
                     ->orderBy('created_at', 'desc')
                     ->get();
         

--- a/app/Http/Controllers/ExpenseTypeController.php
+++ b/app/Http/Controllers/ExpenseTypeController.php
@@ -13,7 +13,8 @@ class ExpenseTypeController extends Controller
     {
     $expenseTypes = ExpenseType::byUserLocality()
         ->with(['creator', 'locality'])
-        ->orderBy('name')
+        ->orderByRaw('locality_id IS NULL DESC')
+        ->orderBy('created_at', 'desc')
         ->paginate(10); 
 
     return view('expenseTypes.index', compact('expenseTypes'));

--- a/app/Http/Controllers/IncidentCategoriesController.php
+++ b/app/Http/Controllers/IncidentCategoriesController.php
@@ -15,6 +15,7 @@ class IncidentCategoriesController extends Controller
             $query->where('locality_id', $authUser->locality_id)
                 ->orWhereNull('locality_id');
         })
+            ->orderByRaw('locality_id IS NULL DESC')
             ->orderBy('created_at', 'desc')
             ->paginate(10);
 

--- a/app/Http/Controllers/IncidentStatusController.php
+++ b/app/Http/Controllers/IncidentStatusController.php
@@ -15,6 +15,7 @@ class IncidentStatusController extends Controller
 
         $statuses = IncidentStatus::where('locality_id', $authUser->locality_id)
                     ->orWhereNull('locality_id')
+                    ->orderByRaw('locality_id IS NULL DESC')
                     ->orderBy('created_at', 'desc')
                     ->paginate(10);
 

--- a/app/Http/Controllers/SectionController.php
+++ b/app/Http/Controllers/SectionController.php
@@ -14,6 +14,7 @@ class SectionController extends Controller
         $authUser = auth()->user();
         $query = Section::where('sections.locality_id', $authUser->locality_id)
             ->orWhereNull('locality_id')
+            ->orderByRaw('locality_id IS NULL DESC')
             ->orderBy('sections.created_at', 'desc')
             ->select('sections.*');
 

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -312,24 +312,6 @@ return [
         'icon' => 'fas fa-fw fa-home',
     ], 
     [
-        'text' => 'Usuarios',
-        'url' => '/users',
-        'icon' => 'fas fa-fw fa-user',
-        'can'  => 'viewUser'
-    ],
-    [
-        'text' => 'Roles',
-        'url' => '/roles',
-        'icon' => 'fas fa-fw fa-user-shield',
-        'can'  => 'viewRoles'
-    ],
-    [
-        'text' => 'Clientes',
-        'url' => '/customers',
-        'icon' => 'fas fa-fw fa-users',
-        'can'  => 'viewCustomers'
-    ],
-    [
         'text' => 'Gestión de Pagos',
         'icon' => 'fas fa-fw fa-dollar-sign',
         'submenu' => [
@@ -346,12 +328,6 @@ return [
                 'can'  => 'viewAdvancePayments',
             ],
         ],
-    ],
-    [
-        'text' => 'Deudas',
-        'url' => '/debts',
-        'icon' => 'fas fa-fw fa-credit-card',
-        'can'  => 'viewDebts'
     ],
     [
         'text' => 'Gestión de Tomas de Agua',
@@ -376,12 +352,6 @@ return [
                 'can'  => 'viewSections'
             ],   
         ],
-    ],
-    [
-        'text' => 'Localidades',
-        'url' => '/localities',
-        'icon' => 'fas fa-fw fa-map-marker-alt',
-        'can'  => 'viewLocality'
     ],
     [
         'text' => 'Gestión de Gastos',
@@ -426,23 +396,6 @@ return [
         ],
     ],
     [
-        'text' => 'Empleados',
-        'url' => '/employees',
-        'icon' => 'fas fa-fw fa-users',
-        'can' => 'viewEmployee'
-    ],
-    [
-        'text' => 'Membresías',
-        'url' => '/memberships',
-        'icon' => 'fas fa-fw fa-id-card',
-        'can' => 'viewMemberships'
-    ],
-    [
-        'text' => 'Falta de pago',
-        'url'  => '/expiredSubscriptions/expired',
-        'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
-    ],
-    [
         'text' => 'Gestion de Inventario',
         'icon' => 'fas fa-fw fa-warehouse',
         'submenu' => [
@@ -459,6 +412,53 @@ return [
                 'can'  => 'viewInventoryCategories',
             ],
         ],
+    ],
+    [
+        'text' => 'Usuarios',
+        'url' => '/users',
+        'icon' => 'fas fa-fw fa-user',
+        'can'  => 'viewUser'
+    ],
+    [
+        'text' => 'Roles',
+        'url' => '/roles',
+        'icon' => 'fas fa-fw fa-user-shield',
+        'can'  => 'viewRoles'
+    ],
+    [
+        'text' => 'Clientes',
+        'url' => '/customers',
+        'icon' => 'fas fa-fw fa-users',
+        'can'  => 'viewCustomers'
+    ],
+    [
+        'text' => 'Deudas',
+        'url' => '/debts',
+        'icon' => 'fas fa-fw fa-credit-card',
+        'can'  => 'viewDebts'
+    ],
+    [
+        'text' => 'Localidades',
+        'url' => '/localities',
+        'icon' => 'fas fa-fw fa-map-marker-alt',
+        'can'  => 'viewLocality'
+    ],
+    [
+        'text' => 'Empleados',
+        'url' => '/employees',
+        'icon' => 'fas fa-fw fa-users',
+        'can' => 'viewEmployee'
+    ],
+    [
+        'text' => 'Membresías',
+        'url' => '/memberships',
+        'icon' => 'fas fa-fw fa-id-card',
+        'can' => 'viewMemberships'
+    ],
+    [
+        'text' => 'Falta de pago',
+        'url'  => '/expiredSubscriptions/expired',
+        'icon' => 'fas fa-fw fa-exclamation-circle text-warning',
     ],
     [
         'text' => 'Mis Pagos',
@@ -488,7 +488,7 @@ return [
         'text' => 'Avisos',
         'url' => '/localityNotices',
         'can' => 'viewNotice',
-        'icon' => 'fas fa-fw fa-bell text-white',
+        'icon' => 'fas fa-fw fa-bell',
     ],
     [
         'text' => 'Reporte de fallas',

--- a/resources/views/incidentCategories/index.blade.php
+++ b/resources/views/incidentCategories/index.blade.php
@@ -63,7 +63,7 @@
                                                             <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $category->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
-                                                            @if ($category->name !== 'Mantenimiento General')
+                                                            @if (!is_null($category->locality_id))
                                                                 @can('editIncidentCategories')
                                                                     <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $category->id }}">
                                                                         <i class="fas fa-edit"></i>


### PR DESCRIPTION
## **Description**
This PR introduces enhancements to how records are ordered and displayed based on the user’s locality, while also reorganizing menu elements to maintain a clearer and more consistent structure:

- Added `orderByRaw('locality_id IS NULL DESC')` to multiple controllers to ensure locality-specific records are displayed before global ones.
- Removed a redundant condition in `CostController` related to creator-based filtering.
- Standardized ordering by creation date (`created_at`) across various modules.
- Updated views to ensure editing is only allowed for records associated with a specific locality.
- Restructured the menu in `adminlte.php`, relocating Users, Roles, Customers, Debts, Localities, Employees, Memberships, and Overdue Payments to a more logical position without altering permissions.
- Corrected the icon for the Notices module.

These changes improve consistency across the system, enhance the user experience, and ensure proper prioritization of locality-based records.