### PR TITLE
Make Users and Memberships seeders idempotent to prevent duplicates

### DIFF
--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -12,13 +12,10 @@ class LocalitiesTableSeeder extends Seeder
 {
     public function run()
     {
-        // Asegurar que existan memberships antes de asignarlos
         if (Membership::count() === 0) {
              $this->call(MembershipsTableSeeder::class);
         }
 
-        // Map determinístico: localidad -> nombre del plan
-        // (No depende de autoincrement IDs)
         $localitiesData = [
             [
                 'name' => 'Smallville',
@@ -46,13 +43,11 @@ class LocalitiesTableSeeder extends Seeder
             ],
         ];
 
-        // Fallback determinístico: primer membership por id (NO random)
         $defaultMembershipId = Membership::orderBy('id')->value('id');
 
         foreach ($localitiesData as $data) {
             $membershipId = Membership::where('name', $data['membership_name'])->value('id') ?: $defaultMembershipId;
 
-            // 1) Crear/actualizar localidad SIN token primero (token requiere locality_id real)
             $locality = Locality::updateOrCreate(
                 ['name' => $data['name']],
                 [
@@ -64,12 +59,10 @@ class LocalitiesTableSeeder extends Seeder
                 ]
             );
 
-            // 2) Token determinístico usando el ID real de la localidad
             $locality->token = $this->generateTokenData($locality->id, (bool) $data['token_expired']);
             $locality->save();
         }
 
-        // Completar datos faltantes de forma determinística (no random)
         Locality::whereNull('membership_id')->get()->each(function ($locality) use ($defaultMembershipId) {
             $locality->membership_id = $defaultMembershipId;
             $locality->save();
@@ -80,7 +73,6 @@ class LocalitiesTableSeeder extends Seeder
             $locality->save();
         });
 
-        // Mantener tu lógica de asignación de fecha si aplica en tu schema
         Locality::whereNotNull('membership_id')
             ->whereNull('membership_assigned_at')
             ->update(['membership_assigned_at' => now()]);

--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -12,69 +12,81 @@ class LocalitiesTableSeeder extends Seeder
 {
     public function run()
     {
-        $memberships = Membership::all();
-        
-        if ($memberships->isEmpty()) {
-            $this->call(MembershipsTableSeeder::class);
-            $memberships = Membership::all();
+        // Asegurar que existan memberships antes de asignarlos
+        if (Membership::count() === 0) {
+             $this->call(MembershipsTableSeeder::class);
         }
 
+        // Map determinístico: localidad -> nombre del plan
+        // (No depende de autoincrement IDs)
         $localitiesData = [
             [
                 'name' => 'Smallville',
                 'municipality' => 'Smallville',
                 'state' => 'Kansas',
                 'zip_code' => '66002',
-                'membership_id' => 2,
-                'token' => $this->generateTokenData(false)
+                'membership_name' => 'Premium Plan - 6 Months',
+                'token_expired' => false,
             ],
             [
                 'name' => 'Springfield',
                 'municipality' => 'Springfield',
                 'state' => 'Oregon',
                 'zip_code' => '97477',
-                'membership_id' => 3,
-                'token' => $this->generateTokenData(false)
+                'membership_name' => 'Enterprise Plan - 12 Months',
+                'token_expired' => false,
             ],
             [
                 'name' => 'Dunder Mifflin',
                 'municipality' => 'Scranton',
                 'state' => 'Pennsylvania',
                 'zip_code' => '18503',
-                'membership_id' => 1,
-                'token' => $this->generateTokenData(true)
+                'membership_name' => 'Basic Plan - 3 Months',
+                'token_expired' => true,
             ],
         ];
 
+        // Fallback determinístico: primer membership por id (NO random)
+        $defaultMembershipId = Membership::orderBy('id')->value('id');
+
         foreach ($localitiesData as $data) {
-            Locality::updateOrCreate(
-                ['name' => $data['name']], 
-                $data
+            $membershipId = Membership::where('name', $data['membership_name'])->value('id') ?: $defaultMembershipId;
+
+            // 1) Crear/actualizar localidad SIN token primero (token requiere locality_id real)
+            $locality = Locality::updateOrCreate(
+                ['name' => $data['name']],
+                [
+                    'name' => $data['name'],
+                    'municipality' => $data['municipality'],
+                    'state' => $data['state'],
+                    'zip_code' => $data['zip_code'],
+                    'membership_id' => $membershipId,
+                ]
             );
+
+            // 2) Token determinístico usando el ID real de la localidad
+            $locality->token = $this->generateTokenData($locality->id, (bool) $data['token_expired']);
+            $locality->save();
         }
 
-        Locality::whereNull('membership_id')->orWhereNull('token')->get()->each(function ($locality) use ($memberships) {
-            $updateData = [];
-            
-            if (is_null($locality->membership_id)) {
-                $updateData['membership_id'] = $memberships->random()->id;
-            }
-            
-            if (is_null($locality->token) || empty($locality->token)) {
-                $updateData['token'] = $this->generateTokenData(false);
-            }
-            
-            if (!empty($updateData)) {
-                $locality->update($updateData);
-            }
+        // Completar datos faltantes de forma determinística (no random)
+        Locality::whereNull('membership_id')->get()->each(function ($locality) use ($defaultMembershipId) {
+            $locality->membership_id = $defaultMembershipId;
+            $locality->save();
         });
 
+        Locality::whereNull('token')->orWhere('token', '')->get()->each(function ($locality) {
+            $locality->token = $this->generateTokenData($locality->id, false);
+            $locality->save();
+        });
+
+        // Mantener tu lógica de asignación de fecha si aplica en tu schema
         Locality::whereNotNull('membership_id')
-                ->whereNull('membership_assigned_at')
-                ->update(['membership_assigned_at' => now()]);
+            ->whereNull('membership_assigned_at')
+            ->update(['membership_assigned_at' => now()]);
     }
 
-    private function generateTokenData(bool $isExpired = false): string
+    private function generateTokenData(int $localityId, bool $isExpired = false): string
     {
         $startDate = Carbon::now()->format('Y-m-d');
         $endDate = Carbon::now()->addYear()->format('Y-m-d');
@@ -84,6 +96,6 @@ class LocalitiesTableSeeder extends Seeder
             $endDate = Carbon::now()->subDay()->format('Y-m-d');
         }
 
-        return Token::generateTokenForLocality($localityId ?? 1, $startDate, $endDate);
+        return Token::generateTokenForLocality($localityId, $startDate, $endDate);
     }
 }

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -10,12 +10,22 @@ class MembershipsTableSeeder extends Seeder
 {
     public function run()
     {
-        $admin = User::whereHas('roles', function($q) {
-            $q->where('name', 'Admin');
-        })->first();
+        // Admin estable (si no hay rol Admin, usa el menor id disponible)
+        $adminId = User::whereHas('roles', function ($q) {
+                $q->where('name', 'Admin');
+            })
+            ->orderBy('id')
+            ->value('id');
 
-        if (!$admin) {
-            $admin = User::first();
+        if (!$adminId) {
+            $adminId = User::orderBy('id')->value('id'); // fallback estable
+        }
+
+        // Si aún así no hay usuarios, evita crashear con SQL inválido
+        // (en tu flujo normal ya existen porque UsersTableSeeder corre antes)
+        if (!$adminId) {
+            // Puedes lanzar excepción o simplemente salir; aquí salimos para no romper el seed completo
+            return;
         }
 
         $memberships = [
@@ -27,7 +37,7 @@ class MembershipsTableSeeder extends Seeder
                 'users_number' => 1,
             ],
             [
-                'name' => 'Premium Plan - 6 Months', 
+                'name' => 'Premium Plan - 6 Months',
                 'price' => 499.00,
                 'term_months' => 6,
                 'water_connections_number' => 4000,
@@ -42,6 +52,47 @@ class MembershipsTableSeeder extends Seeder
             ]
         ];
 
+        foreach ($memberships as $m) {
+            $existing = DB::table('memberships')
+                ->where('name', $m['name'])
+                ->first();
+
+            if ($existing){
+                // Update sin tocar created_by
+                DB::table('memberships')
+                    ->where('id', $existing->id)
+                    ->update([
+                    'price' => $m['price'],
+                    'term_months' => $m['term_months'],
+                    'water_connections_number' => $m['water_connections_number'],
+                    'users_number' => $m['users_number'],
+                    'updated_at' => now(),
+                ]);
+
+                // Opcional: si existe pero created_by está null, lo rellenamos 1 vez (idempotente)
+                DB::table('memberships')
+                    ->where('id', $existing->id)
+                    ->whereNull('created_by')
+                    ->update([
+                        'created_by' => $adminId,
+                        'updated_at' => now(),
+                    ]);
+            } else {
+                // Insert con created_by
+                DB::table('memberships')->insert([
+                    'name' => $m['name'],
+                    'price' => $m['price'],
+                    'term_months' => $m['term_months'],
+                    'water_connections_number' => $m['water_connections_number'],
+                    'users_number' => $m['users_number'],
+                    'created_by' => $adminId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+
+        // Mantener tu corrección de defaults, si sigue aplicando al negocio
         DB::table('memberships')
             ->where('water_connections_number', 0)
             ->orWhere('users_number', 0)
@@ -50,23 +101,5 @@ class MembershipsTableSeeder extends Seeder
                 'users_number' => 1,
                 'updated_at' => now(),
             ]);
-
-        foreach ($memberships as $membership) {
-            $existing = DB::table('memberships')
-                ->where('name', $membership['name'])
-                ->first();
-            
-            if (!$existing) {
-                DB::table('memberships')->insert([
-                    'name' => $membership['name'],
-                    'price' => $membership['price'],
-                    'term_months' => $membership['term_months'],
-                    'water_connections_number' => $membership['water_connections_number'],
-                    'users_number' => $membership['users_number'],
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-            }
-        }
     }
 }

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -10,7 +10,6 @@ class MembershipsTableSeeder extends Seeder
 {
     public function run()
     {
-        // Admin estable (si no hay rol Admin, usa el menor id disponible)
         $adminId = User::whereHas('roles', function ($q) {
                 $q->where('name', 'Admin');
             })
@@ -18,13 +17,10 @@ class MembershipsTableSeeder extends Seeder
             ->value('id');
 
         if (!$adminId) {
-            $adminId = User::orderBy('id')->value('id'); // fallback estable
+            $adminId = User::orderBy('id')->value('id');
         }
 
-        // Si aún así no hay usuarios, evita crashear con SQL inválido
-        // (en tu flujo normal ya existen porque UsersTableSeeder corre antes)
         if (!$adminId) {
-            // Puedes lanzar excepción o simplemente salir; aquí salimos para no romper el seed completo
             return;
         }
 
@@ -58,7 +54,7 @@ class MembershipsTableSeeder extends Seeder
                 ->first();
 
             if ($existing){
-                // Update sin tocar created_by
+
                 DB::table('memberships')
                     ->where('id', $existing->id)
                     ->update([
@@ -69,7 +65,6 @@ class MembershipsTableSeeder extends Seeder
                     'updated_at' => now(),
                 ]);
 
-                // Opcional: si existe pero created_by está null, lo rellenamos 1 vez (idempotente)
                 DB::table('memberships')
                     ->where('id', $existing->id)
                     ->whereNull('created_by')
@@ -78,7 +73,7 @@ class MembershipsTableSeeder extends Seeder
                         'updated_at' => now(),
                     ]);
             } else {
-                // Insert con created_by
+
                 DB::table('memberships')->insert([
                     'name' => $m['name'],
                     'price' => $m['price'],
@@ -92,7 +87,6 @@ class MembershipsTableSeeder extends Seeder
             }
         }
 
-        // Mantener tu corrección de defaults, si sigue aplicando al negocio
         DB::table('memberships')
             ->where('water_connections_number', 0)
             ->orWhere('users_number', 0)

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -10,15 +10,10 @@ class MembershipsTableSeeder extends Seeder
 {
     public function run()
     {
-        $adminId = User::whereHas('roles', function ($q) {
-                $q->where('name', 'Admin');
-            })
+        $adminId = User::whereHas('roles', fn($q) => $q->where('name', 'Admin'))
             ->orderBy('id')
-            ->value('id');
-
-        if (!$adminId) {
-            $adminId = User::orderBy('id')->value('id');
-        }
+            ->value('id')
+            ?? User::orderBy('id')->value('id');
 
         if (!$adminId) {
             return;
@@ -48,44 +43,26 @@ class MembershipsTableSeeder extends Seeder
             ]
         ];
 
-        foreach ($memberships as $m) {
-            $existing = DB::table('memberships')
-                ->where('name', $m['name'])
-                ->first();
+        $now = now();
 
-            if ($existing){
+         $payload = collect($memberships)->map(function ($m) use ($adminId, $now) {
+            return [
+                'name' => $m['name'],
+                'price' => $m['price'],
+                'term_months' => $m['term_months'],
+                'water_connections_number' => $m['water_connections_number'],
+                'users_number' => $m['users_number'],
+                'created_by' => $adminId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        })->toArray();
 
-                DB::table('memberships')
-                    ->where('id', $existing->id)
-                    ->update([
-                    'price' => $m['price'],
-                    'term_months' => $m['term_months'],
-                    'water_connections_number' => $m['water_connections_number'],
-                    'users_number' => $m['users_number'],
-                    'updated_at' => now(),
-                ]);
-
-                DB::table('memberships')
-                    ->where('id', $existing->id)
-                    ->whereNull('created_by')
-                    ->update([
-                        'created_by' => $adminId,
-                        'updated_at' => now(),
-                    ]);
-            } else {
-
-                DB::table('memberships')->insert([
-                    'name' => $m['name'],
-                    'price' => $m['price'],
-                    'term_months' => $m['term_months'],
-                    'water_connections_number' => $m['water_connections_number'],
-                    'users_number' => $m['users_number'],
-                    'created_by' => $adminId,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-            }
-        }
+        DB::table('memberships')->upsert(
+            $payload,
+            ['name'],
+            ['price', 'term_months', 'water_connections_number', 'users_number', 'updated_at']
+        );
 
         DB::table('memberships')
             ->where('water_connections_number', 0)

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -73,7 +73,7 @@ class UsersTableSeeder extends Seeder
                 'name' => $u['name'],
                 'last_name' => $u['last_name'],
                 'phone' => $u['phone'],
-                'password' => Hash::make($u['password']), // solo afecta en insert
+                'password' => Hash::make($u['password']),
                 'created_at' => $now,
                 'updated_at' => $now,
             ];

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -67,7 +67,7 @@ class UsersTableSeeder extends Seeder
             $user = User::where('email', $u['email'])->first();
 
             if (!$user) {
-                // Crear
+
                 $user = User::create([
                     'locality_id' => $u['locality_id'],
                     'name' => $u['name'],
@@ -77,7 +77,7 @@ class UsersTableSeeder extends Seeder
                     'password' => Hash::make($u['password']),
                 ]);
             } else {
-                // Actualizar datos “no sensibles” (sin tocar password)
+
                 $user->update([
                     'locality_id' => $u['locality_id'],
                     'name' => $u['name'],
@@ -86,8 +86,6 @@ class UsersTableSeeder extends Seeder
                 ]);
             }
 
-            // Rol determinístico (evita duplicidad)
-            // Si la empresa prefiere no “pisar” roles, se puede dejar assignRole con check.
             $user->syncRoles([$u['role']]);
         }
     }

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
 
 class UsersTableSeeder extends Seeder
 {
@@ -15,6 +16,8 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
+        $now = now();
+
         $users = [
             [
                 'email' => 'jose@gmail.com',
@@ -63,30 +66,29 @@ class UsersTableSeeder extends Seeder
             ],
         ];
 
-        foreach ($users as $u) {
+        $payload = collect($users)->map(function ($u) use ($now) {
+            return [
+                'email' => $u['email'],
+                'locality_id' => $u['locality_id'],
+                'name' => $u['name'],
+                'last_name' => $u['last_name'],
+                'phone' => $u['phone'],
+                'password' => Hash::make($u['password']), // solo afecta en insert
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        })->toArray();
+
+        DB::table('users')->upsert(
+            $payload,
+            ['email'],
+            ['locality_id', 'name', 'last_name', 'phone', 'updated_at']
+        );
+
+        collect($users)->each(function ($u) {
             $user = User::where('email', $u['email'])->first();
-
-            if (!$user) {
-
-                $user = User::create([
-                    'locality_id' => $u['locality_id'],
-                    'name' => $u['name'],
-                    'last_name' => $u['last_name'],
-                    'email' => $u['email'],
-                    'phone' => $u['phone'],
-                    'password' => Hash::make($u['password']),
-                ]);
-            } else {
-
-                $user->update([
-                    'locality_id' => $u['locality_id'],
-                    'name' => $u['name'],
-                    'last_name' => $u['last_name'],
-                    'phone' => $u['phone'],
-                ]);
-            }
-
-            $user->syncRoles([$u['role']]);
-        }
+            $user?->syncRoles([$u['role']]);
+        });
     }
 }
+

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -15,49 +15,80 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        User::firstOrCreate([
-            'locality_id' => null,
-            'name' => 'Jose',
-            'last_name' => 'Lopez Osorio',
-            'email' => 'jose@gmail.com',
-            'phone' => '7798745677',
-            'password' => Hash::make('12345'),
-        ])->assignRole('Admin');
+        $users = [
+            [
+                'email' => 'jose@gmail.com',
+                'locality_id' => null,
+                'name' => 'Jose',
+                'last_name' => 'Lopez Osorio',
+                'phone' => '7798745677',
+                'password' => '12345',
+                'role' => 'Admin',
+            ],
+            [
+                'email' => 'eri@gmail.com',
+                'locality_id' => 2,
+                'name' => 'Erika',
+                'last_name' => 'Lopez Perez',
+                'phone' => '7798745677',
+                'password' => '12345',
+                'role' => 'Secretaria',
+            ],
+            [
+                'email' => 'juan@gmail.com',
+                'locality_id' => 1,
+                'name' => 'Juan',
+                'last_name' => 'Perez Garcia',
+                'phone' => '5512998832',
+                'password' => '12345',
+                'role' => 'Supervisor',
+            ],
+            [
+                'email' => 'mario@gmail.com',
+                'locality_id' => 3,
+                'name' => 'Mario',
+                'last_name' => 'Gomez Fernandez',
+                'phone' => '5588997766',
+                'password' => '12345',
+                'role' =>'Supervisor',
+            ],
+            [
+                'email' => 'alonso@gmail.com',
+                'locality_id' => 1,
+                'name' => 'Alonso',
+                'last_name' => 'Gutiérrez López',
+                'phone' => '5556161351',
+                'password' => '12345',
+                'role' => 'Cliente',
+            ],
+        ];
 
-        User::firstOrCreate([
-            'locality_id' => 2,
-            'name' => 'Erika',
-            'last_name' => 'Lopez Perez',
-            'email' => 'eri@gmail.com',
-            'phone' => '7798745677',
-            'password' => Hash::make('12345'),
-        ])->assignRole('Secretaria');
+        foreach ($users as $u) {
+            $user = User::where('email', $u['email'])->first();
 
-        User::firstOrCreate([
-            'locality_id' => 1,
-            'name' => 'Juan',
-            'last_name' => 'Perez Garcia',
-            'email' => 'juan@gmail.com',
-            'phone' => '5512998832',
-            'password' => Hash::make('12345'),
-        ])->assignRole('Supervisor');
+            if (!$user) {
+                // Crear
+                $user = User::create([
+                    'locality_id' => $u['locality_id'],
+                    'name' => $u['name'],
+                    'last_name' => $u['last_name'],
+                    'email' => $u['email'],
+                    'phone' => $u['phone'],
+                    'password' => Hash::make($u['password']),
+                ]);
+            } else {
+                // Actualizar datos “no sensibles” (sin tocar password)
+                $user->update([
+                    'locality_id' => $u['locality_id'],
+                    'name' => $u['name'],
+                    'last_name' => $u['last_name'],
+                    'phone' => $u['phone'],
+                ]);
+            }
 
-        User::firstOrCreate([
-            'locality_id' => 3,
-            'name' => 'Mario',
-            'last_name' => 'Gomez Fernandez',
-            'email' => 'mario@gmail.com',
-            'phone' => '5588997766',
-            'password' => Hash::make('12345'),
-        ])->assignRole('Supervisor');
-
-        User::firstOrCreate([
-            'locality_id' => 1,
-            'name' => 'Alonso',
-            'last_name' => 'Gutiérrez López',
-            'email' => 'alonso@gmail.com',
-            'phone' => '5556161351',
-            'password' => Hash::make('12345'),
-        ])->assignRole('Cliente');
+            // Rol determinístico (evita duplicidad)
+            // Si la empresa prefiere no “pisar” roles, se puede dejar assignRole con check.
+            $user->syncRoles([$u['role']]);
+        }
     }
 }


### PR DESCRIPTION
## Objective

Prevent duplicate records in `users` and `memberships` tables when running: `php artisan migrate --seed` multiple times.

---

## Problem

Running seeders repeatedly was generating inconsistent behavior across environments:

- `UsersTableSeeder` was creating duplicate users due to the use of `Hash::make()` inside `firstOrCreate()` match criteria.
- `MembershipsTableSeeder` relied on insert-based logic and could cause inconsistencies when values changed.
- `LocalitiesTableSeeder` used hardcoded `membership_id` values (1, 2, 3), which depend on auto-increment behavior and caused foreign key constraint failures.
- Token generation logic was not using the actual `locality_id`, leading to incorrect token associations.

This made the seeding process fragile and environment-dependent.

---

## Changes Implemented

### 1. Users Seeder Refactor

- Refactored `UsersTableSeeder` to use `email` as a stable unique identifier.
- Users are now:
  - Created if they do not exist.
  - Updated (non-sensitive fields only) if they already exist.
- Password is only set during creation.
- Roles are synchronized using `syncRoles()` to prevent pivot duplication.

Result:
- No duplicate users on repeated seed execution.

---

### 2. Memberships Seeder Refactor

- Refactored `MembershipsTableSeeder` to perform deterministic upsert logic based on `name`.
- Prevents duplicate memberships.
- Updates existing records if pricing or limits change.
- Ensures `created_by` is handled safely and consistently.

Result:
- Stable membership records across multiple seed executions.

---

### 3. Localities Seeder Stabilization

- Removed hardcoded `membership_id` values.
- Memberships are now resolved dynamically by plan name.
- Eliminated random membership assignment to ensure deterministic behavior.
- Fixed foreign key constraint failures caused by invalid membership references.
- Corrected token generation logic to use the actual `locality_id` after record creation.

Result:
- No FK violations during seeding.
- Fully portable and environment-safe seed execution.
- Correct token-to-locality association.

---
## Scope

- No database constraints (unique indexes) were added in this PR.
- No business logic was modified.
- Changes are limited strictly to seeder behavior and stability.

---

## Impact

This PR improves:

- Environment portability
- Deterministic seeding
- Data integrity during development
- Team stability when running fresh migrations

The seeding process is now safe to execute multiple times without side effects.