### PR TITLE
GeneralExpensesSeeder Changes 

### DIFF
--- a/database/seeders/GeneralExpensesSeeder.php
+++ b/database/seeders/GeneralExpensesSeeder.php
@@ -10,59 +10,11 @@ class GeneralExpensesSeeder extends Seeder
 {
     public function run()
     {
-        $faker = Faker::create();
+        $faker = Faker::create('es_MX');
         
-        $this->fixExistingExpensesWithoutType();
+        DB::table('general_expenses')->truncate();
         
         $this->createNewExpensesWithType($faker);
-    }
-
-    private function fixExistingExpensesWithoutType()
-    {
-        $expensesWithoutType = DB::table('general_expenses')
-            ->whereNull('expense_type_id')
-            ->get();
-
-        foreach ($expensesWithoutType as $expense) {
-            $expenseType = DB::table('expense_types')
-                ->where('locality_id', $expense->locality_id)
-                ->first();
-
-            if ($expenseType) {
-                DB::table('general_expenses')
-                    ->where('id', $expense->id)
-                    ->update([
-                        'expense_type_id' => $expenseType->id,
-                        'updated_at' => now()
-                    ]);
-            } else {
-                $existingGeneralType = DB::table('expense_types')
-                    ->where('locality_id', $expense->locality_id)
-                    ->where('name', 'Gastos Generales')
-                    ->first();
-
-                if ($existingGeneralType) {
-                    $expenseTypeId = $existingGeneralType->id;
-                } else {
-                    $expenseTypeId = DB::table('expense_types')->insertGetId([
-                        'name' => 'Gastos Generales',
-                        'description' => 'Gastos varios de operación',
-                        'color' => '#95a5a6',
-                        'locality_id' => $expense->locality_id,
-                        'created_by' => $expense->created_by ?? 1,
-                        'created_at' => now(),
-                        'updated_at' => now(),
-                    ]);
-                }
-
-                DB::table('general_expenses')
-                    ->where('id', $expense->id)
-                    ->update([
-                        'expense_type_id' => $expenseTypeId,
-                        'updated_at' => now()
-                    ]);
-            }
-        }
     }
 
     private function createNewExpensesWithType($faker)
@@ -73,7 +25,40 @@ class GeneralExpensesSeeder extends Seeder
             return;
         }
 
+        $concepts = [
+            'Mantenimiento de Equipos',
+            'Material de Oficina',
+            'Pago de Luz',
+            'Servicio de Internet',
+            'Combustible',
+            'Limpieza',
+            'Papelería',
+            'Herramientas',
+            'Transporte',
+            'Agua'
+        ];
+
+        $descriptions = [
+            'Pago del servicio mensual',
+            'Compra de materiales necesarios',
+            'Mantenimiento preventivo realizado',
+            'Factura del periodo correspondiente',
+            'Adquisición de herramientas',
+            'Servicio contratado para el mes',
+            'Insumos para operaciones diarias',
+            'Reparación de equipo dañado',
+            'Pago correspondiente al mes actual',
+            'Material administrativo'
+        ];
+
+        $recordsToCreate = 5;
+        $recordsCreated = 0;
+        
         foreach ($localities as $locality) {
+            if ($recordsCreated >= $recordsToCreate) {
+                break;
+            }
+            
             $users = DB::table('users')
                 ->where('locality_id', $locality->id)
                 ->pluck('id')
@@ -91,22 +76,26 @@ class GeneralExpensesSeeder extends Seeder
                 continue;
             }
 
-            $numberOfExpenses = rand(3, 5);
+            $expenseTypesArray = $expenseTypes->toArray();
+            $remaining = $recordsToCreate - $recordsCreated;
+            $createForThis = min(2, $remaining);
             
-            for ($i = 0; $i < $numberOfExpenses; $i++) {
-                $expenseType = $faker->randomElement($expenseTypes->toArray());
+            for ($i = 0; $i < $createForThis; $i++) {
+                $expenseType = $faker->randomElement($expenseTypesArray);
                 
                 DB::table('general_expenses')->insert([
                     'locality_id' => $locality->id,
                     'created_by' => $faker->randomElement($users),
-                    'expense_type_id' => $expenseType->id, 
-                    'concept' => $faker->word(),
-                    'description' => $faker->sentence(),
+                    'expense_type_id' => $expenseType->id,
+                    'concept' => $concepts[array_rand($concepts)],
+                    'description' => $descriptions[array_rand($descriptions)],
                     'amount' => mt_rand(10, 50) * 100,
                     'expense_date' => $faker->dateTimeBetween('-60 days', 'now'),
                     'created_at' => now(),
                     'updated_at' => now(),
                 ]);
+                
+                $recordsCreated++;
             }
         }
     }


### PR DESCRIPTION
✅ Changes Made:
1. Data Language
Before: $faker = Faker::create(); (default English)

After: $faker = Faker::create('es_MX'); (Mexican Spanish)

2. Clean Old Records
Before: Kept existing English records

After: DB::table('general_expenses')->truncate(); (deletes all before creating)

3. Removed Unnecessary Logic
Deleted: Complete fixExistingExpensesWithoutType() method

Reason: No longer needed because we delete all records

4. Record Quantity Control
Before: rand(3, 5) per locality (variable, could be many)

After: Exactly 5 total records only

5. Guaranteed Spanish Data
Before: $faker->word() and $faker->sentence() (generated English/Latin)

After: Predefined arrays in Spanish:

$concepts: 10 concepts in Spanish

$descriptions: 10 descriptions in Spanish

6. Smart Distribution
System: Distributes 5 records among available localities

Logic: Maximum 2 records per locality, until reaching 5 total

