### PR TITLE
Fix/solution for duplicate cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,8 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
-# Usar tu propia URL de ngrok para el modo de pruebas con OpenPay
-#APP_URL=https://ventless-unentrenched-kati.ngrok-free.dev
-#ASSET_URL=https://ventless-unentrenched-kati.ngrok-free.dev
+#APP_URL=http://localhost
+#APP_URL=APP_URL=https://aquacontrol.rootheim.com
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-#APP_URL=http://localhost
-#APP_URL=APP_URL=https://aquacontrol.rootheim.com
+APP_URL=http://localhost
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/app/Http/Controllers/CustomerCardController.php
+++ b/app/Http/Controllers/CustomerCardController.php
@@ -93,10 +93,13 @@ class CustomerCardController extends Controller
         }
 
         $lastFour = substr(preg_replace('/[^0-9]/', '', $request->card_number), -4);
+        $expirationMonth = str_pad($request->expiration_month, 2, '0', STR_PAD_LEFT);
+        $expirationYear = str_pad($request->expiration_year, 2, '0', STR_PAD_LEFT);
+
         $duplicate = CustomerCard::where('customer_id', $customer->id)
             ->where('last_four', $lastFour)
-            ->where('expiration_month', $request->expiration_month)
-            ->where('expiration_year', $request->expiration_year)
+            ->where('expiration_month', $expirationMonth)
+            ->where('expiration_year', $expirationYear)
             ->first();
 
         if ($duplicate) {
@@ -130,8 +133,8 @@ class CustomerCardController extends Controller
             'brand' => $result['brand'] ?: $request->brand,
             'last_four' => $result['last_four'] ?: substr(preg_replace('/[^0-9]/', '', $request->card_number), -4),
             'holder_name' => $result['holder_name'] ?: $request->holder_name,
-            'expiration_month' => $result['expiration_month'] ?: $request->expiration_month,
-            'expiration_year' => $result['expiration_year'] ?: $request->expiration_year,
+            'expiration_month' => str_pad($result['expiration_month'] ?? $request->expiration_month, 2, '0', STR_PAD_LEFT),
+            'expiration_year' => str_pad($result['expiration_year'] ?? $request->expiration_year, 2, '0', STR_PAD_LEFT),
             'is_default' => $isDefault,
         ]);
 

--- a/database/migrations/2025_10_27_160701_make_locality_id_nullable_in_costs_and_remove_locality_zero.php
+++ b/database/migrations/2025_10_27_160701_make_locality_id_nullable_in_costs_and_remove_locality_zero.php
@@ -16,7 +16,7 @@ class MakeLocalityIdNullableInCostsAndRemoveLocalityZero extends Migration
         Locality::where('id', 0)->delete();
     }
 
-   public function down()
+    public function down()
     {
         $locality = Locality::first() ?? throw new \RuntimeException('No hay localidades disponibles para revertir la migración.');
         

--- a/resources/views/customerCards/addCardModal.blade.php
+++ b/resources/views/customerCards/addCardModal.blade.php
@@ -30,7 +30,7 @@
                     <div class="row">
                         <div class="col-md-6">
                             <div class="form-group">
-                                <label><i class="fas fa-tag"></i> Alias (opcional)</label>
+                                <label for="add-alias"><i class="fas fa-tag"></i> Alias (opcional)</label>
                                 <input type="text" class="form-control" id="add-alias" name="alias"
                                     placeholder="Ej: Mi tarjeta personal" maxlength="50">
                                 <small class="text-muted">Un nombre para identificar esta tarjeta</small>
@@ -38,7 +38,7 @@
                         </div>
                         <div class="col-md-6">
                             <div class="form-group">
-                                <label><i class="fas fa-user"></i> Nombre del titular</label>
+                                <label for="add-holder-name"><i class="fas fa-user"></i> Nombre del titular</label>
                                 <input type="text" class="form-control" id="add-holder-name"
                                     placeholder="Como aparece en la tarjeta" autocomplete="off"
                                     data-openpay-card="holder_name" pattern="[A-Za-z ]+"
@@ -48,7 +48,7 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label><i class="fas fa-credit-card"></i> Número de tarjeta</label>
+                        <label for="add-card-number"><i class="fas fa-credit-card"></i> Número de tarjeta</label>
                         <input type="text" class="form-control" id="add-card-number"
                             placeholder="•••• •••• •••• ••••" autocomplete="off" data-openpay-card="card_number"
                             maxlength="19" pattern="[0-9]{13,19}" inputmode="numeric"
@@ -58,7 +58,7 @@
                     <div class="row">
                         <div class="col-4">
                             <div class="form-group">
-                                <label>Mes</label>
+                                <label for="add-exp-month">Mes</label>
                                 <select class="form-control" id="add-exp-month" data-openpay-card="expiration_month" required>
                                     <option value="">MM</option>
                                     <option value="01">01</option>
@@ -78,7 +78,7 @@
                         </div>
                         <div class="col-4">
                             <div class="form-group">
-                                <label>Año</label>
+                                <label for="add-exp-year">Año</label>
                                 <input type="text" class="form-control" id="add-exp-year" placeholder="AA"
                                     maxlength="2" pattern="[0-9]{2}" inputmode="numeric"
                                     data-openpay-card="expiration_year" title="2 dígitos del año" required>
@@ -86,7 +86,7 @@
                         </div>
                         <div class="col-4">
                             <div class="form-group">
-                                <label>CVV <i class="fas fa-question-circle text-muted" title="Código de seguridad en el reverso"></i></label>
+                                <label for="add-cvv">CVV <i class="fas fa-question-circle text-muted" title="Código de seguridad en el reverso"></i></label>
                                 <input type="text" class="form-control" id="add-cvv" placeholder="•••" maxlength="4"
                                     pattern="[0-9]{3,4}" inputmode="numeric" autocomplete="off"
                                     data-openpay-card="cvv2" title="3 o 4 dígitos numéricos" required>

--- a/resources/views/customerCards/index.blade.php
+++ b/resources/views/customerCards/index.blade.php
@@ -482,7 +482,6 @@
                     'add-card-form',
                     function (response) {
                         var currentDeviceSessionId = openpayDeviceSessionId || $('input[name="deviceIdHiddenFieldName"]').val();
-                        $('#addCardModal').modal('hide');
                         showLoading('Guardando tarjeta...');
                         $.ajax({
                             url: '{{ route("customerCards.store") }}',
@@ -499,21 +498,19 @@
                                 brand: $('#add-card-brand').val() || 'unknown'
                             },
                             success: function (data) {
-                                var handlers = {
-                                    success: function() { showSuccess('Tarjeta registrada correctamente', function() { location.reload(); }); },
-                                    duplicate: function() { hideLoading(); toastr.warning(data.error, 'Tarjeta ya registrada', { timeOut: 5000 }); },
-                                    error: function() { hideLoading(); toastr.error(data.error || 'Error al guardar la tarjeta'); }
-                                };
-                                var action = data.success ? 'success' : (data.duplicate ? 'duplicate' : 'error');
-                                handlers[action]();
+                                hideLoading();
+                                showSuccess('Tarjeta registrada correctamente', function() { location.reload(); });
                             },
                             error: function (xhr) {
                                 hideLoading();
                                 var errorMsg = 'Error al guardar la tarjeta';
+
                                 if (xhr.responseJSON && xhr.responseJSON.error) {
                                     errorMsg = xhr.responseJSON.error;
                                 }
-                                toastr.error(errorMsg);
+
+                                showAddCardError(errorMsg);
+                                $('#addCardModal').modal('show');
                             }
                         });
                     },


### PR DESCRIPTION
## 🔧 Description
Fixes duplicate card validation in user profile. The backend correctly detected duplicates, but the error message was not displayed in the UI due to data format inconsistencies and improper handling of HTTP 422 errors.

## ✨ Changes
- **Backend**: Normalize expiration month/year with `str_pad()` to ensure consistent database queries
- **Frontend**: Improve AJAX error handler to capture 422 errors and display the message in the modal
- Modal remains open when a duplicate card is detected
- Error message is displayed directly in the form for better UX

## 🎯 Result
Users now receive a clear alert when trying to register a duplicate card:

⚠️ This card is already in your list (Visa •••• 4242)

## 🧪 Testing
- Register a card and verify it saves correctly
- Try to register the same card again
- Verify that the duplicate message appears in the modal