### PR TITLE
Integrate earnings module into movement history tracking

### DIFF
--- a/app/Http/Controllers/MovementHistoryController.php
+++ b/app/Http/Controllers/MovementHistoryController.php
@@ -167,7 +167,7 @@ class MovementHistoryController extends Controller
         ];
 
         $moduleNames = [
-            'pagos' => 'Pagos', 'deudas' => 'Deudas', 'costos' => 'Costos', 'general_expenses' => 'Gastos Generales',
+            'pagos' => 'Pagos', 'deudas' => 'Deudas', 'costos' => 'Costos', 'general_expenses' => 'Gastos Generales', 'general_earnings' => 'Ingresos',
         ];
 
         $processedMovements = $movements->map(fn($movement) => $this->processMovementData($movement, $moduleNames));
@@ -216,6 +216,7 @@ class MovementHistoryController extends Controller
             case 'deudas': case 'debts': return 'deudas';
             case 'costos': case 'costs': return 'costos';
             case 'gastos': case 'generalexpenses': case 'general_expenses': return 'general_expenses';
+            case 'ingresos': case 'earnings': case 'general_earnings': return 'general_earnings';
             default: return null;
         }
     }
@@ -297,7 +298,13 @@ class MovementHistoryController extends Controller
 
     private function shouldSkipField($key, $beforeValue, $currentValue)
     {
-        return in_array($key, ['created_at', 'updated_at', 'deleted_at']) || 
+        $skipFields = [
+            'created_at', 'updated_at', 'deleted_at',
+            'id', 'locality_id', 'created_by',
+            'earning_type_id', 'expense_type_id',
+        ];
+        
+        return in_array($key, $skipFields) || 
                $this->isComplexValue($beforeValue) || 
                $this->isComplexValue($currentValue);
     }

--- a/resources/views/localities/historyModal.blade.php
+++ b/resources/views/localities/historyModal.blade.php
@@ -21,6 +21,7 @@
                             <option value="costos">Costos</option>
                             <option value="deudas">Deudas</option>
                             <option value="gastos">Gastos</option>
+                            <option value="ingresos">Ingresos</option>
                         </select>
                     </div>
                     <div class="form-group"> 


### PR DESCRIPTION
**Summary**

This PR extends the movement history module by including records from the earnings module.

The update allows earnings-related operations to be displayed alongside other system movements, improving traceability and providing a more complete financial activity history.

**Files Modified**

- app/Http/Controllers/MovementHistoryController.php
- resources/views/localities/historyModal.blade.php