### PR TITLE
Fix: Restrict customer notices to active only and improve notices visibility logic

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\Models\LocalityNotice;
 
 class Kernel extends ConsoleKernel
 {
@@ -15,7 +16,18 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->call(function () {
+            $now = now();
+
+            LocalityNotice::where('is_active', false)
+                ->where('start_date', '<=', $now)
+                ->where('end_date', '>=', $now)
+                ->update(['is_active' => true]);
+
+            LocalityNotice::where('is_active', true)
+                ->where('end_date', '<', $now)
+                ->update(['is_active' => false]);
+        })->everyMinute();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,7 +4,6 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use App\Models\LocalityNotice;
 
 class Kernel extends ConsoleKernel
 {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,18 +16,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->call(function () {
-            $now = now();
-
-            LocalityNotice::where('is_active', false)
-                ->where('start_date', '<=', $now)
-                ->where('end_date', '>=', $now)
-                ->update(['is_active' => true]);
-
-            LocalityNotice::where('is_active', true)
-                ->where('end_date', '<', $now)
-                ->update(['is_active' => false]);
-        })->everyMinute();
+        // $schedule->command('inspire')->hourly();
     }
 
     /**

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,6 +5,7 @@ use App\Models\Customer;
 use App\Models\Debt;
 use App\Models\Locality;
 use App\Models\Payment;
+use App\Models\LocalityNotice;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
@@ -71,7 +72,7 @@ class DashboardController extends Controller
         return $debt->amount - $debt->debt_current;
         });
 
-        $notices = \App\Models\LocalityNotice::with(['creator', 'locality'])
+        $notices = LocalityNotice::with(['creator', 'locality'])
             ->where('locality_id', $authUser->locality_id)
             ->where('is_active', true)
             ->where('start_date', '<=', now())

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -74,6 +74,7 @@ class DashboardController extends Controller
         $notices = \App\Models\LocalityNotice::with(['creator', 'locality'])
             ->where('locality_id', $authUser->locality_id)
             ->where('is_active', true)
+            ->where('start_date', '<=', now())
             ->where('end_date', '>=', now())
             ->orderBy('created_at', 'desc')
             ->get();

--- a/app/Http/Controllers/LocalityNoticeController.php
+++ b/app/Http/Controllers/LocalityNoticeController.php
@@ -57,6 +57,8 @@ class LocalityNoticeController extends Controller
             return redirect()->back()->with('error', 'La fecha de fin no puede ser anterior a hoy.')->withInput();
         }
 
+        $isActive = $startDate->lessThanOrEqualTo($today);
+
         $localityNotice = LocalityNotice::create([
             'created_by' => auth()->id(),
             'locality_id' => auth()->user()->locality_id,
@@ -64,14 +66,15 @@ class LocalityNoticeController extends Controller
             'description' => $request->input('description'),
             'start_date' => $request->input('start_date'),
             'end_date' => $request->input('end_date'),
-            'is_active' => true
+            'is_active' => $isActive
         ]);
 
         if ($request->hasFile('attachment')) {
             $localityNotice->addMediaFromRequest('attachment')->toMediaCollection('notice_attachments');
         }
 
-        return redirect()->route('localityNotices.index')->with('success', 'Aviso de localidad creado correctamente.');
+        $status = $isActive ? 'programado' : 'activo';
+        return redirect()->route('localityNotices.index')->with('success', "Aviso de localidad creado correctamente como {$status}.");
     }
 
     public function show($id)
@@ -107,11 +110,13 @@ class LocalityNoticeController extends Controller
                 return redirect()->back()->with('error', 'La fecha de fin no puede ser anterior a hoy.')->withInput();
             }
 
+            $isActive = $startDate->lessThanOrEqualTo($today) && $request->input('is_active', true);
+
             $localityNotice->title = $request->input('title');
             $localityNotice->description = $request->input('description');
             $localityNotice->start_date = $request->input('start_date');
             $localityNotice->end_date = $request->input('end_date');
-            $localityNotice->is_active = $request->input('is_active', true);
+            $localityNotice->is_active = $isActive;
 
             if ($request->has('remove_attachment')) {
                 $localityNotice->clearMediaCollection('notice_attachments');
@@ -149,28 +154,18 @@ class LocalityNoticeController extends Controller
         $localityNotice = LocalityNotice::find($id);
         
         if ($localityNotice) {
-            $now = now();
-            $endDate = Carbon::parse($localityNotice->end_date);
-            
-            if ($endDate->lt($now)) {
-                if ($localityNotice->is_active) {
-                    $localityNotice->is_active = false;
-                    $localityNotice->save();
-                    
-                    return redirect()->back()->with('warning', 'El aviso ha expirado y ha sido desactivado automáticamente.');
-                } else {
-                    return redirect()->back()->with('error', 'No se puede activar un aviso que ya ha expirado.');
-                }
+            if (now()->gt($localityNotice->end_date)) {
+                return redirect()->back()->with('error', 'No se puede activar un aviso expirado.');
             }
             
             $localityNotice->is_active = !$localityNotice->is_active;
             $localityNotice->save();
             $status = $localityNotice->is_active ? 'activado' : 'desactivado';
 
-            return redirect()->back()->with('success', "Aviso de localidad {$status} correctamente.");
+            return redirect()->back()->with('success', "Aviso {$status} correctamente.");
         }
 
-        return redirect()->back()->with('error', 'Aviso de localidad no encontrado.');
+        return redirect()->back()->with('error', 'Aviso no encontrado.');
     }
 
     public function downloadAttachment($id)
@@ -197,17 +192,5 @@ class LocalityNoticeController extends Controller
         } catch (\Exception $e) {
             return response()->json(['error' => $e->getMessage()], 500);
         }
-    }
-
-    public function deactivateExpiredNotices()
-    {
-        $expiredNotices = LocalityNotice::where('is_active', true)->where('end_date', '<', now())->get();
-
-        foreach ($expiredNotices as $notice) {
-            $notice->is_active = false;
-            $notice->save();
-        }
-
-        return $expiredNotices->count();
     }
 }

--- a/app/Models/LocalityNotice.php
+++ b/app/Models/LocalityNotice.php
@@ -11,6 +11,10 @@ class LocalityNotice extends Model implements HasMedia
 {
     use HasFactory, InteractsWithMedia;
 
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_SCHEDULED = 'scheduled';
+    public const STATUS_EXPIRED = 'expired';
+
     protected $table = 'locality_notices';
 
     protected $fillable = [
@@ -48,21 +52,30 @@ class LocalityNotice extends Model implements HasMedia
 
     public function scopeActive($query)
     {
+        $now = now();
         return $query->where('is_active', true)
-                    ->where('start_date', '<=', now())
-                    ->where('end_date', '>=', now());
+                    ->where('start_date', '<=', $now)
+                    ->where('end_date', '>=', $now);
     }
 
-    public function scopeByLocality($query, $localityId)
+    public function getStatusAttribute()
     {
-        return $query->where('locality_id', $localityId);
+        $now = now();
+        
+        if ($this->end_date < $now) {
+            return self::STATUS_EXPIRED;
+        }
+        
+        if ($this->start_date > $now) {
+            return self::STATUS_SCHEDULED;
+        }
+        
+        return self::STATUS_ACTIVE;
     }
 
-    public function getIsCurrentlyActiveAttribute()
+    public function isActive(): bool
     {
-        return $this->is_active && 
-               $this->start_date <= now() && 
-               $this->end_date >= now();
+        return $this->getStatusAttribute() === self::STATUS_ACTIVE && $this->is_active;
     }
 
     public function getLocalityNameAttribute()

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -39,7 +39,7 @@
                                     <div class="card-body">
                                         @if($notices && $notices->count() > 0)
                                             <div class="row">
-                                                @foreach($notices->take(3) as $notice)
+                                                @foreach($notices as $notice)
                                                     <div class="col-md-4 mb-3">
                                                         <div class="card h-100 border-left-{{ $notice->is_active ? 'success' : 'secondary' }} border-left-3">
                                                             <div class="card-body">

--- a/resources/views/localityNotices/index.blade.php
+++ b/resources/views/localityNotices/index.blade.php
@@ -42,7 +42,6 @@
                                             <tr>
                                                 <th>ID</th>
                                                 <th>TÍTULO</th>
-                                                <th>LOCALIDAD</th>
                                                 <th>FECHA Y HORA DE INICIO</th>
                                                 <th>FECHA Y HORA DE FIN</th>
                                                 <th>ESTATUS</th>
@@ -61,19 +60,15 @@
                                                         <td>
                                                             {{ Str::limit($notice->title, 40) }}                                                       
                                                         </td>
-                                                        <td>{{ $notice->locality->name }}</td>
                                                         <td>{{ $notice->start_date->format('d/m/Y H:i') }}</td>
                                                         <td>{{ $notice->end_date->format('d/m/Y H:i') }}</td>
                                                         <td>
                                                             @php
-                                                                $now = now();
-                                                                $startDate = \Carbon\Carbon::parse($notice->start_date);
-                                                                $endDate = \Carbon\Carbon::parse($notice->end_date);
-                                                                
-                                                                if ($notice->is_active && $startDate <= $now && $endDate >= $now) {
+                                                                $status = $notice->status;
+                                                                if ($status === 'active') {
                                                                     $badgeClass = 'badge-success';
                                                                     $text = 'Activo';
-                                                                } elseif ($startDate > $now) {
+                                                                } elseif ($status === 'scheduled') {
                                                                     $badgeClass = 'badge-primary';
                                                                     $text = 'Programado';
                                                                 } else {

--- a/resources/views/localityNotices/index.blade.php
+++ b/resources/views/localityNotices/index.blade.php
@@ -36,7 +36,6 @@
                     <div class="x_content">
                         <div class="row">
                             <div class="col-sm-12">
-<<<<<<< fix/customer-notice-status-and-report-list-view
                                 <div class="card-box table-responsive">
                                     <table id="notices" class="table table-striped display responsive nowrap" style="width:100%">
                                         <thead>
@@ -51,40 +50,30 @@
                                         </thead>
                                         <tbody>
                                             @if (count($localityNotices) <= 0)
-=======
-                                <div class="card-box">
-
-                                        <table id="notices" class="table table-striped display responsive nowrap" style="width:100%">
-                                            <thead>
->>>>>>> develop
                                                 <tr>
-                                                    <th></th>
-                                                    <th>ID</th>
-                                                    <th>TÍTULO</th>
-                                                    <th>LOCALIDAD</th>
-                                                    <th>FECHA Y HORA DE INICIO</th>
-                                                    <th>FECHA Y HORA DE FIN</th>
-                                                    <th>ESTATUS</th>
-                                                    <th>OPCIONES</th>
+                                                    <td colspan="6" class="text-center">No hay avisos registrados</td>
                                                 </tr>
-                                            </thead>
-                                            <tbody>
-                                                @if (count($localityNotices) <= 0)
+                                            @else
+                                                @foreach($localityNotices as $notice)
                                                     <tr>
-<<<<<<< fix/customer-notice-status-and-report-list-view
+                                                        <td></td>
                                                         <td>{{ $notice->id }}</td>
                                                         <td>
-                                                            {{ Str::limit($notice->title, 40) }}                                                       
+                                                            {{ Str::limit($notice->title, 40) }}
                                                         </td>
+                                                        <td>{{ $notice->locality->name }}</td>
                                                         <td>{{ $notice->start_date->format('d/m/Y H:i') }}</td>
                                                         <td>{{ $notice->end_date->format('d/m/Y H:i') }}</td>
                                                         <td>
                                                             @php
-                                                                $status = $notice->status;
-                                                                if ($status === 'active') {
+                                                                $now = now();
+                                                                $startDate = \Carbon\Carbon::parse($notice->start_date);
+                                                                $endDate = \Carbon\Carbon::parse($notice->end_date);
+
+                                                                if ($notice->is_active && $startDate <= $now && $endDate >= $now) {
                                                                     $badgeClass = 'badge-success';
                                                                     $text = 'Activo';
-                                                                } elseif ($status === 'scheduled') {
+                                                                } elseif ($startDate > $now) {
                                                                     $badgeClass = 'badge-primary';
                                                                     $text = 'Programado';
                                                                 } else {
@@ -92,68 +81,9 @@
                                                                     $text = 'Expirado';
                                                                 }
                                                             @endphp
-                                                            
+
                                                             <span class="badge {{ $badgeClass }} px-1 py-1">
                                                                 {{ $text }}
-                                                            </span>
-                                                        </td>
-                                                        <td>
-                                                            <div class="d-flex flex-wrap gap-0">
-                                                                @can('viewNotice')
-                                                                <button type="button" class="btn btn-info btn-sm mx-1 mb-1" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $notice->id }}">
-                                                                    <i class="fas fa-eye"></i>
-                                                                </button>
-                                                                @endcan
-                                                                @can('editNotice')
-                                                                <button type="button" class="btn btn-warning btn-sm mx-1 mb-1" data-toggle="modal" title="Editar Aviso" data-target="#edit{{ $notice->id }}">
-                                                                    <i class="fas fa-edit"></i>
-                                                                </button>
-                                                                @endcan
-                                                                @can('deleteNotice')
-                                                                <button type="button" class="btn btn-danger btn-sm mx-1 mb-1" data-toggle="modal" title="Eliminar Aviso" data-target="#delete{{ $notice->id }}">
-                                                                    <i class="fas fa-trash-alt"></i>
-                                                                </button>
-                                                                @endcan
-                                                            </div>
-                                                        </td>
-                                                        @include('localityNotices.delete', ['notice' => $notice])
-                                                        @include('localityNotices.edit', ['notice' => $notice])
-                                                        @include('localityNotices.show', ['notice' => $notice])
-=======
-                                                        <td colspan="7" class="text-center">No hay avisos registrados</td>
->>>>>>> develop
-                                                    </tr>
-                                                @else
-                                                    @foreach($localityNotices as $notice)
-                                                        <tr>
-                                                            <td></td>
-                                                            <td>{{ $notice->id }}</td>
-                                                            <td>
-                                                                {{ Str::limit($notice->title, 40) }}
-                                                            </td>
-                                                            <td>{{ $notice->locality->name }}</td>
-                                                            <td>{{ $notice->start_date->format('d/m/Y H:i') }}</td>
-                                                            <td>{{ $notice->end_date->format('d/m/Y H:i') }}</td>
-                                                            <td>
-                                                                @php
-                                                                    $now = now();
-                                                                    $startDate = \Carbon\Carbon::parse($notice->start_date);
-                                                                    $endDate = \Carbon\Carbon::parse($notice->end_date);
-
-                                                                    if ($notice->is_active && $startDate <= $now && $endDate >= $now) {
-                                                                        $badgeClass = 'badge-success';
-                                                                        $text = 'Activo';
-                                                                    } elseif ($startDate > $now) {
-                                                                        $badgeClass = 'badge-primary';
-                                                                        $text = 'Programado';
-                                                                    } else {
-                                                                        $badgeClass = 'badge-secondary';
-                                                                        $text = 'Expirado';
-                                                                    }
-                                                                @endphp
-
-                                                                <span class="badge {{ $badgeClass }} px-1 py-1">
-                                                                    {{ $text }}
                                                                 </span>
                                                             </td>
                                                             <td>
@@ -176,18 +106,13 @@
                                                                 </div>
                                                             </td>
                                                         </tr>
+                                                        @include('localityNotices.delete', ['notice' => $notice])
+                                                        @include('localityNotices.edit', ['notice' => $notice])
+                                                        @include('localityNotices.show', ['notice' => $notice])
                                                     @endforeach
-                                                @endif
-                                            </tbody>
-                                        </table>
-
-                                        @if (count($localityNotices) > 0)
-                                            @foreach($localityNotices as $notice)
-                                                @include('localityNotices.delete', ['notice' => $notice])
-                                                @include('localityNotices.edit', ['notice' => $notice])
-                                                @include('localityNotices.show', ['notice' => $notice])
-                                            @endforeach
-                                        @endif
+                                            @endif
+                                        </tbody>
+                                    </table>
 
                                     <div class="d-flex justify-content-center">
                                        {!! $localityNotices->appends(request()->query())->links('pagination::bootstrap-4') !!}


### PR DESCRIPTION
This PR updates the notice visibility logic for customers and improves the notices module behavior.

Changes include:

- Ensuring customers can only see active notices.
- Removing the previous limitation where customers could only see the last 3 notices.
- Allowing customers to view all active notices.
- Removing the locality column from the notices table view.
- Minor adjustments in dashboard and scheduling logic.

These updates improve transparency and ensure customers have full visibility of relevant notices.

📁 Modified Files

- app/Console/Kernel.php
- app/Http/Controllers/DashboardController.php
- app/Http/Controllers/LocalityNoticeController.php
- app/Models/LocalityNotice.php
- resources/views/dashboard.blade.php
- resources/views/localityNotices/index.blade.php