### PR TITLE
ensure create and import modals render without employee data

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -115,15 +115,15 @@
                                                                 @endcan
                                                             </div>
                                                         </td>
-                                                        @include('employees.edit')
-                                                        @include('employees.delete')
-                                                        @include('employees.show')
-                                                        @include('employees.import-modal')
-                                                        @include('employees.create')
                                                     </tr>
+                                                    @include('employees.edit')
+                                                    @include('employees.delete')
+                                                    @include('employees.show')
                                                 @endforeach
                                             @endif
                                         </tbody>
+                                        @include('employees.import-modal')
+                                        @include('employees.create')
                                     </table>
                                     <div class="d-flex justify-content-center">
                                         {!! $employees->links('pagination::bootstrap-4') !!}


### PR DESCRIPTION
## Fix: Modals not appearing when no employees exist

### Overview
This PR fixes an issue where the **"Register Employee"** and **"Import Employees"** modals were not displayed when the employees list was empty (e.g., in a new locality).

### Root Cause
The modals:
- `employees.create`
- `employees.import-modal`

were being included **inside the `@foreach` loop**, which caused:
- The modals to not render when there were no employees.
- Multiple duplicated modal instances (same IDs) when employees existed.

### Solution
- Moved the global modals (`create` and `import`) **outside of the loop**.
- Kept only employee-specific modals (`edit`, `delete`, `show`) inside the loop.

### Result
- Modals now work correctly even when no employees are present.