### PR TITLE
Feature: Implement status and history buttons in Failure Reports module

### DIFF
--- a/app/Http/Controllers/FaultReportController.php
+++ b/app/Http/Controllers/FaultReportController.php
@@ -75,7 +75,7 @@ class FaultReportController extends Controller
         try {
             $request->validate([
                 'fault_report_id' => 'required|exists:fault_report,id',
-                'status' => 'required|string|in:Pendiente,En revisión,Completado',
+                'status' => 'required|string|in:pending,in_review,completed',
                 'comentario' => 'sometimes|string|max:500'
             ]);
 

--- a/app/Http/Controllers/FaultReportController.php
+++ b/app/Http/Controllers/FaultReportController.php
@@ -73,8 +73,6 @@ class FaultReportController extends Controller
     public function updateStatus(Request $request)
     {
         try {
-            \Log::info('updateStatus called', $request->all());
-
             $request->validate([
                 'fault_report_id' => 'required|exists:fault_report,id',
                 'status' => 'required|string|in:Pendiente,En revisión,Completado',
@@ -95,8 +93,6 @@ class FaultReportController extends Controller
             $report->status = $request->status;
             $report->save();
 
-            \Log::info('Fault Report updated', ['report_id' => $report->id, 'new_status' => $request->status]);
-
             $logDescription = $request->comentario ?: 'Cambio de estatus: ' . 
                 $previousStatus . ' → ' . $request->status;
 
@@ -108,19 +104,12 @@ class FaultReportController extends Controller
                 'locality_id' => $authUser->locality_id,
             ]);
 
-            \Log::info('Log created successfully:', [
-                'log_id' => $logFaultReport->id, 
-                'status_value' => $logFaultReport->status,
-                'status_type' => gettype($logFaultReport->status)
-            ]);
-
             return response()->json([
                 'success' => true,
                 'message' => 'Estatus actualizado correctamente'
             ]);
 
         } catch (\Exception $e) {
-            \Log::error('Error in updateStatus: ' . $e->getMessage());
             return response()->json([
                 'success' => false,
                 'message' => 'Error al actualizar el estatus: ' . $e->getMessage()

--- a/app/Http/Controllers/FaultReportController.php
+++ b/app/Http/Controllers/FaultReportController.php
@@ -76,7 +76,7 @@ class FaultReportController extends Controller
             $request->validate([
                 'fault_report_id' => 'required|exists:fault_report,id',
                 'status' => 'required|string|in:pending,in_review,completed',
-                'comentario' => 'sometimes|string|max:500'
+                'description' => 'sometimes|string|max:500'
             ]);
 
             $authUser = auth()->user();
@@ -93,13 +93,13 @@ class FaultReportController extends Controller
             $report->status = $request->status;
             $report->save();
 
-            $logDescription = $request->comentario ?: 'Cambio de estatus: ' . 
+            $logDescription = $request->description ?: 'Cambio de estatus: ' . 
                 $previousStatus . ' → ' . $request->status;
 
             $logFaultReport = LogFaultReport::create([
                 'fault_report_id' => $report->id,
                 'status' => $request->status,
-                'comentario' => $logDescription,
+                'description' => $logDescription,
                 'created_by' => $authUser->id,
                 'locality_id' => $authUser->locality_id,
             ]);

--- a/app/Models/LogFaultReport.php
+++ b/app/Models/LogFaultReport.php
@@ -4,27 +4,20 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 
-class FaultReport extends Model implements HasMedia
+class LogFaultReport extends Model implements HasMedia
 {
-    use HasFactory, SoftDeletes, InteractsWithMedia;
-
-    protected $table = 'fault_report';
+    use HasFactory;
+    use InteractsWithMedia;
 
     protected $fillable = [
-        'created_by',
         'locality_id',
-        'title',
-        'description',
+        'created_by',
         'status',
-        'date_report',
-    ];
-
-    protected $dates = [
-        'date_report',
+        'comentario',
+        'fault_report_id'
     ];
 
     public function locality()
@@ -37,9 +30,8 @@ class FaultReport extends Model implements HasMedia
         return $this->belongsTo(User::class, 'created_by');
     }
 
-    public function logs()
+    public function faultReport()
     {
-        return $this->hasMany(LogFaultReport::class, 'fault_report_id')->orderBy('created_at', 'desc');
+        return $this->belongsTo(FaultReport::class, 'fault_report_id');
     }
-
 }

--- a/app/Models/LogFaultReport.php
+++ b/app/Models/LogFaultReport.php
@@ -12,6 +12,10 @@ class LogFaultReport extends Model implements HasMedia
     use HasFactory;
     use InteractsWithMedia;
 
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_IN_REVIEW = 'in_review';
+    public const STATUS_COMPLETED = 'completed';
+
     protected $fillable = [
         'locality_id',
         'created_by',

--- a/app/Models/LogFaultReport.php
+++ b/app/Models/LogFaultReport.php
@@ -20,7 +20,7 @@ class LogFaultReport extends Model implements HasMedia
         'locality_id',
         'created_by',
         'status',
-        'comentario',
+        'description',
         'fault_report_id'
     ];
 

--- a/database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
+++ b/database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLogFaultReportsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('log_fault_reports', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('fault_report_id');
+            $table->unsignedBigInteger('locality_id');
+            $table->unsignedBigInteger('created_by');
+            $table->enum('status', ['Pendiente', 'En revisión', 'Completado'])->default('Pendiente');
+            $table->text('comentario')->nullable();
+            $table->timestamps();
+
+            $table->foreign('fault_report_id')->references('id')->on('fault_report')->onDelete('cascade');
+            $table->foreign('locality_id')->references('id')->on('localities')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('log_fault_reports');
+    }
+}

--- a/database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
+++ b/database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
@@ -21,7 +21,7 @@ class CreateLogFaultReportsTable extends Migration
             $table->unsignedBigInteger('locality_id');
             $table->unsignedBigInteger('created_by');
             $table->enum('status', self::FAULT_REPORT_STATUSES)->default('pending');
-            $table->text('comentario')->nullable();
+            $table->text('description')->nullable();
             $table->timestamps();
 
             $table->foreign('fault_report_id')->references('id')->on('fault_report')->onDelete('cascade');

--- a/database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
+++ b/database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateLogFaultReportsTable extends Migration
 {
+    private const FAULT_REPORT_STATUSES = ['pending', 'in_review', 'completed'];
+
     /**
      * Run the migrations.
      *
@@ -18,7 +20,7 @@ class CreateLogFaultReportsTable extends Migration
             $table->unsignedBigInteger('fault_report_id');
             $table->unsignedBigInteger('locality_id');
             $table->unsignedBigInteger('created_by');
-            $table->enum('status', ['Pendiente', 'En revisión', 'Completado'])->default('Pendiente');
+            $table->enum('status', self::FAULT_REPORT_STATUSES)->default('pending');
             $table->text('comentario')->nullable();
             $table->timestamps();
 

--- a/resources/views/customerFaultReports/historyModal.blade.php
+++ b/resources/views/customerFaultReports/historyModal.blade.php
@@ -1,0 +1,75 @@
+<div class="modal fade" id="historyModal{{ $report->id }}" tabindex="-1" role="dialog" aria-labelledby="historyModalLabel{{ $report->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="card-header bg-maroon">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Historial del Reporte</h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="card">
+                        <div class="card-header py-2 bg-secondary">
+                            <h3 class="card-title">Cambios de Estatus</h3>
+                            <div class="card-tools">
+                                <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" style="padding-left: 0;">
+                            <div style="margin-left: 27px; margin-bottom: 10px; font-size: 0.95rem;">
+                                <strong>Reporte:</strong> {{ $report->title }}
+                            </div>
+                            <ul class="timeline timeline-inverse">
+                                @forelse($report->logs as $log)
+                                    <div class="time-label" style="margin-left: 25px; margin-bottom: 10px;">
+                                        <span class="bg-maroon" style="padding: 4px 12px; border-radius: 9px; font-weight: 500;">{{ $log->created_at->format('d/m/Y') }}</span>
+                                    </div>
+                                    <div class="timeline-item d-flex align-items-start" style="margin-left: 17px; margin-bottom: 15px;">
+                                        <img src="{{ asset('img/userDefault.png') }}"
+                                            style="width: 30px; height: 30px; object-fit: cover; border-radius: 50%; margin-right: 10px;">
+                                        <div style="border: 1px solid #ccc; border-radius: 10px; padding: 10px; flex: 1;">
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <p class="mb-1" style="font-size: 0.9rem;">
+                                                    <strong>Realizado por:</strong>
+                                                    {{ $log->creator?->name ?? 'Usuario desconocido' }}
+                                                </p>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-clock"></i> {{ $log->created_at->format('H:i') }}
+                                                </small>
+                                            </div>
+                                            <hr style="margin: 8px 0; border-top: 1px solid #aaa;">
+                                            <div style="font-size: 0.9rem;">
+                                                <p class="mb-1"><strong>Estatus:</strong>
+                                                    <span class="badge" style="background-color: #007bff; color: white; padding: 6px 10px; font-size: 12px; border-radius: 4px;">{{ $log->status }}</span>
+                                                </p>
+                                                <p class="mb-1"><strong>Comentario:</strong> {{ $log->comentario ?: 'Sin comentario' }}</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @empty
+                                    <li style="list-style: none;">
+                                        <i class="fas fa-info-circle bg-gray"
+                                        style="width: 30px; height: 30px; line-height: 30px; font-size: 14px; margin-left: 10px;"></i>
+                                        <div class="timeline-item">
+                                            <div class="timeline-body" style="text-align: center;">
+                                                No hay historial registrado aún.
+                                            </div>
+                                        </div>
+                                    </li>
+                                @endforelse
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/customerFaultReports/historyModal.blade.php
+++ b/resources/views/customerFaultReports/historyModal.blade.php
@@ -45,7 +45,21 @@
                                             <hr style="margin: 8px 0; border-top: 1px solid #aaa;">
                                             <div style="font-size: 0.9rem;">
                                                 <p class="mb-1"><strong>Estatus:</strong>
-                                                    <span class="badge" style="background-color: #007bff; color: white; padding: 6px 10px; font-size: 12px; border-radius: 4px;">{{ $log->status }}</span>
+                                                    <span class="badge" style="background-color: #007bff; color: white; padding: 6px 10px; font-size: 12px; border-radius: 4px;">
+                                                        @switch($log->status)
+                                                            @case('pending')
+                                                                Pendiente
+                                                                @break
+                                                            @case('in_review')
+                                                                En revisión
+                                                                @break
+                                                            @case('completed')
+                                                                Completado
+                                                                @break
+                                                            @default
+                                                                {{ $log->status }}
+                                                        @endswitch
+                                                    </span>
                                                 </p>
                                                 <p class="mb-1"><strong>Comentario:</strong> {{ $log->comentario ?: 'Sin comentario' }}</p>
                                             </div>

--- a/resources/views/customerFaultReports/historyModal.blade.php
+++ b/resources/views/customerFaultReports/historyModal.blade.php
@@ -61,7 +61,7 @@
                                                         @endswitch
                                                     </span>
                                                 </p>
-                                                <p class="mb-1"><strong>Comentario:</strong> {{ $log->comentario ?: 'Sin comentario' }}</p>
+                                                <p class="mb-1"><strong>Comentario:</strong> {{ $log->description ?: 'Sin comentario' }}</p>
                                             </div>
                                         </div>
                                     </div>

--- a/resources/views/customerFaultReports/index.blade.php
+++ b/resources/views/customerFaultReports/index.blade.php
@@ -97,12 +97,16 @@
                                                                 <i class="fas fa-trash-alt"></i>
                                                             </button>
                                                             @endcan
+                                                            <button type="button" class="btn bg-maroon mr-2" data-toggle="modal" title="Ver Historial del Reporte" data-target="#historyModal{{ $report->id }}">
+                                                                <i class="fas fa-history"></i>
+                                                            </button>
                                                         </div>
                                                     </td>
                                                 </tr>
                                                 @include('customerFaultReports.show')
                                                 @include('customerFaultReports.edit')
                                                 @include('customerFaultReports.delete')
+                                                @include('customerFaultReports.historyModal')
                                             @endforeach
                                         @endif
                                     </tbody>

--- a/resources/views/faultReport/changeStatusModal.blade.php
+++ b/resources/views/faultReport/changeStatusModal.blade.php
@@ -1,0 +1,63 @@
+<div class="modal fade" id="changeStatusModal" tabindex="-1" role="dialog" aria-labelledby="changeStatusLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="card-header bg-purple">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Cambiar Estatus <small> &nbsp;(*) Campos requeridos</small></h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <form id="changeStatusForm" action="{{ route('faultReport.updateStatus') }}" method="POST">
+                    @csrf
+                    <div class="card-body">
+                        <div class="card">
+                            <div class="card-header py-2 bg-secondary">
+                                <h3 class="card-title">Datos del Cambio de Estatus</h3>
+                                <div class="card-tools">
+                                    <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                                        <i class="fa fa-minus"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="faultReportTitle" class="form-label">Reporte</label>
+                                            <p class="form-control-plaintext mb-0" id="faultReportTitleDisplay"></p>
+                                            <input type="hidden" name="fault_report_id" id="faultReportId">
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="statusSelect" class="form-label">Estatus(*)</label>
+                                            <select class="form-control select2" name="status" id="statusSelect" required>
+                                                <option value="">Selecciona una opción</option>
+                                                <option value="Pendiente">Pendiente</option>
+                                                <option value="En revisión">En revisión</option>
+                                                <option value="Completado">Completado</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="comentarioText" class="form-label">Comentario</label>
+                                            <textarea class="form-control" name="comentario" id="comentarioText" placeholder="Agrega un comentario" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                        <button type="submit" class="btn btn-success">Guardar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/faultReport/changeStatusModal.blade.php
+++ b/resources/views/faultReport/changeStatusModal.blade.php
@@ -36,9 +36,9 @@
                                             <label for="statusSelect" class="form-label">Estatus(*)</label>
                                             <select class="form-control select2" name="status" id="statusSelect" required>
                                                 <option value="">Selecciona una opción</option>
-                                                <option value="Pendiente">Pendiente</option>
-                                                <option value="En revisión">En revisión</option>
-                                                <option value="Completado">Completado</option>
+                                                <option value="pending">Pendiente</option>
+                                                <option value="in_review">En revisión</option>
+                                                <option value="completed">Completado</option>
                                             </select>
                                         </div>
                                     </div>

--- a/resources/views/faultReport/changeStatusModal.blade.php
+++ b/resources/views/faultReport/changeStatusModal.blade.php
@@ -44,8 +44,8 @@
                                     </div>
                                     <div class="col-lg-12">
                                         <div class="form-group">
-                                            <label for="comentarioText" class="form-label">Comentario</label>
-                                            <textarea class="form-control" name="comentario" id="comentarioText" placeholder="Agrega un comentario" rows="3"></textarea>
+                                            <label for="descriptionText" class="form-label">Comentario</label>
+                                            <textarea class="form-control" name="description" id="descriptionText" placeholder="Agrega un comentario" rows="3"></textarea>
                                         </div>
                                     </div>
                                 </div>

--- a/resources/views/faultReport/historyModal.blade.php
+++ b/resources/views/faultReport/historyModal.blade.php
@@ -1,0 +1,75 @@
+<div class="modal fade" id="historyModal{{ $report->id }}" tabindex="-1" role="dialog" aria-labelledby="historyModalLabel{{ $report->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="card-header bg-maroon">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <h4 class="card-title">Historial del Reporte</h4>
+                        <button type="button" class="close d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="card">
+                        <div class="card-header py-2 bg-secondary">
+                            <h3 class="card-title">Cambios de Estatus</h3>
+                            <div class="card-tools">
+                                <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" style="padding-left: 0;">
+                            <div style="margin-left: 27px; margin-bottom: 10px; font-size: 0.95rem;">
+                                <strong>Reporte:</strong> {{ $report->title }}
+                            </div>
+                            <ul class="timeline timeline-inverse">
+                                @forelse($report->logs as $log)
+                                    <div class="time-label" style="margin-left: 25px; margin-bottom: 10px;">
+                                        <span class="bg-maroon" style="padding: 4px 12px; border-radius: 9px; font-weight: 500;">{{ $log->created_at->format('d/m/Y') }}</span>
+                                    </div>
+                                    <div class="timeline-item d-flex align-items-start" style="margin-left: 17px; margin-bottom: 15px;">
+                                        <img src="{{ asset('img/userDefault.png') }}"
+                                            style="width: 30px; height: 30px; object-fit: cover; border-radius: 50%; margin-right: 10px;">
+                                        <div style="border: 1px solid #ccc; border-radius: 10px; padding: 10px; flex: 1;">
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <p class="mb-1" style="font-size: 0.9rem;">
+                                                    <strong>Realizado por:</strong>
+                                                    {{ $log->creator?->name ?? 'Usuario desconocido' }}
+                                                </p>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-clock"></i> {{ $log->created_at->format('H:i') }}
+                                                </small>
+                                            </div>
+                                            <hr style="margin: 8px 0; border-top: 1px solid #aaa;">
+                                            <div style="font-size: 0.9rem;">
+                                                <p class="mb-1"><strong>Estatus:</strong>
+                                                    <span class="badge" style="background-color: #007bff; color: white; padding: 6px 10px; font-size: 12px; border-radius: 4px;">{{ $log->status }}</span>
+                                                </p>
+                                                <p class="mb-1"><strong>Comentario:</strong> {{ $log->comentario ?: 'Sin comentario' }}</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @empty
+                                    <li style="list-style: none;">
+                                        <i class="fas fa-info-circle bg-gray"
+                                        style="width: 30px; height: 30px; line-height: 30px; font-size: 14px; margin-left: 10px;"></i>
+                                        <div class="timeline-item">
+                                            <div class="timeline-body" style="text-align: center;">
+                                                No hay historial registrado aún.
+                                            </div>
+                                        </div>
+                                    </li>
+                                @endforelse
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/faultReport/historyModal.blade.php
+++ b/resources/views/faultReport/historyModal.blade.php
@@ -45,7 +45,21 @@
                                             <hr style="margin: 8px 0; border-top: 1px solid #aaa;">
                                             <div style="font-size: 0.9rem;">
                                                 <p class="mb-1"><strong>Estatus:</strong>
-                                                    <span class="badge" style="background-color: #007bff; color: white; padding: 6px 10px; font-size: 12px; border-radius: 4px;">{{ $log->status }}</span>
+                                                    <span class="badge" style="background-color: #007bff; color: white; padding: 6px 10px; font-size: 12px; border-radius: 4px;">
+                                                        @switch($log->status)
+                                                            @case('pending')
+                                                                Pendiente
+                                                                @break
+                                                            @case('in_review')
+                                                                En revisión
+                                                                @break
+                                                            @case('completed')
+                                                                Completado
+                                                                @break
+                                                            @default
+                                                                {{ $log->status }}
+                                                        @endswitch
+                                                    </span>
                                                 </p>
                                                 <p class="mb-1"><strong>Comentario:</strong> {{ $log->comentario ?: 'Sin comentario' }}</p>
                                             </div>

--- a/resources/views/faultReport/historyModal.blade.php
+++ b/resources/views/faultReport/historyModal.blade.php
@@ -61,7 +61,7 @@
                                                         @endswitch
                                                     </span>
                                                 </p>
-                                                <p class="mb-1"><strong>Comentario:</strong> {{ $log->comentario ?: 'Sin comentario' }}</p>
+                                                <p class="mb-1"><strong>Comentario:</strong> {{ $log->description ?: 'Sin comentario' }}</p>
                                             </div>
                                         </div>
                                     </div>

--- a/resources/views/faultReport/index.blade.php
+++ b/resources/views/faultReport/index.blade.php
@@ -75,28 +75,37 @@
                                                     <td>
                                                         <div class="btn-group" role="group">
                                                             @can('viewFaultReport')
-                                                            <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $report->id }}">
+                                                            <button type="button" class="btn btn-info btn-sm mr-1" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $report->id }}">
                                                                 <i class="fas fa-eye"></i>
                                                             </button>
                                                             @endcan
 
                                                             @can('editFaultReport')
-                                                            <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Datos" data-target="#edit{{ $report->id }}">
+                                                            <button type="button" class="btn btn-warning btn-sm mr-1" data-toggle="modal" title="Editar Datos" data-target="#edit{{ $report->id }}">
                                                                 <i class="fas fa-edit"></i>
                                                             </button>
                                                             @endcan
 
                                                             @can('deleteFaultReport')
-                                                            <button type="button" class="btn btn-secondary mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $report->id }}" disabled>
+                                                            <button type="button" class="btn btn-secondary btn-sm mr-1" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $report->id }}">
                                                                 <i class="fas fa-trash-alt"></i>
                                                             </button>
                                                             @endcan
+
+                                                            <button type="button" class="btn bg-purple btn-sm mr-1" data-toggle="modal" title="Cambiar Estatus" data-target="#changeStatusModal" data-fault-report-id="{{ $report->id }}" data-fault-report-title="{{ $report->title }}">
+                                                                <i class="fas fa-exchange-alt"></i>
+                                                            </button>
+
+                                                            <button type="button" class="btn bg-maroon btn-sm" data-toggle="modal" title="Historial de Reporte" data-target="#historyModal{{ $report->id }}">
+                                                                <i class="fas fa-history"></i>
+                                                            </button>
                                                         </div>
                                                     </td>
                                                 </tr>
                                                 @include('faultReport.show')
                                                 @include('faultReport.edit')
                                                 @include('faultReport.delete')
+                                                @include('faultReport.historyModal')
                                             @endforeach
                                         @endif
                                     </tbody>
@@ -112,6 +121,7 @@
             </div>
         </div>
     </div>
+    @include('faultReport.changeStatusModal')
 </section>
 @endsection
 
@@ -147,6 +157,58 @@
                 confirmButtonText: 'Aceptar'
             });
         }
+
+        $('#changeStatusModal').on('show.bs.modal', function (event) {
+            var button = $(event.relatedTarget);
+            var faultReportId = button.data('fault-report-id');
+            var faultReportTitle = button.data('fault-report-title');
+
+            var modal = $(this);
+            modal.find('#faultReportId').val(faultReportId);
+            modal.find('#faultReportTitleDisplay').text(faultReportTitle);
+            modal.find('#statusSelect').val('');
+            modal.find('#comentarioText').val('');
+        });
+
+        $('#changeStatusForm').on('submit', function(e) {
+            e.preventDefault();
+            
+            var form = $(this);
+            var formData = form.serialize();
+            
+            $.ajax({
+                url: "{{ route('faultReport.updateStatus') }}", 
+                type: 'POST',
+                data: formData,
+                success: function(response) {
+                    if (response.success) {
+                        Swal.fire({
+                            icon: 'success',
+                            title: 'Éxito',
+                            text: response.message,
+                            confirmButtonText: 'Aceptar'
+                        }).then(function() {
+                            location.reload();
+                        });
+                    } else {
+                        Swal.fire({
+                            icon: 'error',
+                            title: 'Error',
+                            text: response.message,
+                            confirmButtonText: 'Aceptar'
+                        });
+                    }
+                },
+                error: function(xhr, status, error) {
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Error',
+                        text: 'Ocurrió un error al actualizar el estatus',
+                        confirmButtonText: 'Aceptar'
+                    });
+                }
+            });
+        });
     });
 </script>
 @endsection

--- a/resources/views/faultReport/index.blade.php
+++ b/resources/views/faultReport/index.blade.php
@@ -43,12 +43,7 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @if(count($reports) <= 0)
-                                            <tr>
-                                                <td colspan="6">No hay resultados</td>
-                                            </tr>
-                                        @else
-                                            @foreach($reports as $report)
+                                        @forelse($reports as $report)
                                                 <tr>
                                                     <td>{{ $report->id }}</td>
                                                     <td>{{ $report->title }}</td>
@@ -106,8 +101,11 @@
                                                 @include('faultReport.edit')
                                                 @include('faultReport.delete')
                                                 @include('faultReport.historyModal')
-                                            @endforeach
-                                        @endif
+                                        @empty
+                                            <tr>
+                                                <td colspan="6">No hay resultados</td>
+                                            </tr>
+                                        @endforelse
                                     </tbody>
                                 </table>
                                 <div class="d-flex justify-content-center">
@@ -181,23 +179,14 @@
                 type: 'POST',
                 data: formData,
                 success: function(response) {
-                    if (response.success) {
-                        Swal.fire({
-                            icon: 'success',
-                            title: 'Éxito',
-                            text: response.message,
-                            confirmButtonText: 'Aceptar'
-                        }).then(function() {
-                            location.reload();
-                        });
-                    } else {
-                        Swal.fire({
-                            icon: 'error',
-                            title: 'Error',
-                            text: response.message,
-                            confirmButtonText: 'Aceptar'
-                        });
-                    }
+                    Swal.fire({
+                        icon: response.success ? 'success' : 'error',
+                        title: response.success ? 'Éxito' : 'Error',
+                        text: response.message,
+                        confirmButtonText: 'Aceptar'
+                    }).then(function() {
+                        if (response.success) location.reload();
+                    });
                 },
                 error: function(xhr, status, error) {
                     Swal.fire({

--- a/resources/views/faultReport/index.blade.php
+++ b/resources/views/faultReport/index.blade.php
@@ -165,7 +165,7 @@
             modal.find('#faultReportId').val(faultReportId);
             modal.find('#faultReportTitleDisplay').text(faultReportTitle);
             modal.find('#statusSelect').val('');
-            modal.find('#comentarioText').val('');
+            modal.find('#descriptionText').val('');
         });
 
         $('#changeStatusForm').on('submit', function(e) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -206,6 +206,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
     Route::group(['middleware' => ['can:viewFaultReport']], function () {
         Route::get('/faultReport', [FaultReportController::class, 'index'])->name('faultReport.index');
         Route::resource('faultReport', FaultReportController::class);
+        Route::post('/faultReport/update-status', [FaultReportController::class, 'updateStatus'])->name('faultReport.updateStatus');
     });
 
     Route::group(['middleware' => ['can:viewCustomerFaultReports']], function () {


### PR DESCRIPTION
This PR introduces two new actions in the Failure Reports module:

Change Status

View History

These features were implemented to improve transparency, traceability, and overall communication with customers regarding their reported issues.

📁 Modified Files

- app/Http/Controllers/FaultReportController.php
- app/Models/FaultReport.php
- resources/views/customerFaultReports/index.blade.php
- resources/views/faultReport/index.blade.php
- routes/web.php

📁 New Files (Untracked → Added in PR)

- app/Models/LogFaultReport.php
- database/migrations/2026_02_18_120000_create_log_fault_reports_table.php
- resources/views/customerFaultReports/historyModal.blade.php
- resources/views/faultReport/changeStatusModal.blade.php
- resources/views/faultReport/historyModal.blade.php