### PR TITLE
fix: unique name for memeberships and unique email for users

### DIFF
--- a/database/migrations/2026_02_23_173108_add_unique_index_to_users_email.php
+++ b/database/migrations/2026_02_23_173108_add_unique_index_to_users_email.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('email', 'users_email_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_email_unique');
+        });
+    }
+};

--- a/database/migrations/2026_02_23_173453_add_unique_index_to_memberships_name.php
+++ b/database/migrations/2026_02_23_173453_add_unique_index_to_memberships_name.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('memberships', function (Blueprint $table) {
+            $table->unique('name', 'memberships_name_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('memberships', function (Blueprint $table) {
+            $table->dropUnique('memberships_name_unique');
+        });
+    }
+};


### PR DESCRIPTION
## Objective

Strengthen data integrity by adding database-level unique constraints for:

- `users.email`
- `memberships.name`

This change complements the previously implemented idempotent seeders.

---

## Background

Although seeders were refactored to be idempotent using declarative logic (`upsert` / `updateOrInsert` patterns), the database schema did not enforce uniqueness constraints.

Without UNIQUE indexes:

- Duplicate records were still possible.
- `upsert()` did not behave as a true upsert operation.
- Data integrity depended solely on application logic.

---

## Changes Implemented

### 1. Added UNIQUE constraint to users.email

Ensures:
- No duplicate user emails.
- Proper conflict detection during `upsert()` operations.
- Login integrity consistency.

### 2. Added UNIQUE constraint to memberships.name

Ensures:
- Catalog consistency.
- No duplicated membership plans.
- Stable behavior for seeding and updates.

---

## Data Cleanup

Before applying the constraints:

- Duplicate records were identified.
- Foreign key references were reassigned to canonical records.
- Redundant duplicates were safely removed.

This prevented migration failures.

---

## Impact

- Enables true upsert behavior.
- Moves uniqueness enforcement from application layer to database layer.
- Improves architectural robustness.
- Prevents future accidental duplication from scripts or manual inserts.

---

## Verification

- Executed `php artisan migrate`
- Ran `php artisan db:seed` multiple times
- Confirmed no duplication occurs
- Confirmed constraints block invalid inserts