### PR TITLE
fix: block edit and delete actions for OpenPay payments

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -175,6 +175,11 @@ class PaymentController extends Controller
 
     public function update(Request $request, Payment $payment)
     {
+        if ($payment->method === 'openpay') {
+            return redirect()->route('payments.index')
+                ->with('error', 'Los pagos realizados vía OpenPay no pueden ser editados.');
+        }
+
         $debt = $payment->debt;
         $before = $payment->toArray();
 
@@ -220,6 +225,12 @@ class PaymentController extends Controller
     public function destroy($id)
     {
         $payment = Payment::findOrFail($id);
+
+        if ($payment->method === 'openpay') {
+            return redirect()->route('payments.index')
+                ->with('error', 'Los pagos realizados vía OpenPay no pueden ser eliminados.');
+        }
+
         $payment->delete();
 
         if (!$payment) {

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -113,16 +113,18 @@
                                                                 <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles" data-target="#view{{ $payment->id }}">
                                                                     <i class="fas fa-eye"></i>
                                                                 </button>
-                                                                @can('editPayment')
-                                                                <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Datos" data-target="#editPayment{{$payment->id}}">
-                                                                    <i class="fas fa-edit"></i>
-                                                                </button>
-                                                                @endcan
-                                                                @can('deletePayment')
-                                                                <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $payment->id }}">
-                                                                    <i class="fas fa-trash-alt"></i>
-                                                                </button>
-                                                                @endcan
+                                                                @if($payment->method !== 'openpay')
+                                                                    @can('editPayment')
+                                                                    <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Datos" data-target="#editPayment{{$payment->id}}">
+                                                                        <i class="fas fa-edit"></i>
+                                                                    </button>
+                                                                    @endcan
+                                                                    @can('deletePayment')
+                                                                    <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $payment->id }}">
+                                                                        <i class="fas fa-trash-alt"></i>
+                                                                    </button>
+                                                                    @endcan
+                                                                @endif
                                                                 <a type="button" class="btn btn-block bg-gradient-secondary mr-2" target="_blank" title="Generar Recibo"
                                                                     href="{{ route('reports.receiptPayment', Crypt::encrypt($payment->id)) }}">
                                                                     <i class="fas fa-file-invoice"></i>


### PR DESCRIPTION
## Summary
- Blocks the edit and delete buttons in the payments view when the method is `openpay`
- Adds validation in the backend (`PaymentController`) to reject edit/delete requests for OpenPay payments
- Prevents inconsistencies between local records and transactions processed in OpenPay

## Changed Files
- `resources/views/payments/index.blade.php`
- `application/Http/Controllers/PaymentController.php`