### PR TITLE
fix: add dependency check for deletion

### DIFF
--- a/app/Models/Membership.php
+++ b/app/Models/Membership.php
@@ -12,7 +12,7 @@ class Membership extends Model
 
     protected $fillable = [
         'created_by',
-        'name', 
+        'name',
         'price',
         'term_months',
         'water_connections_number',
@@ -22,5 +22,15 @@ class Membership extends Model
     public function creator()
     {
         return $this->belongsTo(User::class, 'created_by');
+    }
+    
+    public function localities()
+    {
+        return $this->hasMany(Locality::class, 'membership_id');
+    }
+
+    public function hasDependencies()
+    {
+        return $this->localities()->exists();
     }
 }

--- a/resources/views/memberships/index.blade.php
+++ b/resources/views/memberships/index.blade.php
@@ -79,11 +79,18 @@
                                                                 </button>
                                                                 @endcan
                                                                 @can('deleteMemberships')
-                                                                <button type="button" class="btn btn-danger mr-2"
-                                                                    data-toggle="modal" title="Eliminar Registro"
-                                                                    data-target="#delete{{$membership->id}}">
-                                                                    <i class="fas fa-trash-alt"></i>
-                                                                </button>
+                                                                    @if($membership->hasDependencies())
+                                                                        <button type="button" class="btn btn-secondary mr-2" 
+                                                                                data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
+                                                                            <i class="fas fa-trash-alt"></i>
+                                                                        </button>
+                                                                    @else
+                                                                        <button type="button" class="btn btn-danger mr-2"
+                                                                                data-toggle="modal" title="Eliminar Registro"
+                                                                                data-target="#delete{{$membership->id}}">
+                                                                            <i class="fas fa-trash-alt"></i>
+                                                                        </button>
+                                                                    @endif
                                                                 @endcan
                                                             </div>
                                                         </td>


### PR DESCRIPTION
## 📋 Description
Implemented validation to prevent deletion of memberships that have associated localities, improving database referential integrity.

## 🛠️ Changes Made
1. **Membership Model**:
   - Added `hasDependencies()` method that checks for related localities
   - Implemented `localities()` relationship to query dependencies

2. **Memberships View**:
   - Updated delete button to show two states:
     - 🔴 **Enabled red button**: No associated localities (allows deletion)
     - ⚫ **Disabled gray button**: With associated localities (shows informative tooltip)

## 📸 Preview
**Before:** All delete buttons were red and functional
**After:**
- ✅ No dependencies: Functional red button
- ⚠️ With dependencies: Disabled gray button with informative message

## 🧪 Impact
- Improves data integrity
- Prevents unintended cascade deletion errors
- Guides users on why certain records cannot be deleted

## 🔗 Related
- Consistent with behavior already implemented in other sections (sections, localities)