### PR TITLE
Add responsible selection dropdown to history modal

### DIFF
--- a/resources/views/localities/historyModal.blade.php
+++ b/resources/views/localities/historyModal.blade.php
@@ -24,6 +24,17 @@
                         </select>
                     </div>
                     <div class="form-group"> 
+                        <label for="responsible_{{ $locality->id }}">Responsable</label>
+                        <select name="responsible_id" id="responsible_{{ $locality->id }}" class="form-control">
+                            <option value="">Todos los Responsables</option>
+                             @foreach($locality->users()->distinct()->get() as $user)
+                                @if($user->hasAnyRole(['Supervisor', 'Secretaria']))
+                                    <option value="{{ $user->id }}">{{ $user->name }}</option>
+                                @endif
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="form-group"> 
                         <label for="start_date_{{ $locality->id }}">Fecha Inicio</label>
                         <input type="date" name="start_date" id="start_date_{{ $locality->id }}" class="form-control">
                     </div>


### PR DESCRIPTION
### Overview

This PR introduces a new select dropdown in the history modal to allow choosing a responsible user when viewing or generating the movement history.

### Changes Included

- Added a responsible selection inside the history modal UI.
- Updated the modal layout to properly align the new field.
- Ensured the responsible value is sent correctly to the controller.

### Files Modified

- app/Http/Controllers/MovementHistoryController.php
- resources/views/localities/historyModal.blade.php
