### PR TITLE
Fix seeder queries to prevent records from mixing between localities

### DIFF
--- a/database/seeders/CustomersTableSeeder.php
+++ b/database/seeders/CustomersTableSeeder.php
@@ -21,7 +21,7 @@ class CustomersTableSeeder extends Seeder
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
 
-        foreach (range(1, 20) as $index) {
+        foreach (range(1, 150) as $index) {
             $locality_id = $faker->randomElement($localityIds);
 
             $userIds = DB::table('users')

--- a/database/seeders/CustomersTableSeeder.php
+++ b/database/seeders/CustomersTableSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Factory as Faker;
 use App\Models\Customer;
+use App\Models\User;
 
 class CustomersTableSeeder extends Seeder
 {
@@ -19,9 +20,19 @@ class CustomersTableSeeder extends Seeder
         $faker = Faker::create();
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
-        $userIds = DB::table('users')->pluck('id')->toArray();
 
-        foreach (range(1, 150) as $index) {
+        foreach (range(1, 20) as $index) {
+            $locality_id = $faker->randomElement($localityIds);
+
+            $userIds = DB::table('users')
+                ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+                ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+                ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+                ->where('users.locality_id', $locality_id)
+                ->distinct()
+                ->pluck('users.id')
+                ->toArray();
+
             $status = $faker->boolean;
             $responsibleName = $status ? null : $faker->name;
 
@@ -39,7 +50,7 @@ class CustomersTableSeeder extends Seeder
                 'marital_status' => $faker->boolean,
                 'status' => $status,
                 'responsible_name' => $responsibleName,
-                'locality_id' => $faker->randomElement($localityIds),
+                'locality_id' => $locality_id,
                 'created_by' => $faker->randomElement($userIds),
             ]);
         }

--- a/database/seeders/EmployeesTableSeeder.php
+++ b/database/seeders/EmployeesTableSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Factory as Faker;
+use App\Models\User;
 
 class EmployeesTableSeeder extends Seeder
 {
@@ -18,11 +19,21 @@ class EmployeesTableSeeder extends Seeder
         $faker = Faker::create();
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
-        $userIds = DB::table('users')->pluck('id')->toArray();
         
-        $roles = ['Administrador', 'Recepcionista','Encargado','Seguridad'];
-
         foreach (range(1, 20) as $index) {
+            $locality_id = $faker->randomElement($localityIds);
+
+            $userIds = DB::table('users')
+                ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+                ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+                ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+                ->where('users.locality_id', $locality_id)
+                ->distinct()
+                ->pluck('users.id')
+                ->toArray();
+
+            $roles = ['Administrador', 'Recepcionista','Encargado','Seguridad'];
+        
             DB::table('employees')->insert([
                 'name' => $faker->firstName,
                 'last_name' => $faker->lastName,
@@ -37,7 +48,7 @@ class EmployeesTableSeeder extends Seeder
                 'street' => $faker->streetName,
                 'exterior_number' => $faker->numberBetween(1, 100),
                 'interior_number' => $faker->numberBetween(1, 100),
-                'locality_id' => $faker->randomElement($localityIds),
+                'locality_id' => $locality_id,
                 'created_by' => $faker->randomElement($userIds),
                 'created_at' => now(),
                 'updated_at' => now(),

--- a/database/seeders/ExpenseTypeSeeder.php
+++ b/database/seeders/ExpenseTypeSeeder.php
@@ -65,6 +65,18 @@ class ExpenseTypeSeeder extends Seeder
         ];
 
         foreach ($localities as $localityId) {
+            
+            $validUsers = User::where('locality_id', $localityId)
+                ->whereHas('roles', function ($q) {
+                    $q->whereIn('name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY]);
+                })
+                ->pluck('id')
+                ->toArray();
+
+            if (empty($validUsers)) {
+                continue;
+            }
+
             foreach ($baseTypes as $type) {
                 ExpenseType::updateOrCreate(
                     [
@@ -74,7 +86,7 @@ class ExpenseTypeSeeder extends Seeder
                     [
                         'description' => $type['description'],
                         'color' => $type['color'],
-                        'created_by' => $userId,
+                        'created_by' => collect($validUsers)->random(),
                         'created_at' => now(),
                         'updated_at' => now(),
                     ]

--- a/database/seeders/GeneralExpensesSeeder.php
+++ b/database/seeders/GeneralExpensesSeeder.php
@@ -5,6 +5,7 @@ use App\Models\GeneralExpense;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Factory as Faker;
+use App\Models\User;
 
 class GeneralExpensesSeeder extends Seeder
 {
@@ -60,8 +61,12 @@ class GeneralExpensesSeeder extends Seeder
             }
             
             $users = DB::table('users')
-                ->where('locality_id', $locality->id)
-                ->pluck('id')
+                ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+                ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+                ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+                ->where('users.locality_id', $locality->id)
+                ->distinct()
+                ->pluck('users.id')
                 ->toArray();
 
             if (empty($users)) {

--- a/database/seeders/LocalityNoticesSeeder.php
+++ b/database/seeders/LocalityNoticesSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Factory as Faker;
 use Carbon\Carbon;
+use App\Models\User;
 
 class LocalityNoticesSeeder extends Seeder
 {
@@ -17,51 +18,63 @@ class LocalityNoticesSeeder extends Seeder
         $faker = Faker::create('es_MX');
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
-        $userIds = DB::table('users')->pluck('id')->toArray();
 
-        foreach ($localityIds as $localityId) {
-            foreach (range(1, 2) as $i) {
-                $startDate = $faker->dateTimeBetween('-1 month', '+1 month');
-                $endDate = Carbon::instance($startDate)->addDays($faker->numberBetween(1, 7));
+        foreach (range(1, 150) as $index) {
+            $locality_id = $faker->randomElement($localityIds);
+
+            $userIds = DB::table('users')
+                ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+                ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+                ->where('roles.name', User::ROLE_SUPERVISOR)
+                ->where('users.locality_id', $locality_id)
+                ->distinct()
+                ->pluck('users.id')
+                ->toArray();
+
+            if (!empty($userIds)) {
+                foreach (range(1, 2) as $i) {
+                    $startDate = $faker->dateTimeBetween('-1 month', '+1 month');
+                    $endDate = Carbon::instance($startDate)->addDays($faker->numberBetween(1, 7));
                 
-                DB::table('locality_notices')->insert([
-                    'title' => $faker->randomElement([
-                        'Corte programado de agua potable',
-                        'Interrupción del servicio eléctrico',
-                        'Recolección especial de poda y escombros',
-                        'Jornada de vacunación antirrábica gratuita',
-                        'Inicio de obras de repavimentación',
-                        'Feria artesanal en la Plaza Principal',
-                        'Campaña de descacharrado contra el dengue',
-                        'Limpieza intensiva de calles',
-                        'Taller gratuito de compostaje doméstico',
-                        'vencimiento de tasa municipal',
-                        'Mejoras en el alumbrado público',
-                        'Corte de tránsito por evento cultural'
-                    ]),
-                    'description' => $faker->randomElement([
-                        'Por mantenimiento en la red principal se suspenderá el suministro de agua el día ' . $startDate->format('d/m/Y') . ' de 08:00 a 16:00 hs.',
-                        'La empresa eléctrica realizará trabajos de mejora. Corte programado el ' . $startDate->format('d/m/Y') . ' entre las 09:00 y 14:00 hs.',
-                        'El próximo ' . $startDate->format('d/m/Y') . ' recolectaremos ramas, muebles viejos y escombros. Depositar en la vereda la noche anterior.',
-                        'Vacuna antirrábica gratuita para perros y gatos el ' . $startDate->format('d/m/Y') . ' de 09:00 a 13:00 hs en la Plaza Principal.',
-                        'A partir del ' . $startDate->format('d/m/Y') . ' comenzamos la repavimentación de Av. Principal. Duración estimada: 10 días.',
-                        'Te invitamos a la feria de artesanos y productores locales el ' . $startDate->format('d/m/Y') . ' desde las 10:00 hs. ¡Entrada libre!',
-                        'Para prevenir el dengue, recolectaremos recipientes en desuso el ' . $startDate->format('d/m/Y') . '. Sacar todo antes de las 08:00 hs.',
-                        'El ' . $startDate->format('d/m/Y') . ' realizaremos hidrolavado y desinfección de calles. No estacionar de 07:00 a 14:00 hs.',
-                        'Taller práctico de compostaje en casa el ' . $startDate->format('d/m/Y') . ' a las 18:00 hs en el Centro Cultural. Cupo limitado.',
-                        'Recordamos que el ' . $startDate->format('d/m/Y') . ' vence la cuota municipal. Pague online o en el municipio y evite recargos.',
-                        'Estamos instalando nuevas luminarias LED en todo el barrio. Trabajos nocturnos durante esta semana.',
-                        'Por el festival cultural habrá corte total de tránsito en el centro el ' . $startDate->format('d/m/Y') . ' de 18:00 a 00:00 hs.'
-                    ]),
-                    'start_date' => $startDate,
-                    'end_date' => $endDate,
-                    'is_active' => $faker->boolean(80),
-                    'locality_id' => $localityId,
-                    'created_by' => $faker->randomElement($userIds),
-                    'attachment_url' => null,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
+                    DB::table('locality_notices')->insert([
+                        'title' => $faker->randomElement([
+                            'Corte programado de agua potable',
+                            'Interrupción del servicio eléctrico',
+                            'Recolección especial de poda y escombros',
+                            'Jornada de vacunación antirrábica gratuita',
+                            'Inicio de obras de repavimentación',
+                            'Feria artesanal en la Plaza Principal',
+                            'Campaña de descacharrado contra el dengue',
+                            'Limpieza intensiva de calles',
+                            'Taller gratuito de compostaje doméstico',
+                            'vencimiento de tasa municipal',
+                            'Mejoras en el alumbrado público',
+                            'Corte de tránsito por evento cultural'
+                        ]),
+                        'description' => $faker->randomElement([
+                            'Por mantenimiento en la red principal se suspenderá el suministro de agua el día ' . $startDate->format('d/m/Y') . ' de 08:00 a 16:00 hs.',
+                            'La empresa eléctrica realizará trabajos de mejora. Corte programado el ' . $startDate->format('d/m/Y') . ' entre las 09:00 y 14:00 hs.',
+                            'El próximo ' . $startDate->format('d/m/Y') . ' recolectaremos ramas, muebles viejos y escombros. Depositar en la vereda la noche anterior.',
+                            'Vacuna antirrábica gratuita para perros y gatos el ' . $startDate->format('d/m/Y') . ' de 09:00 a 13:00 hs en la Plaza Principal.',
+                            'A partir del ' . $startDate->format('d/m/Y') . ' comenzamos la repavimentación de Av. Principal. Duración estimada: 10 días.',
+                            'Te invitamos a la feria de artesanos y productores locales el ' . $startDate->format('d/m/Y') . ' desde las 10:00 hs. ¡Entrada libre!',
+                            'Para prevenir el dengue, recolectaremos recipientes en desuso el ' . $startDate->format('d/m/Y') . '. Sacar todo antes de las 08:00 hs.',
+                            'El ' . $startDate->format('d/m/Y') . ' realizaremos hidrolavado y desinfección de calles. No estacionar de 07:00 a 14:00 hs.',
+                            'Taller práctico de compostaje en casa el ' . $startDate->format('d/m/Y') . ' a las 18:00 hs en el Centro Cultural. Cupo limitado.',
+                            'Recordamos que el ' . $startDate->format('d/m/Y') . ' vence la cuota municipal. Pague online o en el municipio y evite recargos.',
+                            'Estamos instalando nuevas luminarias LED en todo el barrio. Trabajos nocturnos durante esta semana.',
+                            'Por el festival cultural habrá corte total de tránsito en el centro el ' . $startDate->format('d/m/Y') . ' de 18:00 a 00:00 hs.'
+                        ]),
+                        'start_date' => $startDate,
+                        'end_date' => $endDate,
+                        'is_active' => $faker->boolean(80),
+                        'locality_id' => $locality_id,
+                        'created_by' => $faker->randomElement($userIds),
+                        'attachment_url' => null,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+                }
             }
         }
     }

--- a/database/seeders/LocalityNoticesSeeder.php
+++ b/database/seeders/LocalityNoticesSeeder.php
@@ -19,7 +19,7 @@ class LocalityNoticesSeeder extends Seeder
 
         $localityIds = DB::table('localities')->pluck('id')->toArray();
 
-        foreach (range(1, 150) as $index) {
+        foreach (range(1, 2) as $index) {
             $locality_id = $faker->randomElement($localityIds);
 
             $userIds = DB::table('users')


### PR DESCRIPTION
## 🧾 Description

Updated seeder queries to properly scope records by locality, preventing data from mixing between different localities.

These changes ensure data consistency and correct separation of records across localities when running database seeders.

---

## 📂 Files Changed

- database/seeders/CustomersTableSeeder.php
- database/seeders/EmployeesTableSeeder.php
- database/seeders/ExpenseTypeSeeder.php
- database/seeders/GeneralExpensesSeeder.php
- database/seeders/LocalityNoticesSeeder.php
