### PR TITLE
Feature/water connection transfer module

### DIFF
--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -24,7 +24,7 @@ class WaterConnectionController extends Controller
             ->join('customers', 'water_connections.customer_id', '=', 'customers.id')
             ->leftJoin('sections', 'water_connections.section_id', '=', 'sections.id')
             ->orderBy('water_connections.created_at', 'desc')
-            ->select('water_connections.*', 'customers.status as customer_status');
+            ->select('water_connections.*', 'customers.status as customer_status', 'customers.name as customer_name', 'customers.last_name as customer_last_name');
 
         if ($request->has('search')) {
             $search = $request->input('search');
@@ -317,15 +317,14 @@ class WaterConnectionController extends Controller
                     ->orWhere('block', 'like', "%{$search}%");
                 });
             }
-            /** @var \Illuminate\Pagination\LengthAwarePaginator $connections */
+
             $connections = $query->paginate(10)->appends(request()->query());
 
-            $connections->getCollection()->transform(function ($connection) {
+            foreach ($connections as $connection) {
                 $connection->formatted_water_days = $this->getFormattedWaterDays($connection->water_days);
                 $connection->water_pressure_text = $connection->has_water_pressure ? 'Sí' : 'No';
                 $connection->cistern_text = $connection->has_cistern ? 'Sí' : 'No';
-                return $connection;
-            });
+            };
         }
 
         return view('viewCustomerWaterConnections.index', compact('connections'));

--- a/app/Http/Controllers/WaterConnectionTransferController.php
+++ b/app/Http/Controllers/WaterConnectionTransferController.php
@@ -11,26 +11,6 @@ use Illuminate\Support\Facades\DB;
 
 class WaterConnectionTransferController extends Controller
 {
-    public function create($id)
-    {
-        $authUser = auth()->user();
-
-        $waterConnection = WaterConnection::with('customer')->findOrFail($id);
-
-        if (!$waterConnection->customer || (int)$waterConnection->customer->status !== 0) {
-            return redirect()
-                ->route('waterConnections.index')
-                ->with('error', 'Solo se puede transferir una toma cuando el titular actual está fallecido.');
-        }
-        $customers = Customer::where('status', 1)
-            ->where('locality_id', $authUser->locality_id)
-            ->orderBy('name')
-            ->get();
-
-        return view('waterConnections.transfer', compact('waterConnection', 'customers'));
-    }
-
-
     public function store(Request $request, $id)
     {
         $waterConnection = WaterConnection::with('customer')->findOrFail($id);

--- a/app/Http/Controllers/WaterConnectionTransferController.php
+++ b/app/Http/Controllers/WaterConnectionTransferController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Customer;
+use App\Models\WaterConnection;
+use App\Models\LogWaterConnectionTransfer;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class WaterConnectionTransferController extends Controller
+{
+    public function create($id)
+    {
+        $authUser = auth()->user();
+
+        $waterConnection = WaterConnection::with('customer')->findOrFail($id);
+
+        if (!$waterConnection->customer || (int)$waterConnection->customer->status !== 0) {
+            return redirect()
+                ->route('waterConnections.index')
+                ->with('error', 'Solo se puede transferir una toma cuando el titular actual está fallecido.');
+        }
+        $customers = Customer::where('status', 1)
+            ->where('locality_id', $authUser->locality_id)
+            ->orderBy('name')
+            ->get();
+
+        return view('waterConnections.transfer', compact('waterConnection', 'customers'));
+    }
+
+
+    public function store(Request $request, $id)
+    {
+        $waterConnection = WaterConnection::with('customer')->findOrFail($id);
+
+        if (!$waterConnection->customer || (int)$waterConnection->customer->status !== 0) {
+            return redirect()
+                ->route('waterConnections.index')
+                ->with('error', 'Solo se puede transferir una toma cuando el titular actual está fallecido.');
+        }
+
+        $request->validate([
+            'new_customer_id' => 'required|exists:customers,id',
+            'note' => 'nullable|string',
+        ]);
+
+        $newCustomerId = (int) $request->new_customer_id;
+        $oldCustomerId = (int) $waterConnection->customer_id;
+
+        if ($newCustomerId === $oldCustomerId) {
+            return back()->with('error', 'El nuevo titular no puede ser el mismo que el titular actual.');
+        }
+
+        DB::transaction(function () use ($waterConnection, $oldCustomerId, $newCustomerId, $request) {
+            LogWaterConnectionTransfer::create([
+                'water_connection_id' => $waterConnection->id,
+                'old_customer_id' => $oldCustomerId,
+                'new_customer_id' => $newCustomerId,
+                'reason' => 'death',
+                'effective_date' => now()->toDateString(),
+                'note' => $request->note,
+                'created_by' => Auth::id(),
+            ]);
+
+            $waterConnection->update([
+                'customer_id' => $newCustomerId,
+            ]);
+        });
+
+        return redirect()
+            ->route('waterConnections.index')
+            ->with('success', 'La toma se transfirió correctamente al nuevo titular.');
+    }
+
+}

--- a/resources/views/waterConnections/index.blade.php
+++ b/resources/views/waterConnections/index.blade.php
@@ -1,4 +1,4 @@
-    @extends('adminlte::page')
+@extends('adminlte::page')
 
 @section('title', config('adminlte.title') . ' | Tomas')
 
@@ -100,11 +100,13 @@
                                                             @endcan
 
                                                             @if(isset($connection->customer_status) && (int)$connection->customer_status === 0)
-                                                                <a href="{{ route('waterConnections.transfer.create', $connection->id) }}"
-                                                                    class="btn btn-dark mr-2"
-                                                                    title="Cambiar propietario (titular fallecido)">
+                                                                <button type="button"
+                                                                        class="btn btn-dark mr-2"
+                                                                        title="Cambiar propietario (titular fallecido)"
+                                                                        data-toggle="modal"
+                                                                        data-target="#transferOwner{{ $connection->id }}">
                                                                     <i class="fas fa-exchange-alt"></i>
-                                                                </a>
+                                                                </button>
                                                             @endif
 
                                                             {{--
@@ -139,6 +141,7 @@
                                                 @include('waterConnections.show')
                                                 @include('waterConnections.edit')
                                                 @include('waterConnections.delete')
+                                                @include('waterConnections.transfer', ['connection' => $connection, 'customers' => $customers])
 
                                                 <div class="modal fade" id="cancel{{ $connection->id }}" tabindex="-1" role="dialog" aria-labelledby="cancelLabel{{ $connection->id }}" aria-hidden="true">
                                                     <div class="modal-dialog" role="document">

--- a/resources/views/waterConnections/index.blade.php
+++ b/resources/views/waterConnections/index.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+    @extends('adminlte::page')
 
 @section('title', config('adminlte.title') . ' | Tomas')
 
@@ -49,7 +49,7 @@
                                             <th>PROPIETARIO</th>
                                             <th>COSTO</th>
                                             <th>TIPO</th>
-                                            <th>SECCIÓN</th> 
+                                            <th>SECCIÓN</th>
                                             <th>OPCIONES</th>
                                         </tr>
                                     </thead>
@@ -98,6 +98,14 @@
                                                                 <i class="fas fa-edit"></i>
                                                             </button>
                                                             @endcan
+
+                                                            @if(isset($connection->customer_status) && (int)$connection->customer_status === 0)
+                                                                <a href="{{ route('waterConnections.transfer.create', $connection->id) }}"
+                                                                    class="btn btn-dark mr-2"
+                                                                    title="Cambiar propietario (titular fallecido)">
+                                                                    <i class="fas fa-exchange-alt"></i>
+                                                                </a>
+                                                            @endif
 
                                                             {{--
                                                             @can('deleteWaterConnection')
@@ -259,10 +267,10 @@
         var modal = $(this);
         var img = modal.find('#qrImage');
         var downloadBtn = modal.find('#downloadQrBtn');
-        
+
         img.attr('src', '').attr('alt', 'Cargando...');
         downloadBtn.attr('href', '#').hide();
-        
+
         $.ajax({
             url: '/waterConnections/' + id + '/qr-generate',
             method: 'GET',
@@ -334,7 +342,7 @@
     @if(session('debtError'))
         $('#debtErrorModal').modal('show');
     @endif
-    
+
     $(document).on('shown.bs.modal', '.modal', function () {
         $(this).find('.select2').select2({
             dropdownParent: $(this)

--- a/resources/views/waterConnections/transfer.blade.php
+++ b/resources/views/waterConnections/transfer.blade.php
@@ -1,65 +1,76 @@
-@extends('adminlte::page')
+<div class="modal fade" id="transferOwner{{ $connection->id }}" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">
+                            Cambio de Propietario (Fallecimiento)
+                            <small>&nbsp;(*) Campos requeridos</small>
+                        </h4>
 
-@section('content')
-<div class="container">
-    <h3>Cambio de Propietario (Fallecimiento)</h3>
-
-    <div class="card mt-3">
-        <div class="card-body">
-
-            <h5>Información de la toma</h5>
-            <p><strong>Toma:</strong> {{ $waterConnection->name }}</p>
-            <p><strong>Dirección:</strong> {{ $waterConnection->street }} {{ $waterConnection->exterior_number }} {{ $waterConnection->interior_number }}</p>
-
-            <hr>
-
-            <h5>Titular actual (Fallecido)</h5>
-            <p><strong>Nombre:</strong> {{ $waterConnection->customer->name }} {{ $waterConnection->customer->last_name }}</p>
-
-            <hr>
-
-            @if(session('error'))
-                <div class="alert alert-danger">{{ session('error') }}</div>
-            @endif
-
-            <form method="POST" action="{{ route('waterConnections.transfer.store', $waterConnection->id) }}">
-                @csrf
-
-                <div class="form-group">
-                    <label for="new_customer_id">Nuevo titular</label>
-                    <select name="new_customer_id" id="new_customer_id" class="form-control" required>
-                        <option value="">Selecciona una opción</option>
-                        @foreach($customers as $customer)
-                            <option value="{{ $customer->id }}">
-                                {{ $customer->name }} {{ $customer->last_name }} (ID: {{ $customer->id }})
-                            </option>
-                        @endforeach
-                    </select>
-                    @error('new_customer_id')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
                 </div>
 
-                <div class="form-group mt-3">
-                    <label for="note">Nota (opcional)</label>
-                    <textarea name="note" id="note" class="form-control" rows="3">{{ old('note') }}</textarea>
-                    @error('note')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
+                <form method="POST" action="{{ route('waterConnections.transfer.store', $connection->id) }}">
+                    @csrf
 
-                <div class="mt-4">
-                    <a href="{{ route('waterConnections.index') }}" class="btn btn-secondary">
-                        Cancelar
-                    </a>
+                    <div class="modal-body">
 
-                    <button type="submit" class="btn btn-primary">
-                        Transferir Toma
-                    </button>
-                </div>
+                        @if(session('error'))
+                            <div class="alert alert-danger">{{ session('error') }}</div>
+                        @endif
 
-            </form>
+                        <h5>Información de la toma</h5>
+                        <p class="mb-1"><strong>Toma:</strong> {{ $connection->name }}</p>
+                        <p class="mb-1"><strong>Dirección:</strong> {{ $connection->street }} {{ $connection->exterior_number }} {{ $connection->interior_number }}</p>
+
+                        <hr>
+
+                        <h5>Titular actual (Fallecido)</h5>
+                        <p class="mb-1"><strong>Titular actual (Fallecido):</strong> {{ $connection->customer_name }} {{ $connection->customer_last_name }}</p>
+                        <hr>
+
+                        <div class="form-group">
+                            <label for="new_customer_id_{{ $connection->id }}">Nuevo titular *</label>
+                            <select name="new_customer_id" id="new_customer_id_{{ $connection->id }}" class="form-control" required>
+                                <option value="">Selecciona una opción</option>
+
+                                @foreach($customers as $customer)
+                                    @if((int)$customer->id !== (int)$connection->customer_id)
+                                        <option value="{{ $customer->id }}">
+                                            {{ $customer->name }} {{ $customer->last_name }} (ID: {{ $customer->id }})
+                                        </option>
+                                    @endif
+                                @endforeach
+                            </select>
+
+                            @error('new_customer_id')
+                                <small class="text-danger">{{ $message }}</small>
+                            @enderror
+                        </div>
+
+                        <div class="form-group mt-3">
+                            <label for="note_{{ $connection->id }}">Nota (opcional)</label>
+                            <textarea name="note" id="note_{{ $connection->id }}" class="form-control" rows="3">{{ old('note') }}</textarea>
+
+                            @error('note')
+                                <small class="text-danger">{{ $message }}</small>
+                            @enderror
+                        </div>
+
+                    </div>
+
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                        <button type="submit" class="btn btn-success">Transferir Toma</button>
+                    </div>
+
+                </form>
+            </div>
         </div>
     </div>
 </div>
-@endsection

--- a/resources/views/waterConnections/transfer.blade.php
+++ b/resources/views/waterConnections/transfer.blade.php
@@ -1,0 +1,65 @@
+@extends('adminlte::page')
+
+@section('content')
+<div class="container">
+    <h3>Cambio de Propietario (Fallecimiento)</h3>
+
+    <div class="card mt-3">
+        <div class="card-body">
+
+            <h5>Información de la toma</h5>
+            <p><strong>Toma:</strong> {{ $waterConnection->name }}</p>
+            <p><strong>Dirección:</strong> {{ $waterConnection->street }} {{ $waterConnection->exterior_number }} {{ $waterConnection->interior_number }}</p>
+
+            <hr>
+
+            <h5>Titular actual (Fallecido)</h5>
+            <p><strong>Nombre:</strong> {{ $waterConnection->customer->name }} {{ $waterConnection->customer->last_name }}</p>
+
+            <hr>
+
+            @if(session('error'))
+                <div class="alert alert-danger">{{ session('error') }}</div>
+            @endif
+
+            <form method="POST" action="{{ route('waterConnections.transfer.store', $waterConnection->id) }}">
+                @csrf
+
+                <div class="form-group">
+                    <label for="new_customer_id">Nuevo titular</label>
+                    <select name="new_customer_id" id="new_customer_id" class="form-control" required>
+                        <option value="">Selecciona una opción</option>
+                        @foreach($customers as $customer)
+                            <option value="{{ $customer->id }}">
+                                {{ $customer->name }} {{ $customer->last_name }} (ID: {{ $customer->id }})
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('new_customer_id')
+                        <small class="text-danger">{{ $message }}</small>
+                    @enderror
+                </div>
+
+                <div class="form-group mt-3">
+                    <label for="note">Nota (opcional)</label>
+                    <textarea name="note" id="note" class="form-control" rows="3">{{ old('note') }}</textarea>
+                    @error('note')
+                        <small class="text-danger">{{ $message }}</small>
+                    @enderror
+                </div>
+
+                <div class="mt-4">
+                    <a href="{{ route('waterConnections.index') }}" class="btn btn-secondary">
+                        Cancelar
+                    </a>
+
+                    <button type="submit" class="btn btn-primary">
+                        Transferir Toma
+                    </button>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -141,7 +141,6 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::patch('/waterConnections/{id}/reactivate', [WaterConnectionController::class, 'reactivate'])->name('waterConnections.reactivate');
         Route::get('/waterConnections/{id}/qr-generate', [WaterConnectionController::class, 'generateQrAjax'])->name('waterConnections.qr-generate');
         Route::get('/waterConnections/{id}/qr-download', [WaterConnectionController::class, 'downloadQr'])->name('waterConnections.qr-download');
-        Route::get('/waterConnections/{id}/transfer', [WaterConnectionTransferController::class, 'create'])->name('waterConnections.transfer.create');
         Route::post('/waterConnections/{id}/transfer', [WaterConnectionTransferController::class, 'store'])->name('waterConnections.transfer.store');
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\FaultReportController;
 use App\Http\Controllers\LocalityController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WaterConnectionController;
+use App\Http\Controllers\WaterConnectionTransferController;
 use App\Http\Controllers\InventoryController;
 use App\Http\Controllers\AdvancePaymentController;
 use App\Http\Controllers\IncidentCategoriesController;
@@ -140,6 +141,8 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::patch('/waterConnections/{id}/reactivate', [WaterConnectionController::class, 'reactivate'])->name('waterConnections.reactivate');
         Route::get('/waterConnections/{id}/qr-generate', [WaterConnectionController::class, 'generateQrAjax'])->name('waterConnections.qr-generate');
         Route::get('/waterConnections/{id}/qr-download', [WaterConnectionController::class, 'downloadQr'])->name('waterConnections.qr-download');
+        Route::get('/waterConnections/{id}/transfer', [WaterConnectionTransferController::class, 'create'])->name('waterConnections.transfer.create');
+        Route::post('/waterConnections/{id}/transfer', [WaterConnectionTransferController::class, 'store'])->name('waterConnections.transfer.store');
     });
 
     Route::group(['middleware' => ['can:viewInventory']], function () {


### PR DESCRIPTION
## Water connection ownership transfer (death scenario)

## Summary
This PR adds a simple ownership transfer flow for water connections when the current owner (customer) is marked as deceased.

## Changes
- Added a "Transfer owner" action button on the Water Connections list (only visible when the current owner is deceased).
- Added transfer routes, controller logic, and a basic form to select the new owner.
- Added backend validations and transaction logic to register the transfer log and update the water connection owner.
