### PR TITLE
Remove unused Auth import from PaymentController

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Facades\Auth;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Crypt;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Auth;
 
 class PaymentController extends Controller {
     public function index(Request $request) {


### PR DESCRIPTION
🎯 Purpose of Change

Resolve naming conflict: Eliminate duplicate or conflicting Auth class import

Code cleanup: Remove unused imports to maintain cleaner and more efficient code

Error prevention: Avoid the fatal error Cannot use Illuminate\Support\Facades\Auth as Auth because the name is already in use