### PR TITLE
Add MovementHistorySeeder with sample records for movement history re…

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -41,5 +41,6 @@ class DatabaseSeeder extends Seeder
         $this->call(GeneralEarningsSeeder::class);
         $this->call(LogInventorySeeder::class);
         $this->call(LogWaterConnectionTransferSeeder::class);
+        $this->call(MovementsHistorySeeder::class);
     }
 }

--- a/database/seeders/MovementsHistorySeeder.php
+++ b/database/seeders/MovementsHistorySeeder.php
@@ -5,20 +5,31 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use App\Models\User;
 
 class MovementsHistorySeeder extends Seeder
 {
     public function run()
     {
         $modules = [
-            'pagos',
-            'deudas',
-            'costos',
+            'payments',
+            'debts',
+            'costs',
             'general_expenses',
             'general_earnings'
         ];
 
-        $users = DB::table('users')->pluck('id')->toArray();
+        $users = DB::table('users')
+            ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
+            ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
+            ->whereIn('roles.name', [
+                User::ROLE_SUPERVISOR,
+                User::ROLE_SECRETARY
+            ])
+            ->distinct()
+            ->pluck('users.id')
+            ->toArray();
+
 
         $records = [];
 

--- a/database/seeders/MovementsHistorySeeder.php
+++ b/database/seeders/MovementsHistorySeeder.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class MovementsHistorySeeder extends Seeder
+{
+    public function run()
+    {
+        $modules = [
+            'pagos',
+            'deudas',
+            'costos',
+            'general_expenses',
+            'general_earnings'
+        ];
+
+        $users = DB::table('users')->pluck('id')->toArray();
+
+        $records = [];
+
+        $recordId = 1;
+
+        foreach ($modules as $module) {
+
+            foreach ($users as $userId) {
+
+                for ($i = 0; $i < 2; $i++) {
+
+                    $before = [
+                        'id' => $recordId,
+                        'amount' => rand(100, 1000),
+                        'status' => 'pending'
+                    ];
+
+                    $current = [
+                        'id' => $recordId,
+                        'amount' => rand(100, 1000),
+                        'status' => 'paid'
+                    ];
+
+                    $records[] = [
+                        'alter_by' => $userId,
+                        'module' => $module,
+                        'action' => 'update',
+                        'record_id' => $recordId,
+                        'before_data' => json_encode($before),
+                        'current_data' => json_encode($current),
+                        'created_at' => Carbon::now()->subDays(rand(0, 30)),
+                        'updated_at' => Carbon::now(),
+                    ];
+
+                    $recordId++;
+                }
+            }
+        }
+
+        DB::table('movements_history')->insert($records);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a database seeder for the `movements_history` table to generate sample records for testing and development purposes.

## Changes

- Added `MovementHistorySeeder`.
- Generates sample records for multiple modules:
  - Payments
  - Debts
  - Costs
  - General Expenses
  - Earnings
- Each record includes:
  - `before_data`
  - `current_data`
  - `record_id`
  - responsible user (`alter_by`)
  - timestamps within a realistic date range.

## Purpose

This seeder allows developers to populate the Movement History module with realistic test data, making it easier to validate report generation and filtering by:

- module
- date range
- responsible user
- locality

## Notes

The JSON structure includes an `id` field so that the existing `extractRecordId()` logic used by the report generator can correctly display the **Record ID**.
