### PR TITLE
Feature/log water connection transfer

### DIFF
--- a/app/Models/LogWaterConnectionTransfer.php
+++ b/app/Models/LogWaterConnectionTransfer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LogWaterConnectionTransfer extends Model
+{
+    use HasFactory;
+
+    protected $table = 'log_water_connection_transfer';
+
+    protected $fillable = [
+        'water_connection_id',
+        'old_customer_id',
+        'new_customer_id',
+        'reason',
+        'effective_date',
+        'note',
+        'created_by',
+    ];
+
+    public function waterConnection()
+    {
+        return $this->belongsTo(WaterConnection::class);
+    }
+
+    public function oldCustomer()
+    {
+        return $this->belongsTo(Customer::class, 'old_customer_id');
+    }
+
+    public function newCustomer()
+    {
+        return $this->belongsTo(Customer::class, 'new_customer_id');
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/database/migrations/2026_01_22_180839_create_log_water_connection_transfer_table.php
+++ b/database/migrations/2026_01_22_180839_create_log_water_connection_transfer_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('log_water_connection_transfer', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('water_connection_id');
+            $table->unsignedBigInteger('old_customer_id');
+            $table->unsignedBigInteger('new_customer_id');
+
+
+
+            $table->string('reason', 50)->default('death');
+
+
+            $table->date('effective_date')->default(DB::raw('CURRENT_DATE'));
+
+            $table->text('note')->nullable();
+
+            $table->unsignedBigInteger('created_by');
+
+            $table->timestamps();
+
+
+            $table->foreign('water_connection_id')
+                ->references('id')->on('water_connections');
+
+            $table->foreign('old_customer_id')
+                ->references('id')->on('customers');
+
+            $table->foreign('new_customer_id')
+                ->references('id')->on('customers');
+
+            $table->foreign('created_by')
+                ->references('id')->on('users');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_water_connection_transfer');
+    }
+};

--- a/database/migrations/2026_01_22_180839_create_log_water_connection_transfer_table.php
+++ b/database/migrations/2026_01_22_180839_create_log_water_connection_transfer_table.php
@@ -11,36 +11,19 @@ return new class extends Migration
     {
         Schema::create('log_water_connection_transfer', function (Blueprint $table) {
             $table->id();
-
             $table->unsignedBigInteger('water_connection_id');
             $table->unsignedBigInteger('old_customer_id');
             $table->unsignedBigInteger('new_customer_id');
-
-
-
             $table->string('reason', 50)->default('death');
-
-
             $table->date('effective_date')->default(DB::raw('CURRENT_DATE'));
-
             $table->text('note')->nullable();
-
             $table->unsignedBigInteger('created_by');
-
             $table->timestamps();
 
-
-            $table->foreign('water_connection_id')
-                ->references('id')->on('water_connections');
-
-            $table->foreign('old_customer_id')
-                ->references('id')->on('customers');
-
-            $table->foreign('new_customer_id')
-                ->references('id')->on('customers');
-
-            $table->foreign('created_by')
-                ->references('id')->on('users');
+            $table->foreign('water_connection_id') ->references('id')->on('water_connections');
+            $table->foreign('old_customer_id') ->references('id')->on('customers');
+            $table->foreign('new_customer_id') ->references('id')->on('customers');
+            $table->foreign('created_by') ->references('id')->on('users');
         });
     }
 

--- a/database/migrations/2026_01_22_180839_create_log_water_connection_transfer_table.php
+++ b/database/migrations/2026_01_22_180839_create_log_water_connection_transfer_table.php
@@ -20,10 +20,10 @@ return new class extends Migration
             $table->unsignedBigInteger('created_by');
             $table->timestamps();
 
-            $table->foreign('water_connection_id') ->references('id')->on('water_connections');
-            $table->foreign('old_customer_id') ->references('id')->on('customers');
-            $table->foreign('new_customer_id') ->references('id')->on('customers');
-            $table->foreign('created_by') ->references('id')->on('users');
+            $table->foreign('water_connection_id')->references('id')->on('water_connections');
+            $table->foreign('old_customer_id')->references('id')->on('customers');
+            $table->foreign('new_customer_id')->references('id')->on('customers');
+            $table->foreign('created_by')->references('id')->on('users');
         });
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -40,5 +40,6 @@ class DatabaseSeeder extends Seeder
         $this->call(EarningTypeSeeder::class);
         $this->call(GeneralEarningsSeeder::class);
         $this->call(LogInventorySeeder::class);
+        $this->call(LogWaterConnectionTransferSeeder::class);
     }
 }

--- a/database/seeders/LogWaterConnectionTransferSeeder.php
+++ b/database/seeders/LogWaterConnectionTransferSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Faker\Factory as Faker;
+
+class LogWaterConnectionTransferSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $faker = Faker::create();
+
+        $waterConnection = DB::table('water_connections')->first();
+        $oldCustomer = DB::table('customers')->where('status', 0)->first();
+        $newCustomer = DB::table('customers')->where('status', 1)->first();
+        $user = DB::table('users')->first();
+
+
+        if (!$waterConnection || !$oldCustomer || !$newCustomer || !$user) {
+            return;
+        }
+
+        DB::table('log_water_connection_transfer')->insert([
+            'water_connection_id' => $waterConnection->id,
+            'old_customer_id' => $oldCustomer->id,
+            'new_customer_id' => $newCustomer->id,
+            'reason' => 'death',
+            'effective_date' => date('Y-m-d'),
+            'note' => 'Transferencia de prueba (fallecimiento) generada por seeder.',
+            'created_by' => $user->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/database/seeders/LogWaterConnectionTransferSeeder.php
+++ b/database/seeders/LogWaterConnectionTransferSeeder.php
@@ -17,7 +17,6 @@ class LogWaterConnectionTransferSeeder extends Seeder
         $newCustomer = DB::table('customers')->where('status', 1)->first();
         $user = DB::table('users')->first();
 
-
         if (!$waterConnection || !$oldCustomer || !$newCustomer || !$user) {
             return;
         }

--- a/resources/views/viewCustomerPayments/index.blade.php
+++ b/resources/views/viewCustomerPayments/index.blade.php
@@ -121,9 +121,9 @@
         </div>
     </div>
 </section>
-@endsection
 @include('viewCustomerPayments.quarterly-report')
 @include('viewCustomerPayments.annualReportTemplate')
+@endsection
 
 @section('js')
 <script>


### PR DESCRIPTION
## Title
Add LogWaterConnectionTransfer migration, model, and seeder

## Description
This PR adds the database layer required to track water connection ownership transfers by introducing:
- A migration for the `log_water_connection_transfer` table
- The `LogWaterConnectionTransfer` model
- The `LogWaterConnectionTransferSeeder` for local testing data