### PR TITLE
Relocate report includes inside the content section

### DIFF
--- a/resources/views/viewCustomerPayments/index.blade.php
+++ b/resources/views/viewCustomerPayments/index.blade.php
@@ -121,9 +121,9 @@
         </div>
     </div>
 </section>
-@endsection
 @include('viewCustomerPayments.quarterly-report')
 @include('viewCustomerPayments.annualReportTemplate')
+@endsection
 
 @section('js')
 <script>


### PR DESCRIPTION
### Relocate report includes inside the content section

The `quarterly-report` and `annualReportTemplate` includes were moved before the `@endsection` to ensure they load correctly within the `content` section and to avoid layout structure issues in AdminLTE. This adjustment also allows the tab logo to display properly.
