### PR TITLE
Fix: Update status seeders per locality and correct created_by in debts seeder

### DIFF
--- a/database/seeders/AdvancePaymentsSeeder.php
+++ b/database/seeders/AdvancePaymentsSeeder.php
@@ -43,7 +43,6 @@ class AdvancePaymentsSeeder extends Seeder {
                 'note' => "Deuda pagada anticipadamente por $monthsAdvance meses - registro #" . ($index + 1),
                 'deleted_at' => null,
                 'created_at' => $createdAt,
-                'updated_at' => $createdAt,
             ]);
 
             DB::table('payments')->insert([

--- a/database/seeders/CostsTableSeeder.php
+++ b/database/seeders/CostsTableSeeder.php
@@ -62,7 +62,6 @@ class CostsTableSeeder extends Seeder
                     'price' => $cost['price'],
                     'description' => $cost['description'],
                     'created_by' => $createdBy,
-                    'updated_at' => now(),
                 ]
             );
         }

--- a/database/seeders/DashboardExpiringPaidDebtsSeeder.php
+++ b/database/seeders/DashboardExpiringPaidDebtsSeeder.php
@@ -53,7 +53,6 @@ class DashboardExpiringPaidDebtsSeeder extends Seeder
                 'note' => 'Dashboard prueba deuda pagada próxima a vencer #' . ($index + 1),
                 'deleted_at' => null,
                 'created_at' => now(),
-                'updated_at' => now(),
             ]);
         }
     }

--- a/database/seeders/DebtsTableSeeder.php
+++ b/database/seeders/DebtsTableSeeder.php
@@ -15,16 +15,8 @@ class DebtsTableSeeder extends Seeder
     private const MAX_AMOUNT = 1000;
     private const DEBT_STATUSES = ['pending','partial','paid'];
 
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
-        DB::table('payments')->delete();
-        DB::table('debts')->delete();
-        
         $faker = Faker::create();
         $startDate = Carbon::createFromDate(2024, 1, 1);
         $endDate = Carbon::createFromDate(2024, 12, 31);

--- a/database/seeders/DebtsTableSeeder.php
+++ b/database/seeders/DebtsTableSeeder.php
@@ -22,64 +22,73 @@ class DebtsTableSeeder extends Seeder
      */
     public function run()
     {
+        DB::table('payments')->delete();
+        DB::table('debts')->delete();
+        
         $faker = Faker::create();
         $startDate = Carbon::createFromDate(2024, 1, 1);
         $endDate = Carbon::createFromDate(2024, 12, 31);
 
-        $alonsoCustomerId = DB::table('customers')
-            ->where('user_id', 5)
-            ->value('id');
+        $customers = DB::table('customers')
+            ->whereNotIn('user_id', [1, 5])
+            ->orWhereNull('user_id')
+            ->get();
 
-        $waterConnectionIds = DB::table('water_connections')
-            ->where('customer_id', '!=', $alonsoCustomerId)
-            ->pluck('id')
-            ->toArray();
-        foreach (range(1, self::DEBT_COUNT) as $index) {
-            if (empty($waterConnectionIds)) {
+        $debtCount = 0;
+        foreach ($customers as $customer) {
+            if ($debtCount >= self::DEBT_COUNT) {
                 break;
             }
 
-            $waterConnectionId = $faker->randomElement($waterConnectionIds);
-            $waterConnection = DB::table('water_connections')->find($waterConnectionId);
+            $waterConnections = DB::table('water_connections')
+                ->where('customer_id', $customer->id)
+                ->get();
 
-            if (!$waterConnection) {
-                continue;
+            foreach ($waterConnections as $waterConnection) {
+                if ($debtCount >= self::DEBT_COUNT) {
+                    break;
+                }
+
+                $createdBy = $this->getUserForLocality($waterConnection->locality_id);
+                if (!$createdBy) {
+                    continue;
+                }
+
+                $debtStartDate = $faker->dateTimeBetween($startDate, $endDate);
+                $debtDuration = $faker->numberBetween(1, 12);
+                $debtEndDate = Carbon::instance($debtStartDate)->addMonths($debtDuration);
+
+                if ($debtEndDate > $endDate) {
+                    $debtEndDate = $endDate;
+                }
+
+                $amount = rand(self::MIN_AMOUNT, self::MAX_AMOUNT);
+                $paymentAmount = rand(0, $amount);
+                $debtCurrent = $amount - $paymentAmount;
+                $status = $this->determineDebtStatus($paymentAmount, $debtCurrent);
+
+                DB::table('debts')->insert([
+                    'water_connection_id' => $waterConnection->id,
+                    'locality_id' => $waterConnection->locality_id,
+                    'created_by' => $createdBy,
+                    'start_date' => $debtStartDate,
+                    'end_date' => $debtEndDate,
+                    'amount' => $amount,
+                    'debt_current' => $debtCurrent,
+                    'status' => $status,
+                    'note' => 'Deuda generada de prueba #' . ($debtCount + 1),
+                    'deleted_at' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                $debtCount++;
             }
-
-            $createdBy = $this->getUserForLocality($waterConnection->locality_id);
-
-            if (!$createdBy) {
-                continue;
-            }
-
-            $debtStartDate = $faker->dateTimeBetween($startDate, $endDate);
-            $debtDuration = $faker->numberBetween(1, 12);
-            $debtEndDate = Carbon::instance($debtStartDate)->addMonths($debtDuration);
-
-            if ($debtEndDate > $endDate) {
-                $debtEndDate = $endDate;
-            }
-
-            $amount = rand(self::MIN_AMOUNT, self::MAX_AMOUNT);
-            $paymentAmount = rand(0, $amount);
-            $debtCurrent = $amount - $paymentAmount;
-            $status = $this->determineDebtStatus($paymentAmount, $debtCurrent);
-
-            DB::table('debts')->insert([
-                'water_connection_id' => $waterConnection->id,
-                'locality_id' => $waterConnection->locality_id,
-                'created_by' => $createdBy,
-                'start_date' => $debtStartDate,
-                'end_date' => $debtEndDate,
-                'amount' => $amount,
-                'debt_current' => $debtCurrent,
-                'status' => $status,
-                'note' => 'Deuda generada de prueba #' . $index,
-                'deleted_at' => null,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
         }
+
+        $alonsoCustomerId = DB::table('customers')
+            ->where('user_id', 5)
+            ->value('id');
 
         if ($alonsoCustomerId) {
             $alonsoWaterConnections = DB::table('water_connections')
@@ -129,13 +138,16 @@ class DebtsTableSeeder extends Seeder
 
     private function getUserForLocality(int $localityId): ?int
     {
-        return DB::table('users')
+        $userIds = DB::table('users')
             ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
             ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
             ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
             ->where('users.locality_id', $localityId)
+            ->whereNotIn('users.id', [1, 5])
             ->distinct()
-            ->value('users.id');
+            ->pluck('users.id')
+            ->toArray();
+        return !empty($userIds) ? $userIds[array_rand($userIds)] : null;
     }
 
     private function determineDebtStatus(int $paymentAmount, int $debtCurrent): string

--- a/database/seeders/DebtsTableSeeder.php
+++ b/database/seeders/DebtsTableSeeder.php
@@ -18,8 +18,8 @@ class DebtsTableSeeder extends Seeder
     public function run()
     {
         $faker = Faker::create();
-        $startDate = Carbon::createFromDate(2024, 1, 1);
-        $endDate = Carbon::createFromDate(2024, 12, 31);
+        $startDate = Carbon::now()->subMonths(2)->startOfMonth();
+        $endDate = Carbon::now()->endOfMonth();
 
         $customers = DB::table('customers')
             ->whereNotIn('user_id', [1, 5])
@@ -71,7 +71,6 @@ class DebtsTableSeeder extends Seeder
                     'note' => 'Deuda generada de prueba #' . ($debtCount + 1),
                     'deleted_at' => null,
                     'created_at' => now(),
-                    'updated_at' => now(),
                 ]);
 
                 $debtCount++;
@@ -107,7 +106,6 @@ class DebtsTableSeeder extends Seeder
                         'note' => 'Deuda del mes anterior',
                         'deleted_at' => null,
                         'created_at' => now(),
-                        'updated_at' => now(),
                     ]);
                     DB::table('debts')->insert([
                         'water_connection_id' => $alonsoWaterConnections[1]->id,
@@ -121,7 +119,6 @@ class DebtsTableSeeder extends Seeder
                         'note' => 'Deuda actual',
                         'deleted_at' => null,
                         'created_at' => now(),
-                        'updated_at' => now(),
                     ]);
                 }
             }

--- a/database/seeders/EarningTypeSeeder.php
+++ b/database/seeders/EarningTypeSeeder.php
@@ -32,7 +32,6 @@ class EarningTypeSeeder extends Seeder
                 'color' => color(16),
                 'created_by' => $adminUserId,
                 'created_at' => now(),
-                'updated_at' => now(),
             ]
         );
 

--- a/database/seeders/EmployeesTableSeeder.php
+++ b/database/seeders/EmployeesTableSeeder.php
@@ -51,7 +51,6 @@ class EmployeesTableSeeder extends Seeder
                 'locality_id' => $locality_id,
                 'created_by' => $faker->randomElement($userIds),
                 'created_at' => now(),
-                'updated_at' => now(),
             ]);
         }
     }

--- a/database/seeders/ExpenseTypeSeeder.php
+++ b/database/seeders/ExpenseTypeSeeder.php
@@ -32,7 +32,6 @@ class ExpenseTypeSeeder extends Seeder
                 'color'       => color(16),
                 'created_by'  => $adminUserId,
                 'created_at'  => now(),
-                'updated_at'  => now(),
             ]
         );
 
@@ -89,7 +88,6 @@ class ExpenseTypeSeeder extends Seeder
                         'color' => $type['color'],
                         'created_by' => collect($userIds)->random(),
                         'created_at' => now(),
-                        'updated_at' => now(),
                     ]
                 );
             }

--- a/database/seeders/FaultReportSeeder.php
+++ b/database/seeders/FaultReportSeeder.php
@@ -54,7 +54,6 @@ class FaultReportSeeder extends Seeder
                 'status'        => $faker->randomElement($statuses),
                 'date_report'   => $faker->dateTimeBetween('-6 months', 'now'),
                 'created_at'    => now(),
-                'updated_at'    => now(),
                 'deleted_at'    => null,
             ]);
         }

--- a/database/seeders/GeneralEarningsSeeder.php
+++ b/database/seeders/GeneralEarningsSeeder.php
@@ -34,7 +34,6 @@ class GeneralEarningsSeeder extends Seeder
                     ->where('id', $earning->id)
                     ->update([
                         'earning_type_id' => $earningType->id,
-                        'updated_at' => now()
                     ]);
             } else {
                 $generalType = EarningType::where('name', 'Operación Administrativa')

--- a/database/seeders/GeneralExpensesSeeder.php
+++ b/database/seeders/GeneralExpensesSeeder.php
@@ -97,7 +97,6 @@ class GeneralExpensesSeeder extends Seeder
                     'amount' => mt_rand(10, 50) * 100,
                     'expense_date' => $faker->dateTimeBetween('-60 days', 'now'),
                     'created_at' => now(),
-                    'updated_at' => now(),
                 ]);
                 
                 $recordsCreated++;

--- a/database/seeders/IncidentCategorySeeder.php
+++ b/database/seeders/IncidentCategorySeeder.php
@@ -4,62 +4,72 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\IncidentCategory;
+use App\Models\Locality;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
 
 class IncidentCategorySeeder extends Seeder
 {
     public function run()
     {
-        $categories = [
+        $categoryConfigs = [
             [
-                'name' => 'Mantenimiento  General',
+                'name' => 'Mantenimiento General',
                 'description' => 'Trabajos generales de reparación o conservación del sistema de agua.',
                 'color' => color(9),
-                'created_by' => 3,
-                'locality_id' => null,
             ],
             [
                 'name' => 'Eléctrica',
                 'description' => 'Problemas con instalación o alumbrado eléctrico.',
                 'color' => color(3),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
             [
                 'name' => 'Plomería',
                 'description' => 'Fugas, tuberías dañadas o problemas de agua.',
                 'color' => color(0),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
             [
                 'name' => 'Infraestructura',
                 'description' => 'Daños estructurales como techos, paredes o pisos.',
                 'color' => color(4),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
             [
                 'name' => 'Tecnología',
                 'description' => 'Fallas con equipo de cómputo, redes o sistemas.',
                 'color' => color(1),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
         ];
 
-        foreach ($categories as $category) {
-            IncidentCategory::updateOrCreate(
-                [
-                    'name' => $category['name'],
-                    'locality_id' => $category['locality_id'],
-                ],
-                [
-                    'description' => $category['description'],
-                    'color' => $category['color'],
-                    'created_by' => $category['created_by'],
-                    'updated_at' => now(),
-                ]
-            );
+        $localities = Locality::all();
+
+        foreach ($localities as $locality) {
+            $createdBy = $this->getUserForLocality($locality->id);
+            
+            foreach ($categoryConfigs as $categoryConfig) {
+                IncidentCategory::updateOrCreate(
+                    [
+                        'name' => $categoryConfig['name'],
+                        'locality_id' => $locality->id,
+                    ],
+                    [
+                        'description' => $categoryConfig['description'],
+                        'color' => $categoryConfig['color'],
+                        'created_by' => $createdBy,
+                        'updated_at' => now(),
+                    ]
+                );
+            }
         }
+    }
+
+    private function getUserForLocality(int $localityId): ?int
+    {
+        return DB::table('users')
+            ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+            ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+            ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+            ->where('users.locality_id', $localityId)
+            ->distinct()
+            ->value('users.id');
     }
 }

--- a/database/seeders/IncidentCategorySeeder.php
+++ b/database/seeders/IncidentCategorySeeder.php
@@ -55,7 +55,6 @@ class IncidentCategorySeeder extends Seeder
                         'description' => $categoryConfig['description'],
                         'color' => $categoryConfig['color'],
                         'created_by' => $createdBy,
-                        'updated_at' => now(),
                     ]
                 );
             }

--- a/database/seeders/IncidentSeeder.php
+++ b/database/seeders/IncidentSeeder.php
@@ -21,17 +21,17 @@ class IncidentSeeder extends Seeder
         foreach (Locality::all() as $locality) {
             $createdBy = $this->getUserForLocality($locality->id);
             
-            $pendienteId = IncidentStatus::where('status', 'Pendiente')
+            $pendingId = IncidentStatus::where('status', 'Pendiente')
                 ->where('locality_id', $locality->id)
                 ->value('id');
-            $enProgresoId = IncidentStatus::where('status', 'En progreso')
+            $inProgressId = IncidentStatus::where('status', 'En progreso')
                 ->where('locality_id', $locality->id)
                 ->value('id');
 
-            $plomeriaId = IncidentCategory::where('name', 'Plomería')
+            $plumbingId = IncidentCategory::where('name', 'Plomería')
                 ->where('locality_id', $locality->id)
                 ->value('id');
-            $electricaId = IncidentCategory::where('name', 'Eléctrica')
+            $electricalId = IncidentCategory::where('name', 'Eléctrica')
                 ->where('locality_id', $locality->id)
                 ->value('id');
 
@@ -39,18 +39,18 @@ class IncidentSeeder extends Seeder
                 [
                     'name' => 'Falla en iluminación',
                     'description' => 'No funcionan las luces del pasillo principal.',
-                    'status_id' => $pendienteId,
+                    'status_id' => $pendingId,
                     'start_date' => Carbon::now()->subDays(3)->toDateString(),
-                    'category_id' => $electricaId,
+                    'category_id' => $electricalId,
                     'locality_id' => $locality->id,
                     'created_by' => $createdBy,
                 ],
                 [
                     'name' => 'Fuga en baño',
                     'description' => 'Se reporta fuga de agua en el baño de hombres.',
-                    'status_id' => $enProgresoId,
+                    'status_id' => $inProgressId,
                     'start_date' => Carbon::now()->subDays(2)->toDateString(),
-                    'category_id' => $plomeriaId,
+                    'category_id' => $plumbingId,
                     'locality_id' => $locality->id,
                     'created_by' => $createdBy,
                 ],

--- a/database/seeders/IncidentSeeder.php
+++ b/database/seeders/IncidentSeeder.php
@@ -21,36 +21,30 @@ class IncidentSeeder extends Seeder
         foreach (Locality::all() as $locality) {
             $createdBy = $this->getUserForLocality($locality->id);
             
-            $pendingId = IncidentStatus::where('status', 'Pendiente')
-                ->where('locality_id', $locality->id)
-                ->value('id');
-            $inProgressId = IncidentStatus::where('status', 'En progreso')
-                ->where('locality_id', $locality->id)
-                ->value('id');
+            $statusIds = IncidentStatus::where('locality_id', $locality->id)
+                ->pluck('id')
+                ->toArray();
 
-            $plumbingId = IncidentCategory::where('name', 'Plomería')
-                ->where('locality_id', $locality->id)
-                ->value('id');
-            $electricalId = IncidentCategory::where('name', 'Eléctrica')
-                ->where('locality_id', $locality->id)
-                ->value('id');
+            $categoryIds = IncidentCategory::where('locality_id', $locality->id)
+                ->pluck('id')
+                ->toArray();
 
             $incidents = [
                 [
                     'name' => 'Falla en iluminación',
                     'description' => 'No funcionan las luces del pasillo principal.',
-                    'status_id' => $pendingId,
+                    'status_id' => $statusIds[array_rand($statusIds)] ?? null,
                     'start_date' => Carbon::now()->subDays(3)->toDateString(),
-                    'category_id' => $electricalId,
+                    'category_id' => $categoryIds[array_rand($categoryIds)] ?? null,
                     'locality_id' => $locality->id,
                     'created_by' => $createdBy,
                 ],
                 [
                     'name' => 'Fuga en baño',
                     'description' => 'Se reporta fuga de agua en el baño de hombres.',
-                    'status_id' => $inProgressId,
+                    'status_id' => $statusIds[array_rand($statusIds)] ?? null,
                     'start_date' => Carbon::now()->subDays(2)->toDateString(),
-                    'category_id' => $plumbingId,
+                    'category_id' => $categoryIds[array_rand($categoryIds)] ?? null,
                     'locality_id' => $locality->id,
                     'created_by' => $createdBy,
                 ],
@@ -68,7 +62,6 @@ class IncidentSeeder extends Seeder
                         'start_date' => $incident['start_date'],
                         'category_id' => $incident['category_id'],
                         'created_by' => $incident['created_by'],
-                        'updated_at' => now(),
                     ]
                 );
             }

--- a/database/seeders/IncidentSeeder.php
+++ b/database/seeders/IncidentSeeder.php
@@ -5,72 +5,84 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\Incident;
 use App\Models\IncidentStatus;
+use App\Models\IncidentCategory;
+use App\Models\Locality;
+use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class IncidentSeeder extends Seeder
 {
     public function run()
     {
         $this->call(IncidentStatusSeeder::class);
+        $this->call(IncidentCategorySeeder::class);
 
-        $pendienteId = IncidentStatus::where('status', 'Pendiente')->value('id');
-        $enProgresoId = IncidentStatus::where('status', 'En progreso')->value('id');
-        $terminadaId = IncidentStatus::where('status', 'Terminada')->value('id');
+        foreach (Locality::all() as $locality) {
+            $createdBy = $this->getUserForLocality($locality->id);
+            
+            $pendienteId = IncidentStatus::where('status', 'Pendiente')
+                ->where('locality_id', $locality->id)
+                ->value('id');
+            $enProgresoId = IncidentStatus::where('status', 'En progreso')
+                ->where('locality_id', $locality->id)
+                ->value('id');
 
-        $incidents = [
-            [
-                'name' => 'Falla en iluminación',
-                'description' => 'No funcionan las luces del pasillo principal.',
-                'status_id' => $pendienteId,
-                'start_date' => Carbon::now()->subDays(3)->toDateString(),
-                'category_id' => 3,
-                'locality_id' => 1,
-                'created_by' => 3,
-            ],
-            [
-                'name' => 'Fuga en baño',
-                'description' => 'Se reporta fuga de agua en el baño de hombres.',
-                'status_id' => $enProgresoId,
-                'start_date' => Carbon::now()->subDays(2)->toDateString(),
-                'category_id' => 4,
-                'locality_id' => 1,
-                'created_by' => 3,
-            ],
-            [
-                'name' => 'Ventana rota',
-                'description' => 'Ventana rota en la oficina',
-                'status_id' => $terminadaId,
-                'start_date' => Carbon::now()->subDays(5)->toDateString(),
-                'category_id' => 3,
-                'locality_id' => 1,
-                'created_by' => 3,
-            ],
-            [
-                'name' => 'Puerta dañada',
-                'description' => 'Puerta principal con bisagras flojas, requiere reparación urgente.',
-                'status_id' => $pendienteId,
-                'start_date' => Carbon::now()->subDays(1)->toDateString(),
-                'category_id' => 3,
-                'locality_id' => 1,
-                'created_by' => 3,
-            ],
-        ];
+            $plomeriaId = IncidentCategory::where('name', 'Plomería')
+                ->where('locality_id', $locality->id)
+                ->value('id');
+            $electricaId = IncidentCategory::where('name', 'Eléctrica')
+                ->where('locality_id', $locality->id)
+                ->value('id');
 
-        foreach ($incidents as $incident) {
-            Incident::updateOrCreate(
+            $incidents = [
                 [
-                    'name' => $incident['name'],
-                    'locality_id' => $incident['locality_id'],
+                    'name' => 'Falla en iluminación',
+                    'description' => 'No funcionan las luces del pasillo principal.',
+                    'status_id' => $pendienteId,
+                    'start_date' => Carbon::now()->subDays(3)->toDateString(),
+                    'category_id' => $electricaId,
+                    'locality_id' => $locality->id,
+                    'created_by' => $createdBy,
                 ],
                 [
-                    'description' => $incident['description'],
-                    'status_id' => $incident['status_id'],
-                    'start_date' => $incident['start_date'],
-                    'category_id' => $incident['category_id'],
-                    'created_by' => $incident['created_by'],
-                    'updated_at' => now(),
-                ]
-            );
+                    'name' => 'Fuga en baño',
+                    'description' => 'Se reporta fuga de agua en el baño de hombres.',
+                    'status_id' => $enProgresoId,
+                    'start_date' => Carbon::now()->subDays(2)->toDateString(),
+                    'category_id' => $plomeriaId,
+                    'locality_id' => $locality->id,
+                    'created_by' => $createdBy,
+                ],
+            ];
+
+            foreach ($incidents as $incident) {
+                Incident::updateOrCreate(
+                    [
+                        'name' => $incident['name'],
+                        'locality_id' => $incident['locality_id'],
+                    ],
+                    [
+                        'description' => $incident['description'],
+                        'status_id' => $incident['status_id'],
+                        'start_date' => $incident['start_date'],
+                        'category_id' => $incident['category_id'],
+                        'created_by' => $incident['created_by'],
+                        'updated_at' => now(),
+                    ]
+                );
+            }
         }
+    }
+
+    private function getUserForLocality(int $localityId): ?int
+    {
+        return DB::table('users')
+            ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+            ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+            ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+            ->where('users.locality_id', $localityId)
+            ->distinct()
+            ->value('users.id');
     }
 }

--- a/database/seeders/IncidentStatusSeeder.php
+++ b/database/seeders/IncidentStatusSeeder.php
@@ -50,7 +50,6 @@ class IncidentStatusSeeder extends Seeder
                         'description' => $statusConfig['description'],
                         'color' => $statusConfig['color'],
                         'created_by' => $createdBy,
-                        'updated_at' => now(),
                     ]
                 );
             }

--- a/database/seeders/IncidentStatusSeeder.php
+++ b/database/seeders/IncidentStatusSeeder.php
@@ -4,55 +4,67 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\IncidentStatus;
+use App\Models\Locality;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
 
 class IncidentStatusSeeder extends Seeder
 {
     public function run()
     {
-        $statuses = [
+        $statusConfigs = [
             [
                 'status' => 'Reportada',
                 'description' => 'Incidencia registrada y en espera de ser evaluada o asignada para su atención.',
                 'color' => color(1),
-                'created_by' => 3,
-                'locality_id' => null,
             ],
             [
                 'status' => 'Pendiente',
                 'description' => 'Incidencia en proceso de ser atendida',
                 'color' => color(13),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
             [
                 'status' => 'En progreso',
                 'description' => 'Incidencia en proceso de resolución',
                 'color' => color(12),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
             [
                 'status' => 'Terminada',
                 'description' => 'Incidencia resuelta y cerrada.',
                 'color' => color(10),
-                'created_by' => 3,
-                'locality_id' => 1,
             ],
         ];
 
-        foreach ($statuses as $status) {
-            IncidentStatus::updateOrCreate(
-                [
-                    'status' => $status['status'],
-                    'locality_id' => $status['locality_id'],
-                ],
-                [
-                    'description' => $status['description'],
-                    'color' => $status['color'],
-                    'created_by' => $status['created_by'],
-                    'updated_at' => now(),
-                ]
-            );
+        $localities = Locality::all();
+
+        foreach ($localities as $locality) {
+            $createdBy = $this->getUserForLocality($locality->id);
+            
+            foreach ($statusConfigs as $statusConfig) {
+                IncidentStatus::updateOrCreate(
+                    [
+                        'status' => $statusConfig['status'],
+                        'locality_id' => $locality->id,
+                    ],
+                    [
+                        'description' => $statusConfig['description'],
+                        'color' => $statusConfig['color'],
+                        'created_by' => $createdBy,
+                        'updated_at' => now(),
+                    ]
+                );
+            }
         }
+    }
+
+    private function getUserForLocality(int $localityId): ?int
+    {
+        return DB::table('users')
+            ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+            ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+            ->whereIn('roles.name', [User::ROLE_SUPERVISOR, User::ROLE_SECRETARY])
+            ->where('users.locality_id', $localityId)
+            ->distinct()
+            ->value('users.id');
     }
 }

--- a/database/seeders/InventoryCategorySeeder.php
+++ b/database/seeders/InventoryCategorySeeder.php
@@ -23,7 +23,6 @@ class InventoryCategorySeeder extends Seeder
                 'color' => color(2),
                 'created_by' => $firstUser,
                 'created_at' => now(),
-                'updated_at' => now(),
             ]
         );
 
@@ -75,7 +74,6 @@ class InventoryCategorySeeder extends Seeder
                         'color' => $category['color'],
                         'created_by' => $users[0],
                         'created_at' => now(),
-                        'updated_at' => now(),
                     ]
                 );
             }

--- a/database/seeders/InventoryTableSeeder.php
+++ b/database/seeders/InventoryTableSeeder.php
@@ -105,7 +105,6 @@ class InventoryTableSeeder extends Seeder
                     'material' => $item['material'],
                     'dimensions' => $item['dimensions'],
                     'created_at' => Carbon::now(),
-                    'updated_at' => Carbon::now(),
                 ];
             }
         }

--- a/database/seeders/LocalityNoticesSeeder.php
+++ b/database/seeders/LocalityNoticesSeeder.php
@@ -72,7 +72,6 @@ class LocalityNoticesSeeder extends Seeder
                         'created_by' => $faker->randomElement($userIds),
                         'attachment_url' => null,
                         'created_at' => now(),
-                        'updated_at' => now(),
                     ]);
                 }
             }

--- a/database/seeders/LogIncidentTableSeeder.php
+++ b/database/seeders/LogIncidentTableSeeder.php
@@ -57,7 +57,6 @@ class LogIncidentTableSeeder extends Seeder
                 [
                     'employee_id' => $log['employee_id'],
                     'created_by' => $log['created_by'],
-                    'updated_at' => now(),
                 ]
             );
         }

--- a/database/seeders/LogInventorySeeder.php
+++ b/database/seeders/LogInventorySeeder.php
@@ -74,7 +74,6 @@ class LogInventorySeeder extends Seeder
                     'amount' => $currentAmount,
                     'description' => $description . " (" . ($change >= 0 ? "+" : "") . $change . ")",
                     'created_at' => $createdAt,
-                    'updated_at' => $createdAt,
                 ];
                 
                 $currentAmount = $previousAmount;

--- a/database/seeders/LogWaterConnectionTransferSeeder.php
+++ b/database/seeders/LogWaterConnectionTransferSeeder.php
@@ -47,7 +47,6 @@ class LogWaterConnectionTransferSeeder extends Seeder
                 'note' => 'Transferencia de prueba generada por seeder.',
                 'created_by' => $faker->randomElement($userIds),
                 'created_at' => now(),
-                'updated_at' => now(),
             ]);
         }
     }

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -54,14 +54,13 @@ class MembershipsTableSeeder extends Seeder
                 'users_number' => $m['users_number'],
                 'created_by' => $adminId,
                 'created_at' => $now,
-                'updated_at' => $now,
             ];
         })->toArray();
 
         DB::table('memberships')->upsert(
             $payload,
             ['name'],
-            ['price', 'term_months', 'water_connections_number', 'users_number', 'updated_at']
+            ['price', 'term_months', 'water_connections_number', 'users_number']
         );
 
         DB::table('memberships')
@@ -70,7 +69,6 @@ class MembershipsTableSeeder extends Seeder
             ->update([
                 'water_connections_number' => 1000,
                 'users_number' => 1,
-                'updated_at' => now(),
             ]);
     }
 }

--- a/database/seeders/PaymentsTableSeeder.php
+++ b/database/seeders/PaymentsTableSeeder.php
@@ -106,7 +106,6 @@ class PaymentsTableSeeder extends Seeder
             'note' => 'Pago correspondiente a la deuda #' . $debt->id . ' en localidad ' . $debt->locality_id,
             'deleted_at' => null,
             'created_at' => $createdAt,
-            'updated_at' => $updatedAt,
         ];
     }
 }


### PR DESCRIPTION
**Summary**

This PR updates several seeders to improve data consistency across localities and correct ownership assignment.

Changes include:
- Updating status-related seeders to create two records per locality.
- Fixing the created_by field assignment in the Debts seeder to ensure records are properly associated with their creator.
These adjustments help maintain correct relationships and data ownership in multi-locality environments.

**Files Modified**

- database/seeders/DebtsTableSeeder.php
- database/seeders/IncidentCategorySeeder.php
- database/seeders/IncidentSeeder.php
- database/seeders/IncidentStatusSeeder.php