### PR TITLE
Add water connection transfer history modal with tabs

### DIFF
--- a/app/Http/Controllers/WaterConnectionDetailsController.php
+++ b/app/Http/Controllers/WaterConnectionDetailsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\WaterConnection;
+use App\Models\LogWaterConnectionTransfer;
+use Illuminate\Http\Request;
+
+class WaterConnectionDetailsController extends Controller
+{
+    public function history($id)
+    {
+        $authUser = auth()->user();
+
+        // 1) Seguridad / multitenancy: asegurar que la toma pertenece a la localidad del usuario
+        $connection = WaterConnection::withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED)
+            ->where('locality_id', $authUser->locality_id)
+            ->findOrFail($id);
+
+        // 2) Traer historial con relaciones para evitar N+1
+        $transfers = LogWaterConnectionTransfer::query()
+            ->where('water_connection_id', $connection->id)
+            ->with([
+                'oldCustomer:id,name,last_name',
+                'newCustomer:id,name,last_name',
+                'creator:id,name,last_name',
+            ])
+            ->orderByDesc('effective_date')
+            ->orderByDesc('id')
+            ->get();
+
+        // 3) Devolvemos un partial HTML que el tab insertará
+        return view('waterConnections.tabs.history', compact('connection', 'transfers'));
+    }
+}

--- a/app/Http/Controllers/WaterConnectionDetailsController.php
+++ b/app/Http/Controllers/WaterConnectionDetailsController.php
@@ -12,12 +12,10 @@ class WaterConnectionDetailsController extends Controller
     {
         $authUser = auth()->user();
 
-        // 1) Seguridad / multitenancy: asegurar que la toma pertenece a la localidad del usuario
         $connection = WaterConnection::withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED)
             ->where('locality_id', $authUser->locality_id)
             ->findOrFail($id);
 
-        // 2) Traer historial con relaciones para evitar N+1
         $transfers = LogWaterConnectionTransfer::query()
             ->where('water_connection_id', $connection->id)
             ->with([
@@ -29,7 +27,6 @@ class WaterConnectionDetailsController extends Controller
             ->orderByDesc('id')
             ->get();
 
-        // 3) Devolvemos un partial HTML que el tab insertará
         return view('waterConnections.tabs.history', compact('connection', 'transfers'));
     }
 }

--- a/resources/views/waterConnections/details.blade.php
+++ b/resources/views/waterConnections/details.blade.php
@@ -1,10 +1,5 @@
-<div class="modal fade"
-     id="details{{ $connection->id }}"
-     tabindex="-1"
-     role="dialog"
-     aria-hidden="true"
-     data-connection-id="{{ $connection->id }}">
-
+<div class="modal fade" id="details{{ $connection->id }}" tabindex="-1" role="dialog" aria-hidden="true"
+    data-connection-id="{{ $connection->id }}">
     <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
             <div class="card-info mb-0">
@@ -16,63 +11,46 @@
                                 Toma: {{ $connection->name }} | ID: {{ $connection->id }}
                             </small>
                         </h4>
-
-                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal"
+                            aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
                     </div>
                 </div>
-
                 <div class="modal-body">
                     <ul class="nav nav-tabs" role="tablist">
                         <li class="nav-item">
-                            <a class="nav-link active"
-                               id="history-tab-{{ $connection->id }}"
-                               data-toggle="tab"
-                               href="#history-{{ $connection->id }}"
-                               role="tab">
+                            <a class="nav-link active" id="history-tab-{{ $connection->id }}" data-toggle="tab"
+                                href="#history-{{ $connection->id }}" role="tab">
                                 Historial
                             </a>
                         </li>
-
                         <li class="nav-item">
-                            <a class="nav-link"
-                               id="debts-tab-{{ $connection->id }}"
-                               data-toggle="tab"
-                               href="#debts-{{ $connection->id }}"
-                               role="tab">
+                            <a class="nav-link" id="debts-tab-{{ $connection->id }}" data-toggle="tab"
+                                href="#debts-{{ $connection->id }}" role="tab">
                                 Deudas
                             </a>
                         </li>
                     </ul>
-
                     <div class="tab-content pt-3">
-                        <div class="tab-pane fade show active"
-                             id="history-{{ $connection->id }}"
-                             role="tabpanel">
+                        <div class="tab-pane fade show active" id="history-{{ $connection->id }}" role="tabpanel">
                             <div id="historyContent{{ $connection->id }}">
                                 <div class="text-muted">
                                     Cargando historial...
                                 </div>
                             </div>
                         </div>
-
-                        <div class="tab-pane fade"
-                             id="debts-{{ $connection->id }}"
-                             role="tabpanel">
+                        <div class="tab-pane fade" id="debts-{{ $connection->id }}" role="tabpanel">
                             <div class="alert alert-secondary mb-0">
                                 Próximamente: aquí se mostrará el tab de deudas.
                             </div>
                         </div>
                     </div>
-
                 </div>
-
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
                 </div>
             </div>
-
         </div>
     </div>
 </div>

--- a/resources/views/waterConnections/details.blade.php
+++ b/resources/views/waterConnections/details.blade.php
@@ -1,0 +1,83 @@
+<div class="modal fade"
+     id="details{{ $connection->id }}"
+     tabindex="-1"
+     role="dialog"
+     aria-hidden="true"
+     data-connection-id="{{ $connection->id }}">
+
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+
+            <div class="card-info mb-0">
+                <div class="card-header">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title mb-0">
+                            Detalles de la toma
+                            <small class="d-block text-white-50">
+                                Toma: {{ $connection->name }} | ID: {{ $connection->id }}
+                            </small>
+                        </h4>
+
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="modal-body">
+
+                    {{-- Tabs --}}
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li class="nav-item">
+                            <a class="nav-link active"
+                               id="history-tab-{{ $connection->id }}"
+                               data-toggle="tab"
+                               href="#history-{{ $connection->id }}"
+                               role="tab">
+                                Historial
+                            </a>
+                        </li>
+
+                        <li class="nav-item">
+                            <a class="nav-link"
+                               id="debts-tab-{{ $connection->id }}"
+                               data-toggle="tab"
+                               href="#debts-{{ $connection->id }}"
+                               role="tab">
+                                Deudas
+                            </a>
+                        </li>
+                    </ul>
+
+                    <div class="tab-content pt-3">
+                        {{-- Historial --}}
+                        <div class="tab-pane fade show active"
+                             id="history-{{ $connection->id }}"
+                             role="tabpanel">
+                            <div id="historyContent{{ $connection->id }}">
+                                <div class="text-muted">
+                                    Cargando historial...
+                                </div>
+                            </div>
+                        </div>
+
+                        {{-- Deudas (placeholder para PR futuro) --}}
+                        <div class="tab-pane fade"
+                             id="debts-{{ $connection->id }}"
+                             role="tabpanel">
+                            <div class="alert alert-secondary mb-0">
+                                Próximamente: aquí se mostrará el tab de deudas.
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>

--- a/resources/views/waterConnections/details.blade.php
+++ b/resources/views/waterConnections/details.blade.php
@@ -7,7 +7,6 @@
 
     <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
-
             <div class="card-info mb-0">
                 <div class="card-header">
                     <div class="d-sm-flex align-items-center justify-content-between">
@@ -25,8 +24,6 @@
                 </div>
 
                 <div class="modal-body">
-
-                    {{-- Tabs --}}
                     <ul class="nav nav-tabs" role="tablist">
                         <li class="nav-item">
                             <a class="nav-link active"
@@ -50,7 +47,6 @@
                     </ul>
 
                     <div class="tab-content pt-3">
-                        {{-- Historial --}}
                         <div class="tab-pane fade show active"
                              id="history-{{ $connection->id }}"
                              role="tabpanel">
@@ -61,7 +57,6 @@
                             </div>
                         </div>
 
-                        {{-- Deudas (placeholder para PR futuro) --}}
                         <div class="tab-pane fade"
                              id="debts-{{ $connection->id }}"
                              role="tabpanel">

--- a/resources/views/waterConnections/index.blade.php
+++ b/resources/views/waterConnections/index.blade.php
@@ -99,6 +99,10 @@
                                                             </button>
                                                             @endcan
 
+                                                            <button type="button" class="btn btn-primary mr-2" data-toggle="modal" title="Detalles / Historial"  data-target="#details{{ $connection->id }}">
+                                                                <i class="fas fa-history"></i>
+                                                            </button>
+
                                                             @if(isset($connection->customer_status) && (int)$connection->customer_status === 0)
                                                                 <button type="button"
                                                                         class="btn btn-dark mr-2"
@@ -141,6 +145,7 @@
                                                 @include('waterConnections.show')
                                                 @include('waterConnections.edit')
                                                 @include('waterConnections.delete')
+                                                @include('waterConnections.details', ['connection' => $connection])
                                                 @include('waterConnections.transfer', ['connection' => $connection, 'customers' => $customers])
 
                                                 <div class="modal fade" id="cancel{{ $connection->id }}" tabindex="-1" role="dialog" aria-labelledby="cancelLabel{{ $connection->id }}" aria-hidden="true">
@@ -328,6 +333,27 @@
                 confirmButtonText: 'Aceptar'
             });
         }
+
+        const loadedHistory = {};
+
+        $('div.modal[id^="details"]').on('shown.bs.modal', function () {
+            const $modal = $(this);
+            const connectionId = $modal.data('connection-id');
+
+            if (loadedHistory[connectionId]) return;
+
+            const $container = $('#historyContent' + connectionId);
+            $container.html('<div class="text-muted">Cargando historial...</div>');
+
+            $.get('/waterConnections/' + connectionId + '/history')
+                .done(function (html) {
+                    $container.html(html);
+                    loadedHistory[connectionId] = true;
+                })
+                .fail(function () {
+                    $container.html('<div class="alert alert-danger mb-0">No se pudo cargar el historial.</div>');
+                });
+        });
     });
 
     $('#createWaterConnections').on('shown.bs.modal', function() {

--- a/resources/views/waterConnections/tabs/history.blade.php
+++ b/resources/views/waterConnections/tabs/history.blade.php
@@ -1,0 +1,42 @@
+@if($transfers->isEmpty())
+    <div class="alert alert-info mb-0">
+        No hay transferencias registradas para esta toma.
+    </div>
+@else
+    <div class="table-responsive">
+        <table class="table table-sm table-bordered mb-0">
+            <thead class="thead-light">
+                <tr>
+                    <th>Fecha</th>
+                    <th>Titular anterior</th>
+                    <th>Nuevo titular</th>
+                    <th>Realizó</th>
+                    <th>Nota</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($transfers as $t)
+                    <tr>
+                        <td>
+                            {{ $t->effective_date ?? optional($t->created_at)->format('Y-m-d') }}
+                        </td>
+                        <td>
+                            {{ optional($t->oldCustomer)->name }} {{ optional($t->oldCustomer)->last_name }}
+                            <small class="text-muted">(ID: {{ $t->old_customer_id }})</small>
+                        </td>
+                        <td>
+                            {{ optional($t->newCustomer)->name }} {{ optional($t->newCustomer)->last_name }}
+                            <small class="text-muted">(ID: {{ $t->new_customer_id }})</small>
+                        </td>
+                        <td>
+                            {{ optional($t->creator)->name }} {{ optional($t->creator)->last_name }}
+                        </td>
+                        <td>
+                            {{ $t->note ?? '-' }}
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\LocalityController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WaterConnectionController;
 use App\Http\Controllers\WaterConnectionTransferController;
+use App\Http\Controllers\WaterConnectionDetailsController;
 use App\Http\Controllers\InventoryController;
 use App\Http\Controllers\AdvancePaymentController;
 use App\Http\Controllers\IncidentCategoriesController;
@@ -142,6 +143,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('/waterConnections/{id}/qr-generate', [WaterConnectionController::class, 'generateQrAjax'])->name('waterConnections.qr-generate');
         Route::get('/waterConnections/{id}/qr-download', [WaterConnectionController::class, 'downloadQr'])->name('waterConnections.qr-download');
         Route::post('/waterConnections/{id}/transfer', [WaterConnectionTransferController::class, 'store'])->name('waterConnections.transfer.store');
+        Route::get('/waterConnections/{id}/history', [WaterConnectionDetailsController::class, 'history'])->name('waterConnections.history');
     });
 
     Route::group(['middleware' => ['can:viewInventory']], function () {


### PR DESCRIPTION
## PR #4 — Water Connection History Modal

### Summary
This PR adds a new **Details / History** button to the Water Connections list.  
The button opens a modal with tab navigation where supervisors can view the **owner transfer history** of a water connection.

### Key Points
- Reuses the existing `log_water_connection_transfer` table created in previous PRs
- Loads history dynamically using AJAX to improve performance
- Introduces a new read-only controller for tab data retrieval
- Prepares the modal structure for future tabs (debts, payments, etc.)

### Result
Supervisors can now easily access the full transfer history of a water connection from the main list screen.
