### PR TITLE
Fix rollback by cleaning NULL customers before applying NOT NULL

### DIFF
--- a/database/migrations/2025_10_31_124827_modify_nullable_columns_in_customers_table.php
+++ b/database/migrations/2025_10_31_124827_modify_nullable_columns_in_customers_table.php
@@ -25,6 +25,10 @@ class ModifyNullableColumnsInCustomersTable extends Migration
      */
     public function down()
     {
+        DB::table('customers')->whereNull('name')->update(['name' => 'Sin nombre']);
+        DB::table('customers')->whereNull('last_name')->update(['last_name' => 'Sin apellido']);
+        DB::table('customers')->whereNull('email')->update(['email' => 'no-email@example.com']);
+
         DB::statement('ALTER TABLE customers MODIFY name VARCHAR(255) NOT NULL');
         DB::statement('ALTER TABLE customers MODIFY last_name VARCHAR(255) NOT NULL');
         DB::statement('ALTER TABLE customers MODIFY email VARCHAR(255) NOT NULL');


### PR DESCRIPTION
Fix rollback error by cleaning NULL values before restoring NOT NULL

## Description

This PR fixes a rollback issue caused by NULL values when restoring NOT NULL constraints in the `customers` table.

### Problem
Rollback failed because some rows had NULL values in:
- name
- last_name
- email

This caused MySQL to throw an error when applying NOT NULL constraints.

### Solution
NULL values are now replaced with safe default values before restoring NOT NULL:
- name → "Sin nombre"
- last_name → "Sin apellido"
- email → "no-email@example.com"

### Impact
Prevents rollback failure  
Improves database integrity  
No functional impact on the application
