### PR TITLE
Feature/log fault report seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -42,5 +42,6 @@ class DatabaseSeeder extends Seeder
         $this->call(LogInventorySeeder::class);
         $this->call(LogWaterConnectionTransferSeeder::class);
         $this->call(MovementsHistorySeeder::class);
+        $this->call(LogFaultReportSeeder::class);
     }
 }

--- a/database/seeders/LogFaultReportSeeder.php
+++ b/database/seeders/LogFaultReportSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\LogFaultReport;
+
+class LogFaultReportSeeder extends Seeder
+{
+    public function run(): void
+    {
+        LogFaultReport::create([
+            'fault_report_id' => 1,
+            'locality_id' => 1,
+            'created_by' => 1,
+            'status' => LogFaultReport::STATUS_PENDING,
+            'description' => 'Primer registro de log (pendiente)'
+        ]);
+
+        LogFaultReport::create([
+            'fault_report_id' => 1,
+            'locality_id' => 1,
+            'created_by' => 1,
+            'status' => LogFaultReport::STATUS_IN_REVIEW,
+            // description omitido
+        ]);
+
+        LogFaultReport::create([
+            'fault_report_id' => 1,
+            'locality_id' => 1,
+            'created_by' => 1,
+            'status' => LogFaultReport::STATUS_COMPLETED,
+            'description' => 'Registro finalizado correctamente.'
+        ]);
+    }
+}

--- a/database/seeders/LogFaultReportSeeder.php
+++ b/database/seeders/LogFaultReportSeeder.php
@@ -12,7 +12,7 @@ class LogFaultReportSeeder extends Seeder
         LogFaultReport::create([
             'fault_report_id' => 1,
             'locality_id' => 1,
-            'created_by' => 1,
+            'created_by' => 5, 
             'status' => LogFaultReport::STATUS_PENDING,
             'description' => 'Primer registro de log (pendiente)'
         ]);
@@ -20,14 +20,14 @@ class LogFaultReportSeeder extends Seeder
         LogFaultReport::create([
             'fault_report_id' => 1,
             'locality_id' => 1,
-            'created_by' => 1,
+            'created_by' => 5,
             'status' => LogFaultReport::STATUS_IN_REVIEW,
         ]);
 
         LogFaultReport::create([
             'fault_report_id' => 1,
             'locality_id' => 1,
-            'created_by' => 1,
+            'created_by' => 5, 
             'status' => LogFaultReport::STATUS_COMPLETED,
             'description' => 'Registro finalizado correctamente.'
         ]);

--- a/database/seeders/LogFaultReportSeeder.php
+++ b/database/seeders/LogFaultReportSeeder.php
@@ -22,7 +22,6 @@ class LogFaultReportSeeder extends Seeder
             'locality_id' => 1,
             'created_by' => 1,
             'status' => LogFaultReport::STATUS_IN_REVIEW,
-            // description omitido
         ]);
 
         LogFaultReport::create([


### PR DESCRIPTION
## Description

This PR adds a seeder for the `log_fault_reports` table to provide sample data for testing and development purposes.

## Changes
- Created `LogFaultReportSeeder`
- Inserted 3 sample records with different statuses:
  - pending
  - in_review
  - completed
- Ensured all foreign keys are valid (fault_report_id, locality_id, created_by)
- Registered the seeder in `DatabaseSeeder`

## Purpose
The seeder helps simulate the lifecycle of a fault report by providing log entries that represent status changes and tracking actions.

## Notes
- Minimal data was added following project standards
- No changes were made to migrations or core system configuration