### PR TITLE
Restrict transfer dropdown and validated new owner must be alive in t…

### DIFF
--- a/app/Http/Controllers/WaterConnectionController.php
+++ b/app/Http/Controllers/WaterConnectionController.php
@@ -41,7 +41,12 @@ class WaterConnectionController extends Controller
 
         $connections = $query->paginate(10);
 
-        $customers = Customer::where('locality_id', $authUser->locality_id)->get();
+        $customers = Customer::query()
+            ->where('locality_id', $authUser->locality_id)
+            ->where('status', 1)
+            ->orderBy('name')
+            ->orderBy('last_name')
+            ->get();
         $costs = Cost::where('locality_id', $authUser->locality_id)
                     ->orWhereNull('locality_id')
                     ->get();

--- a/app/Http/Controllers/WaterConnectionTransferController.php
+++ b/app/Http/Controllers/WaterConnectionTransferController.php
@@ -6,6 +6,7 @@ use App\Models\Customer;
 use App\Models\WaterConnection;
 use App\Models\LogWaterConnectionTransfer;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -22,8 +23,14 @@ class WaterConnectionTransferController extends Controller
         }
 
         $request->validate([
-            'new_customer_id' => 'required|exists:customers,id',
+            'new_customer_id' => [
+                'required',
+                'integer',
+                Rule::exists('customers', 'id')->where('status', 1)->where('locality_id', $waterConnection->locality_id),
+            ],
             'note' => 'nullable|string',
+        ], [
+            'new_customer_id.exists' => 'Solo puedes seleccionar clientes activos (con vida).',
         ]);
 
         $newCustomerId = (int) $request->new_customer_id;

--- a/resources/views/waterConnections/transfer.blade.php
+++ b/resources/views/waterConnections/transfer.blade.php
@@ -47,6 +47,7 @@
                                     @endif
                                 @endforeach
                             </select>
+                            <small class="text-muted">Solo se muestran clientes activos (con vida).</small>
 
                             @error('new_customer_id')
                                 <small class="text-danger">{{ $message }}</small>


### PR DESCRIPTION
## Water connection ownership transfer (active customer restriction)

### Summary
This PR adds a validation layer to the existing water connection ownership transfer flow, ensuring that transfers can only be made to active (alive) customers.

### Changes
- Updated the customer list in the transfer modal to display only active customers.
- Added backend validation to prevent transferring a water connection to a deceased customer.
- Added a helper message in the transfer form to clarify that only active customers can be selected.

### Why
This change enforces the business rule that water connections cannot be transferred to deceased customers, preventing invalid scenarios and improving data consistency.