### PR TITLE
Make LogWaterConnectionTransferSeeder consistent with other seeders (…

### DIFF
--- a/database/seeders/LogWaterConnectionTransferSeeder.php
+++ b/database/seeders/LogWaterConnectionTransferSeeder.php
@@ -5,32 +5,50 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Factory as Faker;
+use App\Models\User;
 
 class LogWaterConnectionTransferSeeder extends Seeder
 {
     public function run(): void
     {
         $faker = Faker::create();
+        $localityIds = DB::table('localities')->pluck('id')->toArray();
 
-        $waterConnection = DB::table('water_connections')->first();
-        $oldCustomer = DB::table('customers')->where('status', 0)->first();
-        $newCustomer = DB::table('customers')->where('status', 1)->first();
-        $user = DB::table('users')->first();
+        foreach (range(1, 40) as $index) {
+            $locality_id = $faker->randomElement($localityIds);
 
-        if (!$waterConnection || !$oldCustomer || !$newCustomer || !$user) {
-            return;
+            $userIds = DB::table('users')
+                ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+                ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+                ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+                ->where('users.locality_id', $locality_id)
+                ->distinct()
+                ->pluck('users.id')
+                ->toArray();
+
+            if (empty($userIds)) {
+                continue;
+            }
+
+            $waterConnection = DB::table('water_connections')->inRandomOrder()->first();
+            $oldCustomer = DB::table('customers')->where('status', 0)->where('locality_id', $locality_id)->inRandomOrder()->first();
+            $newCustomer = DB::table('customers')->where('status', 1)->where('locality_id', $locality_id)->inRandomOrder()->first();
+
+            if (!$waterConnection || !$oldCustomer || !$newCustomer) {
+                continue;
+            }
+
+            DB::table('log_water_connection_transfer')->insert([
+                'water_connection_id' => $waterConnection->id,
+                'old_customer_id' => $oldCustomer->id,
+                'new_customer_id' => $newCustomer->id,
+                'reason' => $faker->randomElement(['death', 'sale', 'other']),
+                'effective_date' => $faker->date(),
+                'note' => 'Transferencia de prueba generada por seeder.',
+                'created_by' => $faker->randomElement($userIds),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
         }
-
-        DB::table('log_water_connection_transfer')->insert([
-            'water_connection_id' => $waterConnection->id,
-            'old_customer_id' => $oldCustomer->id,
-            'new_customer_id' => $newCustomer->id,
-            'reason' => 'death',
-            'effective_date' => date('Y-m-d'),
-            'note' => 'Transferencia de prueba (fallecimiento) generada por seeder.',
-            'created_by' => $user->id,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
     }
 }

--- a/database/seeders/LogWaterConnectionTransferSeeder.php
+++ b/database/seeders/LogWaterConnectionTransferSeeder.php
@@ -30,7 +30,7 @@ class LogWaterConnectionTransferSeeder extends Seeder
                 continue;
             }
 
-            $waterConnection = DB::table('water_connections')->inRandomOrder()->first();
+            $waterConnection = DB::table('water_connections')->where('locality_id', $locality_id)->inRandomOrder()->first();
             $oldCustomer = DB::table('customers')->where('status', 0)->where('locality_id', $locality_id)->inRandomOrder()->first();
             $newCustomer = DB::table('customers')->where('status', 1)->where('locality_id', $locality_id)->inRandomOrder()->first();
 


### PR DESCRIPTION
## Make LogWaterConnectionTransferSeeder consistent with other seeders

### Summary
This PR updates `LogWaterConnectionTransferSeeder.php` so its behavior and data sourcing align with other seeders (e.g. `CustomersTableSeeder.php`, `EmployeesTableSeeder.php`). Instead of inserting a single record, the seeder now:

- Uses locality IDs (`localityIds`) and selects eligible user IDs (`userIds`) per locality.
- Inserts multiple records inside a loop (up to 40 iterations).
- Selects `created_by` from users in the same locality who have the `ROLE_SUPERVISOR` or `ROLE_SECRETARY` roles (matching other seeders' logic).
- Uses Faker to vary `reason` and `effective_date`, and guards against missing users/customers by skipping iterations when necessary.

### Files changed
- `database/seeders/LogWaterConnectionTransferSeeder.php`

### Motivation
Making the seeder consistent improves test data quality and mirrors how other seeders associate `created_by` with users scoped to the same locality. It also produces more realistic and diverse seed records.

### Testing performed
Changes were committed locally and the seeder was executed with:

```bash
php artisan db:seed --class=LogWaterConnectionTransferSeeder
