### PR TITLE
Fix unique constraint errors to show user-friendly messages for membe…

### DIFF
--- a/app/Http/Controllers/MembershipController.php
+++ b/app/Http/Controllers/MembershipController.php
@@ -5,13 +5,15 @@ namespace App\Http\Controllers;
 use App\Models\Membership;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Illuminate\Database\QueryException;
 
 class MembershipController extends Controller
 {
     public function index(Request $request)
     {
         $search = $request->input('search');
-        
+
         $memberships = Membership::with('creator')
             ->when($search, function($query, $search) {
                 return $query->where('name', 'like', '%'.$search.'%');
@@ -29,23 +31,41 @@ class MembershipController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255', 'unique:memberships,name'],
             'price' => 'required|numeric|min:0',
             'term_months' => 'required|integer|min:1',
-            'water_connections_number' => 'required|integer|min:0', 
-            'users_number' => 'required|integer|min:0' 
+            'water_connections_number' => 'required|integer|min:0',
+            'users_number' => 'required|integer|min:0'
+        ], [
+            'name.unique' => 'Ya existe una membresía con ese nombre.',
+            'name.required' => 'El nombre de la membresía es obligatorio.',
+            'price.required' => 'El precio es obligatorio.',
+            'term_months.required' => 'La duración es obligatoria.',
         ]);
 
-        Membership::create([
-            'created_by' => Auth::id(),
-            'name' => $request->name,
-            'price' => $request->price,
-            'term_months' => $request->term_months,
-            'water_connections_number' => $request->water_connections_number, 
-            'users_number' => $request->users_number
-        ]);
+        try {
+            Membership::create([
+                'created_by' => Auth::id(),
+                'name' => $request->name,
+                'price' => $request->price,
+                'term_months' => $request->term_months,
+                'water_connections_number' => $request->water_connections_number,
+                'users_number' => $request->users_number
+            ]);
 
         return redirect()->route('memberships.index')->with('success', 'Membresía creada exitosamente.');
+
+        } catch (QueryException $e) {
+            if (isset($e->errorInfo[1]) && (int)$e->errorInfo[1] === 1062) {
+                return redirect()->back()
+                    ->withInput()
+                    ->with('error', 'Ya existe una membresía con ese nombre.');
+            }
+
+            return redirect()->back()
+                ->withInput()
+                ->with('error', 'Hubo un problema al crear la membresía. Intenta nuevamente.');
+        }
     }
 
     public function show(Membership $membership)
@@ -62,22 +82,36 @@ class MembershipController extends Controller
     public function update(Request $request, Membership $membership)
     {
         $request->validate([
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255',  Rule::unique('memberships', 'name')->ignore($membership->id)],
             'price' => 'required|numeric|min:0',
             'term_months' => 'required|integer|min:1',
             'water_connections_number' => 'required|integer|min:0',
-            'users_number' => 'required|integer|min:0' 
+            'users_number' => 'required|integer|min:0'
+        ], [
+            'name.unique' => 'Ya existe una membresía con ese nombre.',
+            'name.required' => 'El nombre de la membresía es obligatorio.',
+            'price.required' => 'El precio es obligatorio.',
+            'term_months.required' => 'La duración es obligatoria.',
         ]);
 
+        try{
         $membership->update([
             'name' => $request->name,
             'price' => $request->price,
             'term_months' => $request->term_months,
-            'water_connections_number' => $request->water_connections_number, 
+            'water_connections_number' => $request->water_connections_number,
             'users_number' => $request->users_number
         ]);
 
         return redirect()->route('memberships.index')->with('success', 'Membresía actualizada exitosamente.');
+
+        } catch (QueryException $e) {
+            if (isset($e->errorInfo[1]) && (int)$e->errorInfo[1] === 1062) {
+                return redirect()->back()->withInput()->with('error', 'Ya existe una membresía con ese nombre.');
+            }
+
+            return redirect()->back()->withInput()->with('error', 'Hubo un problema al crear la membresía. Intenta nuevamente.');
+        }
     }
 
     public function destroy(Membership $membership)
@@ -89,7 +123,7 @@ class MembershipController extends Controller
     public function generateMembershipListReport()
     {
         $memberships = Membership::with('creator')->get();
-        
+
         return view('memberships.report', compact('memberships'));
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -8,36 +8,40 @@ use App\Models\Locality;
 use Spatie\Permission\Models\Role;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Database\QueryException;
 
 class UserController extends Controller
 {
     public function index()
     {
         $currentUserId = auth()->id();
-        
+
         $roles = Role::whereIn('name', ['Supervisor', 'Secretaria'])->get();
-        
+
         $localities = Locality::all();
-        
+
         $users = User::where('id', '!=', $currentUserId)
                     ->whereDoesntHave('roles', function($query) {
                         $query->whereIn('name', ['cliente', '$currentUserId']);
                     })
                     ->orderBy('id', 'desc')
                     ->get();
-                    
+
         return view('users.index', compact('users', 'localities', 'roles'));
     }
 
     public function store(Request $request)
     {
         $request->validate([
+            'email' => 'required|email|max:255|unique:users,email',
             'locality_id' => 'required|exists:localities,id'
+        ], [
+            'email.unique' => 'Ya existe un usuario con ese correo.',
         ]);
 
         try {
             $locality = Locality::with('membership')->findOrFail($request->locality_id);
-            
+
             if (!$locality->membership) {
                 return redirect()->back()->with('error', 'La localidad no tiene una membresía asignada. Por favor, contacte al administrador.');
             }
@@ -45,9 +49,7 @@ class UserController extends Controller
             $currentUsersCount = User::where('locality_id', $request->locality_id)->count();
 
             if ($currentUsersCount >= $locality->membership->users_number) {
-                return redirect()->back()->with('error', 
-                    'No se pueden registrar más usuarios. Límite de ' . $locality->membership->users_number . 
-                    ' usuarios alcanzado para la localidad '. $locality->name .'.');
+                return redirect()->back()->with('error', 'No se pueden registrar más usuarios. Límite de ' . $locality->membership->users_number . ' usuarios alcanzado para la localidad '. $locality->name .'.');
             }
 
             $userData = $request->only(['name', 'last_name', 'email', 'phone','locality_id']);
@@ -63,10 +65,14 @@ class UserController extends Controller
 
             return redirect()->back()->with('success', 'Usuario creado exitosamente');
 
+        } catch (QueryException $e) {
+            if (isset($e->errorInfo[1]) && (int)$e->errorInfo[1] === 1062) {
+                return redirect()->back()->withInput()->with('error', 'Ya existe un usuario con ese correo.');
+            }
+            return redirect()->back()->withInput()->with('error', 'Hubo un problema al crear el usuario. Intenta nuevamente.');
+
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             return redirect()->back()->with('error', 'Localidad no encontrada.');
-        } catch (\Exception $e) {
-            return redirect()->back()->with('error', 'Error al crear el usuario: ' . $e->getMessage());
         }
     }
 
@@ -109,9 +115,9 @@ class UserController extends Controller
     {
         $userId = Crypt::decrypt($encryptedUserId);
         $user = User::findOrFail($userId);
-        
+
         $roles = Role::whereIn('name', ['Supervisor', 'Secretaria'])->get();
-        
+
         return view('users.assignRole', compact('user', 'roles'));
     }
 

--- a/resources/views/memberships/index.blade.php
+++ b/resources/views/memberships/index.blade.php
@@ -80,7 +80,7 @@
                                                                 @endcan
                                                                 @can('deleteMemberships')
                                                                     @if($membership->hasDependencies())
-                                                                        <button type="button" class="btn btn-secondary mr-2" 
+                                                                        <button type="button" class="btn btn-secondary mr-2"
                                                                                 data-toggle="modal" title="Eliminación no permitida: Existen datos relacionados con este registro." disabled>
                                                                             <i class="fas fa-trash-alt"></i>
                                                                         </button>
@@ -127,10 +127,10 @@
                 info: false,
                 searching: false
             });
-            
+
             var successMessage = "{{ session('success') }}";
             var errorMessage = "{{ session('error') }}";
-            
+
             if (successMessage) {
                 Swal.fire({
                     icon: 'success',
@@ -139,7 +139,7 @@
                     confirmButtonText: 'Aceptar'
                 });
             }
-            
+
             if (errorMessage) {
                 Swal.fire({
                     icon: 'error',
@@ -148,6 +148,17 @@
                     confirmButtonText: 'Aceptar'
                 });
             }
+
+            @if ($errors->any())
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Error',
+                    text: @json($errors->first()),
+                    confirmButtonText: 'Aceptar'
+                });
+
+                $('#createMembership').modal('show');
+            @endif
         });
     </script>
 @endsection

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -129,6 +129,17 @@
         var successMessage = "{{ session('success') }}";
         var errorMessage = "{{ session('error') }}";
 
+        @if ($errors->any())
+            Swal.fire({
+                icon: 'error',
+                title: 'Error',
+                text: @json($errors->first()),
+                confirmButtonText: 'Aceptar'
+            });
+
+            $('#create').modal('show');
+        @endif
+
         if (successMessage) {
             Swal.fire({
                 icon: 'success',


### PR DESCRIPTION
##  Improves error handling for unique constraints in Memberships and Users.

## Changes

- Added `unique` validation for:
  - `memberships.name`
  - `users.email`
- Implemented `QueryException` handling (error code 1062) to prevent SQL error pages.
- Added SweetAlert support for Laravel validation errors using `$errors`.
- Ensured modals reopen automatically when validation fails.

## Result

- Duplicate entries no longer show technical SQL errors.
- Users now see clear and user-friendly error messages.
- Consistent error handling across Memberships and Users modules.

## Reason

This improves user experience and prevents exposure of technical database error details.