### PR TITLE
Remove customer field from fault report table and improve role-based filtering

### DIFF
--- a/app/Http/Controllers/CustomerFaultReportController.php
+++ b/app/Http/Controllers/CustomerFaultReportController.php
@@ -12,7 +12,7 @@ class CustomerFaultReportController extends Controller
     {
         $authUser = Auth::user();
 
-        $query = FaultReport::where('customer_id', $authUser->id)
+        $query = FaultReport::where('created_by', $authUser->id)
             ->orderBy('created_at', 'desc');
 
         if ($request->has('search')) {
@@ -48,7 +48,7 @@ class CustomerFaultReportController extends Controller
         $report->description = $request->description;
         $report->status = 'Earring';
         $report->date_report = now();
-        $report->customer_id = Auth::id();
+        $report->locality_id = Auth::user()->locality_id;
         $report->created_by = Auth::id();
         $report->save();
 
@@ -58,24 +58,25 @@ class CustomerFaultReportController extends Controller
 
     public function show($id)
     {
-        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+        $report = FaultReport::where('created_by', Auth::id())->findOrFail($id);
         return view('customerFaultReports.show', compact('report'));
     }
 
     public function edit($id)
     {
-        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+        $report = FaultReport::where('created_by', Auth::id())->findOrFail($id);
         return view('customerFaultReports.edit', compact('report'));
     }
 
     public function update(Request $request, $id)
     {
-        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
+        $report = FaultReport::where('created_by', Auth::id())->findOrFail($id);
 
         $report->update([
             'title' => $request->input('titleUpdate'),
             'description' => $request->input('descriptionUpdate'),
             'date_report' => $request->input('dateReportUpdate'),
+            'updated_at' => now(),
         ]);
 
         return redirect()->route('customerFaultReports.index')
@@ -84,9 +85,10 @@ class CustomerFaultReportController extends Controller
 
     public function destroy($id)
     {
-        $report = FaultReport::where('customer_id', Auth::id())->findOrFail($id);
-        $report->delete();
-
+        $report = FaultReport::where('created_by', Auth::id())->findOrFail($id);
+        $report->delete([
+            'deleted_at' => now(),
+        ]);
         return redirect()->route('customerFaultReports.index')
             ->with('success', 'Reporte de falla eliminado correctamente.');
     }

--- a/app/Models/FaultReport.php
+++ b/app/Models/FaultReport.php
@@ -15,7 +15,6 @@ class FaultReport extends Model implements HasMedia
     protected $table = 'fault_report';
 
     protected $fillable = [
-        'customer_id',
         'created_by',
         'locality_id',
         'title',
@@ -38,8 +37,4 @@ class FaultReport extends Model implements HasMedia
         return $this->belongsTo(User::class, 'created_by');
     }
 
-    public function customer()
-    {
-        return $this->belongsTo(User::class, 'customer_id');
-    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,6 +18,11 @@ class User extends Authenticatable implements HasMedia
 {
     use HasApiTokens, HasFactory, Notifiable, InteractsWithMedia, SoftDeletes, HasRoles;
 
+    const ROLE_ADMIN = 'Admin';
+    const ROLE_SECRETARY = 'Secretaria';
+    const ROLE_SUPERVISOR = 'Supervisor';
+    const ROLE_CUSTOMER = 'Cliente';
+
     /**
      * The attributes that are mass assignable.
      *

--- a/database/migrations/2026_01_12_122140_remove_customer_id_from_fault_report_table.php
+++ b/database/migrations/2026_01_12_122140_remove_customer_id_from_fault_report_table.php
@@ -29,7 +29,6 @@ class RemoveCustomerIdFromFaultReportTable extends Migration
         Schema::table('fault_report', function (Blueprint $table) {
             $table->unsignedBigInteger('customer_id')->nullable();
             $table->foreign('customer_id')->references('id')->on('users')->onDelete('set null');
-        });
-      
+        }); 
     }
 }

--- a/database/migrations/2026_01_12_122140_remove_customer_id_from_fault_report_table.php
+++ b/database/migrations/2026_01_12_122140_remove_customer_id_from_fault_report_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveCustomerIdFromFaultReportTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('fault_report', function (Blueprint $table) {
+            $table->dropForeign(['customer_id']);
+            $table->dropColumn('customer_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+      //
+    }
+}

--- a/database/migrations/2026_01_12_122140_remove_customer_id_from_fault_report_table.php
+++ b/database/migrations/2026_01_12_122140_remove_customer_id_from_fault_report_table.php
@@ -26,6 +26,10 @@ class RemoveCustomerIdFromFaultReportTable extends Migration
      */
     public function down()
     {
-      //
+        Schema::table('fault_report', function (Blueprint $table) {
+            $table->unsignedBigInteger('customer_id')->nullable();
+            $table->foreign('customer_id')->references('id')->on('users')->onDelete('set null');
+        });
+      
     }
 }

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Factory as Faker;
+use App\Models\User;
 
 class FaultReportSeeder extends Seeder
 {
@@ -13,12 +14,17 @@ class FaultReportSeeder extends Seeder
         $faker = Faker::create('es_MX');
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
-        $userIds = DB::table('users')->pluck('id')->toArray();
+        $userIds = DB::table('users')
+        ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+            ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+            ->where('roles.name', User::ROLE_CUSTOMER)
+            ->distinct()
+            ->pluck('users.id')
+            ->toArray();
         $statuses = ['Earring', 'In process', 'Resolved', 'Closed'];
 
         foreach (range(1, 20) as $i) {
-            DB::table('fault_report')->insert([
-                'customer_id'   => $faker->numberBetween(1, 10), 
+            DB::table('fault_report')->insert([ 
                 'created_by'    => $faker->randomElement($userIds),  
                 'locality_id'   => $faker->randomElement($localityIds),
                 'title'         => $faker->randomElement([


### PR DESCRIPTION
## 🧾 Description

This PR introduces a new migration to remove the `customer` field from the `fault_report` table.

Additionally, role constants were added to the `User` model to improve role-based filtering.  
With these changes:
- Customers can only see their own fault reports
- Supervisors can only see fault reports related to customers within their locality

This ensures better data isolation and correct access control across roles.

---

## 📂 Files Changed

- app/Http/Controllers/CustomerFaultReportController.php
- app/Models/FaultReport.php
- app/Models/User.php
- database/seeders/FaultReportSeeder.php
- database/migrations/2026_01_12_122140_remove_customer_field_from_fault_reports_table.php

