### PR TITLE
restructure customers PDF generation with pagination and new layout

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -278,14 +278,8 @@ class CustomerController extends Controller
         $firstPageCustomers = $customers->take($customersPerFirstPage);
         $remainingCustomers = $customers->slice($customersPerFirstPage);
         $otherPagesCustomers = $remainingCustomers->chunk($customersPerNextPages);
-        $totalCustomers = $customers->count();
 
-        if ($totalCustomers <= $customersPerFirstPage) {
-            $totalPages = 1;
-        } else {
-            $remainingCount = $totalCustomers - $customersPerFirstPage;
-            $totalPages = 1 + ceil($remainingCount / $customersPerNextPages);
-        }
+        $totalPages = 1 + ceil(max(0, $customers->count() - $customersPerFirstPage) / $customersPerNextPages);
 
         $pdf = PDF::loadView('reports.pdfCustomers', compact(
             'authUser',

--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -266,11 +266,33 @@ class CustomerController extends Controller
     public function pdfCustomers()
     {
         $authUser = auth()->user();
+
         $customers = Customer::where('locality_id', $authUser->locality_id)
-            ->with('user')
+            ->with(['user', 'waterConnections'])
+            ->orderBy('id')
             ->get();
-        $pdf = PDF::loadView('reports.pdfCustomers', compact('customers', 'authUser'))
-            ->setPaper('A4', 'landscape');
+
+        $customersPerFirstPage = 26;
+        $customersPerNextPages = 40;
+
+        $firstPageCustomers = $customers->take($customersPerFirstPage);
+        $remainingCustomers = $customers->slice($customersPerFirstPage);
+        $otherPagesCustomers = $remainingCustomers->chunk($customersPerNextPages);
+        $totalCustomers = $customers->count();
+
+        if ($totalCustomers <= $customersPerFirstPage) {
+            $totalPages = 1;
+        } else {
+            $remainingCount = $totalCustomers - $customersPerFirstPage;
+            $totalPages = 1 + ceil($remainingCount / $customersPerNextPages);
+        }
+
+        $pdf = PDF::loadView('reports.pdfCustomers', compact(
+            'authUser',
+            'firstPageCustomers',
+            'otherPagesCustomers',
+            'totalPages'
+        ))->setPaper('A4', 'portrait');
 
         return $pdf->stream('customers.pdf');
     }

--- a/resources/views/reports/pdfCustomers.blade.php
+++ b/resources/views/reports/pdfCustomers.blade.php
@@ -1,201 +1,333 @@
 @php
-$locality = Auth::user()->locality ?? null;
-$verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
-    ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
-    : public_path('img/backgroundReport.png');
-
-$horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizontal')
-    ? $locality->getFirstMedia('pdfBackgroundHorizontal')->getPath()
-    : public_path('img/customersBackgroundHorizontal.png');
+    $locality = Auth::user()->locality ?? null;
+    $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+        ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+        : public_path('img/backgroundReport.png');
 @endphp
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Lista de Clientes</title>
-        <style>
-            @page {
-                size: A4 portrait;
-                margin: 0;
-            }
+<head>
+    <title>Lista de Clientes</title>
+    <style>
+        @page {
+            size: A4 portrait;
+            margin: 0;
+        }
 
-            html {
-                margin: 0;
-                padding: 15px;
-            }
+        html, body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Montserrat', sans-serif;
+        }
 
-            body {
-                height: 100%;
-                margin: 0;
-                padding: 0;
-                background-image: url('file://{{ $verticalBgPath }}');
-                background-size: cover;
-                background-position: center;
-                background-repeat: no-repeat;
-            }
+        body {
+            margin: 0;
+            padding: 0;
+            background: none;
+        }
 
-            #page_pdf {
-                margin: 40px;
-            }
+        .report-page {
+            position: relative;
+            width: 100%;
+            height: 1122px;
+            overflow: hidden;
+            box-sizing: border-box;
+        }
 
-            .info_empresa {
-                width: 100%;
-                margin-top: 60px;
-                text-align: center;
-                align-content: stretch;
-                font-family: 'Montserrat', sans-serif;
-            }
+        .page-break {
+            page-break-before: always;
+        }
 
-            .aqua_titulo {
-                font-family: 'Montserrat', sans-serif;
-                font-size: 20pt;
-                font-weight: bold;
-                margin-right: 5px;
-                display: inline-block;
-                text-decoration: none;
-                color: #0B1C80;
-                text-transform: uppercase;
-            }
+        .page-bg {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 1;
+        }
 
-            p, label, span, table {
-                font-family: 'Montserrat', sans-serif;
-                font-size: 12pt;
-            }
+        .page-bg img {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
 
-            .h2 {
-                font-family: 'Montserrat', sans-serif;
-                font-size: 15pt;
-            }
+        .page-content {
+            position: absolute;
+            top: 24px;
+            left: 18px;
+            right: 18px;
+            bottom: 42px;
+            z-index: 2;
+        }
 
-            .h3 {
-                font-weight: bold;
-                font-family: 'Montserrat', sans-serif;
-                font-size: 13pt;
-                display: block;
-                color: #0B1C80;
-                text-align: left;
-                margin-bottom: 5px;
-            }
+        .page-inner {
+            width: 89%;
+            margin-left: 3%;
+            margin-right: 11%;
+        }
 
-            .textable {
-                text-align: center;
-                font-family: 'Montserrat', sans-serif;
-                font-size: 10pt;
-                color: #FFF;
-            }
+        .report-footer {
+            position: absolute;
+            left: 16px;
+            right: 16px;
+            bottom: 8px;
+            text-align: center;
+            z-index: 3;
+        }
 
-            .textcenter {
-                background-color: #FFF;
-                text-align: center;
-                font-size: 9pt;
-                font-family: 'Montserrat', sans-serif;
-            }
+        .text_infoE {
+            font-size: 10pt;
+            color: white;
+            text-decoration: none;
+            display: inline-block;
+        }
 
-            #reporte_detalle {
-                border-collapse: collapse;
-                width: 100%;
-                margin-bottom: 150px;
-                page-break-inside: auto;
-            }
+        .page-number {
+            font-weight: bold;
+            font-size: 10pt;
+            letter-spacing: 0.5px;
+        }
 
-            #reporte_detalle thead th {
-                background: #0B1C80;
-                color: #FFF;
-                padding: 5px;
-            }
+        .footer-branding {
+            color: #0B1C80 !important;
+        }
 
-            #detalle_clientes tr {
-                border-top: 1px solid #bfc9ff;
-            }
+        .footer-branding img {
+            filter: brightness(0) saturate(100%) invert(5%) sepia(100%) saturate(10000%) hue-rotate(200deg);
+        }
 
-            .info_Eabajo {
-                text-align: center;
-                margin-top: 22px;
-                padding: 10px;
-                position: absolute;
-                bottom: 1px;
-                left: 20px;
-                right: 20px;
-            }
+        .first-page-header {
+            margin-top: 0;
+            margin-bottom: 12px;
+        }
 
-            .text_infoE {
-                text-align: center;
-                font-size: 10pt;
-                font-family: 'Montserrat', sans-serif;
-                color: white;
-                text-decoration: none;
-                display: inline-block;
-            }
+        .first-page-logo-row {
+            width: 100%;
+            position: relative;
+            margin-bottom: 8px;
+        }
 
-            #reporte_head {
-                justify-content: center;
-            }
+        .first-page-logo {
+            text-align: left;
+            padding-left: 74px;
+        }
 
-            #reporte_head .logo {
-                height: auto;
-                margin-left: 60px;
-            }
+        .first-page-logo img {
+            width: 112px;
+            height: 112px;
+            border-radius: 50%;
+            display: block;
+        }
 
-            #reporte_head .logo img {
-                border-radius: 50%;
-                width: 120px;
-                height: 120px;
-            }
+        .first-page-title-block {
+            margin-top: 114px;
+            text-align: center;
+        }
 
-            .title {
-                color: #0B1C80;
-                font-family: 'Montserrat', sans-serif;
-                font-size: 12pt;
-                text-align: center;
-            }
-        </style>
-    </head>
-    <body>
-        <div id="page_pdf">
-            <table id="reporte_head">
-                <tr>
-                    <td>
-                        <div class="logo">
+        .first-page-title {
+            color: #0B1C80;
+            font-size: 18pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin: 0 0 10px 0;
+            line-height: 1.18;
+            text-align: center;
+        }
+
+        .first-page-subtitle {
+            color: #0B1C80;
+            font-size: 14pt;
+            font-weight: bold;
+            margin: 28px 0 6px 0;
+            text-align: center;
+        }
+
+        .inner-page-header {
+            width: 100%;
+            margin-top: 18px;
+            margin-bottom: 14px;
+            padding-bottom: 0;
+        }
+
+        .inner-page-committee {
+            color: #ffffff;
+            font-size: 8.5pt;
+            text-align: center;
+            margin: 0 0 4px 0;
+            line-height: 1.2;
+        }
+
+        .inner-page-title {
+            color: #ffffff;
+            font-size: 12pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            text-align: center;
+            margin: 0;
+        }
+
+        .report-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+            table-layout: fixed;
+        }
+
+        .report-table thead th {
+            background: #0B1C80;
+            color: #FFF;
+            padding: 6px 5px;
+            font-size: 10pt;
+            text-align: center;
+        }
+
+        .report-table tbody tr {
+            border-top: 1px solid #bfc9ff;
+        }
+
+        .report-table td {
+            background-color: transparent;
+            text-align: center;
+            font-size: 9pt;
+            padding: 4px 6px;
+            word-wrap: break-word;
+            line-height: 1.15;
+        }
+
+        .report-table th:nth-child(1),
+        .report-table td:nth-child(1) {
+            width: 12%;
+        }
+
+        .report-table th:nth-child(2),
+        .report-table td:nth-child(2) {
+            width: 28%;
+        }
+
+        .report-table th:nth-child(3),
+        .report-table td:nth-child(3) {
+            width: 40%;
+        }
+
+        .report-table th:nth-child(4),
+        .report-table td:nth-child(4) {
+            width: 20%;
+        }
+    </style>
+</head>
+<body>
+    <div class="report-page">
+        <div class="page-bg">
+            <img src="file://{{ $verticalBgPath }}" alt="Background">
+        </div>
+        <div class="page-content">
+            <div class="page-inner">
+                <div class="first-page-header">
+                    <div class="first-page-logo-row">
+                        <div class="first-page-logo">
                             @if ($authUser->locality->hasMedia('localityGallery'))
-                                <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}" alt="Photo of {{ $authUser->locality->name }}">
+                                <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}"
+                                     alt="Photo of {{ $authUser->locality->name }}">
                             @else
-                                <img src='img/localityDefault.png' alt="Default Photo">
+                                <img src="{{ public_path('img/localityDefault.png') }}" alt="Default Photo">
                             @endif
                         </div>
-                    </td>
-                </tr>
-            </table>
-            <div class="info_empresa">
-                <p class="aqua_titulo">
-                    COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
-                </p>
-            </div>
-            <div class="title">
-                <h3>LISTA DE CLIENTES</h3>
-            </div>
-            <table id="reporte_detalle">
-                <thead>
-                    <tr>
-                        <th class="textable">ID</th>
-                        <th class="textable">NOMBRE</th>
-                        <th class="textable">DIRECCIÓN</th>
-                        <th class="textable">NUM. DE TOMAS</th>
-                    </tr>
-                </thead>
-                <tbody id="detalle_clientes">
-                    @foreach ($customers as $customer)
+                    </div>
+                    <div class="first-page-title-block">
+                        <p class="first-page-title">
+                            COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
+                        </p>
+                        <p class="first-page-subtitle">LISTA DE CLIENTES</p>
+                    </div>
+                </div>
+                <table class="report-table">
+                    <thead>
                         <tr>
-                            <td class="textcenter">{{ $customer->id }}</td>
-                            <td class="textcenter">{{ $customer->name }} {{ $customer->last_name }}</td>
-                            <td class="textcenter"> {{ $customer->street }} No. Ext.{{ $customer->interior_number }} No. Int.{{ $customer->interior_number }}</td>
-                            <td class="textcenter">{{ $customer->waterConnections->count() }}</td>
+                            <th>ID</th>
+                            <th>NOMBRE</th>
+                            <th>DIRECCIÓN</th>
+                            <th>NUM. DE TOMAS</th>
                         </tr>
-                    @endforeach
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        @foreach ($firstPageCustomers as $customer)
+                            <tr>
+                                <td>{{ $customer->id }}</td>
+                                <td>{{ $customer->name }} {{ $customer->last_name }}</td>
+                                <td>
+                                    {{ $customer->street }}
+                                    No. Ext.{{ $customer->exterior_number ?? '' }}
+                                    No. Int.{{ $customer->interior_number ?? '' }}
+                                </td>
+                                <td>{{ $customer->waterConnections->count() }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
         </div>
-        <div class="info_Eabajo">
+        <div class="report-footer">
             <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
-            <a class="text_infoE" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a><img src="img/rootheim.png" width="20px" height="15px">
+            <span class="text_infoE"> | </span>
+            <span class="text_infoE page-number">Página 1 de {{ $totalPages }}</span>
+            <span class="text_infoE"> | </span>
+            <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+            <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
         </div>
-    </body>
+    </div>
+
+    @foreach ($otherPagesCustomers as $pageCustomers)
+        <div class="report-page page-break">
+            <div class="page-bg">
+                <img src="file://{{ $verticalBgPath }}" alt="Background">
+            </div>
+
+            <div class="page-content">
+                <div class="page-inner">
+                    <div class="inner-page-header">
+                        <p class="inner-page-committee">
+                            COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
+                        </p>
+                        <p class="inner-page-title">LISTA DE CLIENTES</p>
+                    </div>
+
+                    <table class="report-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>NOMBRE</th>
+                                <th>DIRECCIÓN</th>
+                                <th>NUM. DE TOMAS</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($pageCustomers as $customer)
+                                <tr>
+                                    <td>{{ $customer->id }}</td>
+                                    <td>{{ $customer->name }} {{ $customer->last_name }}</td>
+                                    <td>
+                                        {{ $customer->street }}
+                                        No. Ext.{{ $customer->exterior_number ?? '' }}
+                                        No. Int.{{ $customer->interior_number ?? '' }}
+                                    </td>
+                                    <td>{{ $customer->waterConnections->count() }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="report-footer">
+                <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                <span class="text_infoE"> | </span>
+                <span class="text_infoE page-number">Página {{ $loop->iteration + 1 }} de {{ $totalPages }}</span>
+                <span class="text_infoE"> | </span>
+                <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+            </div>
+        </div>
+    @endforeach
+</body>
 </html>

--- a/resources/views/reports/pdfCustomers.blade.php
+++ b/resources/views/reports/pdfCustomers.blade.php
@@ -6,293 +6,242 @@
 @endphp
 <!DOCTYPE html>
 <html>
-<head>
-    <title>Lista de Clientes</title>
-    <style>
-        @page {
-            size: A4 portrait;
-            margin: 0;
-        }
+    <head>
+        <title>Lista de Clientes</title>
+        <style>
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
 
-        html, body {
-            margin: 0;
-            padding: 0;
-            font-family: 'Montserrat', sans-serif;
-        }
+            html, body {
+                margin: 0;
+                padding: 0;
+                font-family: 'Montserrat', sans-serif;
+            }
 
-        body {
-            margin: 0;
-            padding: 0;
-            background: none;
-        }
+            body {
+                margin: 0;
+                padding: 0;
+                background: none;
+            }
 
-        .report-page {
-            position: relative;
-            width: 100%;
-            height: 1122px;
-            overflow: hidden;
-            box-sizing: border-box;
-        }
+            .report-page {
+                position: relative;
+                width: 100%;
+                height: 1122px;
+                overflow: hidden;
+                box-sizing: border-box;
+            }
 
-        .page-break {
-            page-break-before: always;
-        }
+            .page-break {
+                page-break-before: always;
+            }
 
-        .page-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            z-index: 1;
-        }
+            .page-bg {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                z-index: 1;
+            }
 
-        .page-bg img {
-            width: 100%;
-            height: 100%;
-            display: block;
-        }
+            .page-bg img {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
 
-        .page-content {
-            position: absolute;
-            top: 24px;
-            left: 18px;
-            right: 18px;
-            bottom: 42px;
-            z-index: 2;
-        }
+            .page-content {
+                position: absolute;
+                top: 24px;
+                left: 18px;
+                right: 18px;
+                bottom: 42px;
+                z-index: 2;
+            }
 
-        .page-inner {
-            width: 89%;
-            margin-left: 3%;
-            margin-right: 11%;
-        }
+            .page-inner {
+                width: 89%;
+                margin-left: 3%;
+                margin-right: 11%;
+            }
 
-        .report-footer {
-            position: absolute;
-            left: 16px;
-            right: 16px;
-            bottom: 8px;
-            text-align: center;
-            z-index: 3;
-        }
+            .report-footer {
+                position: absolute;
+                left: 16px;
+                right: 16px;
+                bottom: 8px;
+                text-align: center;
+                z-index: 3;
+            }
 
-        .text_infoE {
-            font-size: 10pt;
-            color: white;
-            text-decoration: none;
-            display: inline-block;
-        }
+            .text_infoE {
+                font-size: 10pt;
+                color: white;
+                text-decoration: none;
+                display: inline-block;
+            }
 
-        .page-number {
-            font-weight: bold;
-            font-size: 10pt;
-            letter-spacing: 0.5px;
-        }
+            .page-number {
+                font-weight: bold;
+                font-size: 10pt;
+                letter-spacing: 0.5px;
+            }
 
-        .footer-branding {
-            color: #0B1C80 !important;
-        }
+            .footer-branding {
+                color: #0B1C80 !important;
+            }
 
-        .footer-branding img {
-            filter: brightness(0) saturate(100%) invert(5%) sepia(100%) saturate(10000%) hue-rotate(200deg);
-        }
+            .footer-branding img {
+                filter: brightness(0) saturate(100%) invert(5%) sepia(100%) saturate(10000%) hue-rotate(200deg);
+            }
 
-        .first-page-header {
-            margin-top: 0;
-            margin-bottom: 12px;
-        }
+            .first-page-header {
+                margin-top: 0;
+                margin-bottom: 12px;
+            }
 
-        .first-page-logo-row {
-            width: 100%;
-            position: relative;
-            margin-bottom: 8px;
-        }
+            .first-page-logo-row {
+                width: 100%;
+                position: relative;
+                margin-bottom: 8px;
+            }
 
-        .first-page-logo {
-            text-align: left;
-            padding-left: 74px;
-        }
+            .first-page-logo {
+                text-align: left;
+                padding-left: 74px;
+            }
 
-        .first-page-logo img {
-            width: 112px;
-            height: 112px;
-            border-radius: 50%;
-            display: block;
-        }
+            .first-page-logo img {
+                width: 112px;
+                height: 112px;
+                border-radius: 50%;
+                display: block;
+            }
 
-        .first-page-title-block {
-            margin-top: 114px;
-            text-align: center;
-        }
+            .first-page-title-block {
+                margin-top: 114px;
+                text-align: center;
+            }
 
-        .first-page-title {
-            color: #0B1C80;
-            font-size: 18pt;
-            font-weight: bold;
-            text-transform: uppercase;
-            margin: 0 0 10px 0;
-            line-height: 1.18;
-            text-align: center;
-        }
+            .first-page-title {
+                color: #0B1C80;
+                font-size: 18pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                margin: 0 0 10px 0;
+                line-height: 1.18;
+                text-align: center;
+            }
 
-        .first-page-subtitle {
-            color: #0B1C80;
-            font-size: 14pt;
-            font-weight: bold;
-            margin: 28px 0 6px 0;
-            text-align: center;
-        }
+            .first-page-subtitle {
+                color: #0B1C80;
+                font-size: 14pt;
+                font-weight: bold;
+                margin: 28px 0 6px 0;
+                text-align: center;
+            }
 
-        .inner-page-header {
-            width: 100%;
-            margin-top: 18px;
-            margin-bottom: 14px;
-            padding-bottom: 0;
-        }
+            .inner-page-header {
+                width: 100%;
+                margin-top: 18px;
+                margin-bottom: 14px;
+                padding-bottom: 0;
+            }
 
-        .inner-page-committee {
-            color: #ffffff;
-            font-size: 8.5pt;
-            text-align: center;
-            margin: 0 0 4px 0;
-            line-height: 1.2;
-        }
+            .inner-page-committee {
+                color: #ffffff;
+                font-size: 8.5pt;
+                text-align: center;
+                margin: 0 0 4px 0;
+                line-height: 1.2;
+            }
 
-        .inner-page-title {
-            color: #ffffff;
-            font-size: 12pt;
-            font-weight: bold;
-            text-transform: uppercase;
-            text-align: center;
-            margin: 0;
-        }
+            .inner-page-title {
+                color: #ffffff;
+                font-size: 12pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                text-align: center;
+                margin: 0;
+            }
 
-        .report-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 8px;
-            table-layout: fixed;
-        }
+            .report-table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 8px;
+                table-layout: fixed;
+            }
 
-        .report-table thead th {
-            background: #0B1C80;
-            color: #FFF;
-            padding: 6px 5px;
-            font-size: 10pt;
-            text-align: center;
-        }
+            .report-table thead th {
+                background: #0B1C80;
+                color: #FFF;
+                padding: 6px 5px;
+                font-size: 10pt;
+                text-align: center;
+            }
 
-        .report-table tbody tr {
-            border-top: 1px solid #bfc9ff;
-        }
+            .report-table tbody tr {
+                border-top: 1px solid #bfc9ff;
+            }
 
-        .report-table td {
-            background-color: transparent;
-            text-align: center;
-            font-size: 9pt;
-            padding: 4px 6px;
-            word-wrap: break-word;
-            line-height: 1.15;
-        }
+            .report-table td {
+                background-color: transparent;
+                text-align: center;
+                font-size: 9pt;
+                padding: 4px 6px;
+                word-wrap: break-word;
+                line-height: 1.15;
+            }
 
-        .report-table th:nth-child(1),
-        .report-table td:nth-child(1) {
-            width: 12%;
-        }
+            .report-table th:nth-child(1),
+            .report-table td:nth-child(1) {
+                width: 12%;
+            }
 
-        .report-table th:nth-child(2),
-        .report-table td:nth-child(2) {
-            width: 28%;
-        }
+            .report-table th:nth-child(2),
+            .report-table td:nth-child(2) {
+                width: 28%;
+            }
 
-        .report-table th:nth-child(3),
-        .report-table td:nth-child(3) {
-            width: 40%;
-        }
+            .report-table th:nth-child(3),
+            .report-table td:nth-child(3) {
+                width: 40%;
+            }
 
-        .report-table th:nth-child(4),
-        .report-table td:nth-child(4) {
-            width: 20%;
-        }
-    </style>
-</head>
-<body>
-    <div class="report-page">
-        <div class="page-bg">
-            <img src="file://{{ $verticalBgPath }}" alt="Background">
-        </div>
-        <div class="page-content">
-            <div class="page-inner">
-                <div class="first-page-header">
-                    <div class="first-page-logo-row">
-                        <div class="first-page-logo">
-                            @if ($authUser->locality->hasMedia('localityGallery'))
-                                <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}"
-                                     alt="Photo of {{ $authUser->locality->name }}">
-                            @else
-                                <img src="{{ public_path('img/localityDefault.png') }}" alt="Default Photo">
-                            @endif
-                        </div>
-                    </div>
-                    <div class="first-page-title-block">
-                        <p class="first-page-title">
-                            COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
-                        </p>
-                        <p class="first-page-subtitle">LISTA DE CLIENTES</p>
-                    </div>
-                </div>
-                <table class="report-table">
-                    <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>NOMBRE</th>
-                            <th>DIRECCIÓN</th>
-                            <th>NUM. DE TOMAS</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach ($firstPageCustomers as $customer)
-                            <tr>
-                                <td>{{ $customer->id }}</td>
-                                <td>{{ $customer->name }} {{ $customer->last_name }}</td>
-                                <td>
-                                    {{ $customer->street }}
-                                    No. Ext.{{ $customer->exterior_number ?? '' }}
-                                    No. Int.{{ $customer->interior_number ?? '' }}
-                                </td>
-                                <td>{{ $customer->waterConnections->count() }}</td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="report-footer">
-            <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
-            <span class="text_infoE"> | </span>
-            <span class="text_infoE page-number">Página 1 de {{ $totalPages }}</span>
-            <span class="text_infoE"> | </span>
-            <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
-            <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
-        </div>
-    </div>
-
-    @foreach ($otherPagesCustomers as $pageCustomers)
-        <div class="report-page page-break">
+            .report-table th:nth-child(4),
+            .report-table td:nth-child(4) {
+                width: 20%;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="report-page">
             <div class="page-bg">
                 <img src="file://{{ $verticalBgPath }}" alt="Background">
             </div>
-
             <div class="page-content">
                 <div class="page-inner">
-                    <div class="inner-page-header">
-                        <p class="inner-page-committee">
-                            COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
-                        </p>
-                        <p class="inner-page-title">LISTA DE CLIENTES</p>
+                    <div class="first-page-header">
+                        <div class="first-page-logo-row">
+                            <div class="first-page-logo">
+                                @if ($authUser->locality->hasMedia('localityGallery'))
+                                    <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}"
+                                        alt="Photo of {{ $authUser->locality->name }}">
+                                @else
+                                    <img src="{{ public_path('img/localityDefault.png') }}" alt="Default Photo">
+                                @endif
+                            </div>
+                        </div>
+                        <div class="first-page-title-block">
+                            <p class="first-page-title">
+                                COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
+                            </p>
+                            <p class="first-page-subtitle">LISTA DE CLIENTES</p>
+                        </div>
                     </div>
-
                     <table class="report-table">
                         <thead>
                             <tr>
@@ -303,7 +252,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($pageCustomers as $customer)
+                            @foreach ($firstPageCustomers as $customer)
                                 <tr>
                                     <td>{{ $customer->id }}</td>
                                     <td>{{ $customer->name }} {{ $customer->last_name }}</td>
@@ -322,12 +271,63 @@
             <div class="report-footer">
                 <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
                 <span class="text_infoE"> | </span>
-                <span class="text_infoE page-number">Página {{ $loop->iteration + 1 }} de {{ $totalPages }}</span>
+                <span class="text_infoE page-number">Página 1 de {{ $totalPages }}</span>
                 <span class="text_infoE"> | </span>
                 <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
                 <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
             </div>
         </div>
-    @endforeach
-</body>
+
+        @foreach ($otherPagesCustomers as $pageCustomers)
+            <div class="report-page page-break">
+                <div class="page-bg">
+                    <img src="file://{{ $verticalBgPath }}" alt="Background">
+                </div>
+
+                <div class="page-content">
+                    <div class="page-inner">
+                        <div class="inner-page-header">
+                            <p class="inner-page-committee">
+                                COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUser->locality->name }}, {{ $authUser->locality->municipality }}, {{ $authUser->locality->state }}
+                            </p>
+                            <p class="inner-page-title">LISTA DE CLIENTES</p>
+                        </div>
+
+                        <table class="report-table">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>NOMBRE</th>
+                                    <th>DIRECCIÓN</th>
+                                    <th>NUM. DE TOMAS</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($pageCustomers as $customer)
+                                    <tr>
+                                        <td>{{ $customer->id }}</td>
+                                        <td>{{ $customer->name }} {{ $customer->last_name }}</td>
+                                        <td>
+                                            {{ $customer->street }}
+                                            No. Ext.{{ $customer->exterior_number ?? '' }}
+                                            No. Int.{{ $customer->interior_number ?? '' }}
+                                        </td>
+                                        <td>{{ $customer->waterConnections->count() }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="report-footer">
+                    <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                    <span class="text_infoE"> | </span>
+                    <span class="text_infoE page-number">Página {{ $loop->iteration + 1 }} de {{ $totalPages }}</span>
+                    <span class="text_infoE"> | </span>
+                    <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                    <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+                </div>
+            </div>
+        @endforeach
+    </body>
 </html>


### PR DESCRIPTION
##  Improves the Customers PDF report.

## Changes

- Added manual pagination logic in the controller:
  - First page: 26 records
  - Next pages: 40 records
  - Total pages calculation included

- Updated Blade structure to support multi-page rendering

- Added page numbering in the footer:
  - Format: "Page X of Y"
  - Works correctly for first and subsequent pages

- Improved footer styling:
  - Adjusted text colors for better contrast with background
  - Applied consistent styling across all pages
  - Added visual separation using separators (`|`)

## Technical Details

- Pagination handled in controller using:
  - `take()` for first page
  - `slice()` and `chunk()` for remaining pages

- Page number logic:
  - First page is fixed as page 1
  - Next pages use `$loop->iteration + 1`

- Footer is positioned using absolute layout and shared across all pages

## Impact

- Improves readability of PDF reports
- Provides clear navigation through pages
- Establishes a reusable pagination pattern for future reports