### PR TITLE
length of the modal columns increased

### DIFF
--- a/resources/views/earningTypes/show.blade.php
+++ b/resources/views/earningTypes/show.blade.php
@@ -20,7 +20,7 @@
                                         <input type="text" disabled class="form-control" value="{{ $earningType->id }}" />
                                     </div>
                                 </div>
-                                <div class="col-lg-6">
+                                <div class="col-lg-10">
                                     <div class="form-group">
                                         <label>Nombre</label>
                                         <input type="text" disabled class="form-control" value="{{ $earningType->name }}" />

--- a/resources/views/expenseTypes/show.blade.php
+++ b/resources/views/expenseTypes/show.blade.php
@@ -20,7 +20,7 @@
                                         <input type="text" disabled class="form-control" value="{{ $expenseType->id }}" />
                                     </div>
                                 </div>
-                                <div class="col-lg-6">
+                                <div class="col-lg-10">
                                     <div class="form-group">
                                         <label>Nombre</label>
                                         <input type="text" disabled class="form-control" value="{{ $expenseType->name }}" />

--- a/resources/views/inventoryCategories/show.blade.php
+++ b/resources/views/inventoryCategories/show.blade.php
@@ -20,7 +20,7 @@
                                         <input type="text" disabled class="form-control" value="{{ $category->id }}" />
                                     </div>
                                 </div>
-                                <div class="col-lg-6">
+                                <div class="col-lg-10">
                                     <div class="form-group">
                                         <label>Nombre</label>
                                         <input type="text" disabled class="form-control" value="{{ $category->name }}" />


### PR DESCRIPTION
## Improve visual consistency and usability.

## Changes Made
- Increased the width of the `Nombre` (Name) input field from `col-lg-6` to `col-lg-10`.
- Applied this change across the following modules:
  - Inventory Categories
  - Expense Types
  - Earning Types

## Files Modified
- `resources/views/inventoryCategories/show.blade.php`
- `resources/views/expensesTypes/show.blade.php`
- `resources/views/earningTypes/show.blade.php`

## Details
Previously, the `Nombre` field was constrained to a 6-column width (`col-lg-6`), which caused unnecessary unused space within the modal.  
This update expands the field to `col-lg-10`, allowing better alignment with other form elements and improving readability.

## UI Impact
- More consistent form layout across modals.
- Better use of available horizontal space.
- Improved user experience when viewing longer names.

## Before / After
- Before: Narrow input field (`col-lg-6`)
- After: Wider input field (`col-lg-10`)

## Notes
- No backend logic was modified.
- This change is purely visual (frontend/UI only).