### PR TITLE
Creation of Migration and Model for Movement History

### DIFF
--- a/app/Models/MovementHistory.php
+++ b/app/Models/MovementHistory.php
@@ -14,7 +14,6 @@ class MovementHistory extends Model
         'module',
         'action',
         'record_id',
-        'created_by',
         'before_data',
         'current_data',
     ];

--- a/app/Models/MovementHistory.php
+++ b/app/Models/MovementHistory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MovementHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'alter_by',
+        'module',
+        'action',
+        'record_id',
+        'created_by',
+        'before_data',
+        'current_data',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'before_data' => 'array',
+        'current_data' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'alter_by');
+    }
+}

--- a/database/migrations/2025_11_24_113123_create_movements_history_table.php
+++ b/database/migrations/2025_11_24_113123_create_movements_history_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMovementsHistoryTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('movements_history', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('alter_by');
+            $table->timestamps();
+            $table->string('module');
+            $table->string('action');
+            $table->json('record_id');
+            $table->json('before_data');
+            $table->json('current_data')->nullable();
+
+            $table->foreign('alter_by')->references('id')->on('users')->onDelete('cascade');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('movements_history');
+    }
+}

--- a/database/migrations/2025_11_24_113123_create_movements_history_table.php
+++ b/database/migrations/2025_11_24_113123_create_movements_history_table.php
@@ -19,7 +19,7 @@ class CreateMovementsHistoryTable extends Migration
             $table->timestamps();
             $table->string('module');
             $table->string('action');
-            $table->json('record_id');
+            $table->unsignedBigInteger('record_id');
             $table->json('before_data');
             $table->json('current_data')->nullable();
 


### PR DESCRIPTION
This PR adds the migration and model needed to store movement history logs.

**Migration Fields**

- The new table includes:
- id
- alter_by
- date
- module
- action
- record_id (JSON)
- before_data (JSON)
- current_data (JSON, nullable)

**Files New**

- app/Models/MovementHistory.php
- database/migrations/2025_11_24_113123_create_movements_history_table.php