### PR TITLE
cost deletion issue

### DIFF
--- a/app/Http/Controllers/CostController.php
+++ b/app/Http/Controllers/CostController.php
@@ -98,6 +98,11 @@ class CostController extends Controller
 
     public function destroy(Cost $cost)
     {
+        if ($cost->hasDependencies()) {
+            return redirect()->route('costs.index')
+                ->with('error', 'No se puede eliminar el costo porque tiene tomas de agua asociadas.');
+        }
+
         $before = $cost->toArray();
         $cost->delete();
 

--- a/app/Models/Cost.php
+++ b/app/Models/Cost.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\WaterConnection;
+
 class Cost extends Model
 {
     use HasFactory,  SoftDeletes;
@@ -38,6 +40,16 @@ class Cost extends Model
     public function creator()
     {
         return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function waterConnections()
+    {
+        return $this->hasMany(WaterConnection::class, 'cost_id');
+    }
+
+    public function hasDependencies()
+    {
+        return $this->waterConnections()->exists();
     }
 
     public function scopeByUserLocality($query)

--- a/app/Models/WaterConnection.php
+++ b/app/Models/WaterConnection.php
@@ -63,7 +63,7 @@ class WaterConnection extends Model
 
     public function cost()
     {
-        return $this->belongsTo(Cost::class);
+        return $this->belongsTo(Cost::class)->withTrashed();
     }
 
     public function section()
@@ -84,7 +84,7 @@ class WaterConnection extends Model
     public function getStatusCalculatedAttribute()
     {
         $today = Carbon::today();
-        
+
         $debts = $this->debts()->withSum('payments', 'amount')->get();
 
         $hasUnpaidDebt = false;
@@ -92,12 +92,12 @@ class WaterConnection extends Model
 
         foreach ($debts as $debt) {
             $pendingAmount = $debt->amount - $debt->payments_sum_amount;
-            
+
             if ($pendingAmount > 0) {
                 $hasUnpaidDebt = true;
             }
-            
-            if ($debt->status === Debt::STATUS_PAID && 
+
+            if ($debt->status === Debt::STATUS_PAID &&
                 Carbon::parse($debt->start_date)->gt($today)) {
                 $hasFuturePaid = true;
             }
@@ -127,37 +127,37 @@ class WaterConnection extends Model
             self::VIEW_STATUS_CANCELED => 'background-color: #6c757d; color: white;',
         ][$this->getStatusCalculatedAttribute()] ?? '';
     }
-    
+
     public function hasDebt()
     {
         $debts = $this->debts()->withSum('payments', 'amount')->get();
-        
+
         foreach ($debts as $debt) {
             $pendingAmount = $debt->amount - $debt->payments_sum_amount;
             if ($pendingAmount > 0) {
                 return true;
             }
         }
-        
+
         return false;
     }
 
     public function getPendingBalance()
     {
         $totalPending = 0;
-        
+
         $unpaidDebts = $this->debts()
             ->withSum('payments', 'amount')
             ->get();
-        
+
         foreach ($unpaidDebts as $debt) {
             $pendingAmount = $debt->amount - $debt->payments_sum_amount;
-            
+
             if ($pendingAmount > 0) {
                 $totalPending += $pendingAmount;
             }
         }
-        
+
         return $totalPending;
     }
 
@@ -170,7 +170,7 @@ class WaterConnection extends Model
     {
         return $this->attributes['cancel_description'];
     }
-    
+
     public function setCancelDescriptionAttribute($value)
     {
         $this->attributes['cancel_description'] = $value;

--- a/resources/views/costs/index.blade.php
+++ b/resources/views/costs/index.blade.php
@@ -79,7 +79,10 @@
                                                             @endcan
                                                             @can('deleteCost')
                                                             @if (!is_null($cost->locality_id))
-                                                                <button type="button" class="btn btn-danger mr-2" data-toggle="modal" title="Eliminar Registro" data-target="#delete{{ $cost->id }}">
+                                                                <button type="button"
+                                                                    class="btn {{ $cost->hasDependencies() ? 'btn-secondary' : 'btn-danger' }} mr-2"
+                                                                    title="{{ $cost->hasDependencies() ? 'Eliminación no permitida: este costo tiene tomas de agua asociadas.' : 'Eliminar Registro' }}"
+                                                                    {{ $cost->hasDependencies() ? 'disabled' : 'data-toggle=modal data-target=#delete' . $cost->id }}>
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>
                                                             @endif

--- a/resources/views/waterConnections/index.blade.php
+++ b/resources/views/waterConnections/index.blade.php
@@ -70,7 +70,11 @@
                                                             <span class="text-danger">Toma sin cliente asignado</span>
                                                         @endif
                                                     </td>
-                                                    <td>${{ $connection->cost->price }}</td>
+                                                   <td>
+                                                        {!! $connection->cost
+                                                            ? '$' . number_format($connection->cost->price, 2)
+                                                            : '<span class="text-danger">Costo no disponible</span>' !!}
+                                                    </td>
                                                     @if ($connection->type === 'residencial')
                                                         <td>Residencial</td>
                                                     @elseif ($connection->type === 'commercial')


### PR DESCRIPTION
## Fix: Cost deletion handling and null safety in water connections

### Problem
Deleting a cost that was associated with one or more water connections caused the system to break, due to null references when accessing the cost in the water connections module.

###  Solution

#### 1. Prevent deletion of costs with dependencies
- Added relationship between `Cost` and `WaterConnection`
- Implemented `hasDependencies()` method in `Cost` model
- Updated `destroy()` in `CostController` to block deletion if the cost is in use

#### 2. UI validation in Costs module
- Disabled delete button when the cost has associated water connections
- Added tooltip message explaining why deletion is not allowed

#### 3. Null safety in Water Connections module
- Updated cost display to safely handle missing relationships
- Prevents system crash when a cost is not available

---

### Result
- Prevents inconsistent data (orphan references)
- Improves system stability
- Enhances user experience with clear UI feedback
- Keeps code clean and maintainable