### PR TITLE
Added Debts tab to water connection details modal

### DIFF
--- a/app/Http/Controllers/WaterConnectionDetailsController.php
+++ b/app/Http/Controllers/WaterConnectionDetailsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\WaterConnection;
 use App\Models\LogWaterConnectionTransfer;
 use Illuminate\Http\Request;
+use App\Models\Debt;
 
 class WaterConnectionDetailsController extends Controller
 {
@@ -28,5 +29,35 @@ class WaterConnectionDetailsController extends Controller
             ->get();
 
         return view('waterConnections.tabs.history', compact('connection', 'transfers'));
+    }
+
+    public function debts($id)
+    {
+        $authUser = auth()->user();
+
+        $connection = WaterConnection::withoutGlobalScope(WaterConnection::SCOPE_NOT_CANCELED)
+            ->where('locality_id', $authUser->locality_id)
+            ->findOrFail($id);
+
+        $debts = Debt::query()
+            ->where('water_connection_id', $connection->id)
+            ->where('locality_id', $authUser->locality_id)
+            ->whereIn('status', [Debt::STATUS_PENDING, Debt::STATUS_PARTIAL])
+            ->with(['creator:id,name,last_name'])
+            ->withSum('payments as payments_sum_amount', 'amount')
+            ->orderByDesc('start_date')
+            ->get();
+
+        $totalAmount = $debts->sum('amount');
+        $totalPaid = $debts->sum(fn($d) => (float)($d->payments_sum_amount ?? 0));
+        $totalPending = $totalAmount - $totalPaid;
+
+        return view('waterConnections.tabs.debts', compact(
+            'connection',
+            'debts',
+            'totalAmount',
+            'totalPaid',
+            'totalPending'
+        ));
     }
 }

--- a/app/Http/Controllers/WaterConnectionTransferController.php
+++ b/app/Http/Controllers/WaterConnectionTransferController.php
@@ -60,5 +60,4 @@ class WaterConnectionTransferController extends Controller
             ->route('waterConnections.index')
             ->with('success', 'La toma se transfirió correctamente al nuevo titular.');
     }
-
 }

--- a/resources/views/waterConnections/details.blade.php
+++ b/resources/views/waterConnections/details.blade.php
@@ -41,8 +41,10 @@
                             </div>
                         </div>
                         <div class="tab-pane fade" id="debts-{{ $connection->id }}" role="tabpanel">
-                            <div class="alert alert-secondary mb-0">
-                                Próximamente: aquí se mostrará el tab de deudas.
+                            <div id="debtsContent{{ $connection->id }}">
+                                <div class="text-muted">
+                                    Cargando deudas...
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/waterConnections/index.blade.php
+++ b/resources/views/waterConnections/index.blade.php
@@ -354,6 +354,26 @@
                     $container.html('<div class="alert alert-danger mb-0">No se pudo cargar el historial.</div>');
                 });
         });
+
+        const loadedDebts = {};
+
+        $(document).on('click', 'a[id^="debts-tab-"]', function () {
+            const connectionId = $(this).attr('id').replace('debts-tab-', '');
+
+            if (loadedDebts[connectionId]) return;
+
+            const $container = $('#debtsContent' + connectionId);
+            $container.html('<div class="text-muted">Cargando deudas...</div>');
+
+            $.get('/waterConnections/' + connectionId + '/debts')
+                .done(function (html) {
+                    $container.html(html);
+                    loadedDebts[connectionId] = true;
+                })
+                .fail(function () {
+                    $container.html('<div class="alert alert-danger mb-0">No se pudieron cargar las deudas.</div>');
+                });
+        });
     });
 
     $('#createWaterConnections').on('shown.bs.modal', function() {

--- a/resources/views/waterConnections/tabs/debts.blade.php
+++ b/resources/views/waterConnections/tabs/debts.blade.php
@@ -20,7 +20,6 @@
         </div>
         <hr class="my-3">
     </div>
-
     <div class="table-responsive">
         <table class="table table-sm table-bordered mb-0">
             <thead class="thead-light">
@@ -36,6 +35,7 @@
             </thead>
             <tbody>
                 @foreach($debts as $d)
+
                     @php
                         $paid = (float)($d->payments_sum_amount ?? 0);
                         $pending = (float)$d->amount - $paid;

--- a/resources/views/waterConnections/tabs/debts.blade.php
+++ b/resources/views/waterConnections/tabs/debts.blade.php
@@ -1,0 +1,72 @@
+@if($debts->isEmpty())
+    <div class="alert alert-info mb-0">
+        Esta toma no tiene deudas pendientes o abonadas.
+    </div>
+@else
+    <div class="mb-3">
+        <div class="row">
+            <div class="col-md-4">
+                <div class="small text-muted">Total deuda</div>
+                <div><strong>${{ number_format($totalAmount, 2) }}</strong></div>
+            </div>
+            <div class="col-md-4">
+                <div class="small text-muted">Total pagado</div>
+                <div><strong>${{ number_format($totalPaid, 2) }}</strong></div>
+            </div>
+            <div class="col-md-4">
+                <div class="small text-muted">Total pendiente</div>
+                <div><strong>${{ number_format($totalPending, 2) }}</strong></div>
+            </div>
+        </div>
+        <hr class="my-3">
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-sm table-bordered mb-0">
+            <thead class="thead-light">
+                <tr>
+                    <th>Periodo</th>
+                    <th>Monto</th>
+                    <th>Pagado</th>
+                    <th>Saldo</th>
+                    <th>Estado</th>
+                    <th>Nota</th>
+                    <th>Registró</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($debts as $d)
+                    @php
+                        $paid = (float)($d->payments_sum_amount ?? 0);
+                        $pending = (float)$d->amount - $paid;
+
+                        if ($pending <= 0) {
+                            $statusText = 'Pagada';
+                            $badge = 'badge-success';
+                        } elseif ($paid > 0) {
+                            $statusText = 'Abonada';
+                            $badge = 'badge-warning';
+                        } else {
+                            $statusText = 'Pendiente';
+                            $badge = 'badge-danger';
+                        }
+                    @endphp
+
+                    <tr>
+                        <td>
+                            {{ \Carbon\Carbon::parse($d->start_date)->format('Y-m-d') }}
+                            <span class="text-muted">a</span>
+                            {{ \Carbon\Carbon::parse($d->end_date)->format('Y-m-d') }}
+                        </td>
+                        <td>${{ number_format($d->amount, 2) }}</td>
+                        <td>${{ number_format($paid, 2) }}</td>
+                        <td>${{ number_format(max($pending, 0), 2) }}</td>
+                        <td><span class="badge {{ $badge }}">{{ $statusText }}</span></td>
+                        <td>{{ $d->note ?? '-' }}</td>
+                        <td>{{ optional($d->creator)->name }} {{ optional($d->creator)->last_name }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -144,6 +144,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('/waterConnections/{id}/qr-download', [WaterConnectionController::class, 'downloadQr'])->name('waterConnections.qr-download');
         Route::post('/waterConnections/{id}/transfer', [WaterConnectionTransferController::class, 'store'])->name('waterConnections.transfer.store');
         Route::get('/waterConnections/{id}/history', [WaterConnectionDetailsController::class, 'history'])->name('waterConnections.history');
+        Route::get('/waterConnections/{id}/debts', [WaterConnectionDetailsController::class, 'debts'])->name('waterConnections.debts');
     });
 
     Route::group(['middleware' => ['can:viewInventory']], function () {


### PR DESCRIPTION
## Add Debts Tab to Water Connection Details

### Summary
This PR adds a new **Debts** tab to the Water Connection details modal.  
The tab displays all pending and partially paid debts for a water connection.

### What was done
- Added a new Debts tab inside the details modal
- Loaded debts data dynamically using AJAX
- Displayed total debt, total paid, and pending balance
- Calculated debt status based on payments
- Reused existing debts and payments data without new tables

### Result
Supervisors can now easily review the debt status of a water connection directly from the main list.