### PR TITLE
Fix/mail config password security

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -160,7 +160,17 @@ class DashboardController extends Controller
     public function sendEmailsForDebtsExpiringSoon()
     {
         $authUser = Auth::user();
+        $locality = $authUser->locality;
         $mailConfig = $authUser->locality->mailConfiguration;
+
+        if (!$mailConfig || !$mailConfig->isComplete()) {
+            return back()->with('error', 'No hay configuración de correo válida para esta localidad.');
+        }
+
+
+        if ($locality->last_reminder_sent_at && $locality->last_reminder_sent_at->isToday()) {
+            return back()->with('warning', 'Ya se enviaron recordatorios el día de hoy.');
+        }
 
         Config::set('mail.mailers.smtp.host', $mailConfig->host);
         Config::set('mail.mailers.smtp.port', $mailConfig->port);
@@ -190,6 +200,9 @@ class DashboardController extends Controller
         $uniqueCustomers->chunk(50)->each(function ($chunk) use ($authUser) {
             dispatch(new SendUpcomingPaymentEmails($chunk, $authUser->id));
         });
+
+        $locality->last_reminder_sent_at = now();
+        $locality->save();
 
         return back()->with('success', 'Los correos están en proceso de envío y pronto llegarán a sus destinatarios.');
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -161,7 +161,7 @@ class DashboardController extends Controller
     {
         $authUser = Auth::user();
         $locality = $authUser->locality;
-        $mailConfig = $authUser->locality->mailConfiguration;
+        $mailConfig = $locality?->mailConfiguration;
 
         if (!$mailConfig || !$mailConfig->isComplete()) {
             return back()->with('error', 'No hay configuración de correo válida para esta localidad.');
@@ -195,14 +195,28 @@ class DashboardController extends Controller
 
         } while ($customers->hasMorePages());
 
-        $uniqueCustomers = $allCustomers->unique('customerEmail');
+       $uniqueCustomers = $allCustomers
+            ->filter(function ($customer) {
+                return !empty($customer['customerEmail']);
+            })
+            ->unique('customerEmail')
+            ->values();
 
-        $uniqueCustomers->chunk(50)->each(function ($chunk) use ($authUser) {
+        if ($uniqueCustomers->isEmpty()) {
+            return back()->with('warning', 'No hay clientes con correo válido para enviar recordatorios.');
+        }
+
+        $jobsDispatched = false;
+
+        $uniqueCustomers->chunk(50)->each(function ($chunk) use ($authUser, &$jobsDispatched) {
             dispatch(new SendUpcomingPaymentEmails($chunk, $authUser->id));
+            $jobsDispatched = true;
         });
 
-        $locality->last_reminder_sent_at = now();
-        $locality->save();
+        if ($jobsDispatched) {
+            $locality->last_reminder_sent_at = now();
+            $locality->save();
+        }
 
         return back()->with('success', 'Los correos están en proceso de envío y pronto llegarán a sus destinatarios.');
     }

--- a/app/Http/Controllers/MailConfigurationController.php
+++ b/app/Http/Controllers/MailConfigurationController.php
@@ -10,19 +10,27 @@ class MailConfigurationController extends Controller
 {
     public function createOrUpdateMailConfigurations(Request $request, $localityId)
     {
+        $locality = Locality::findOrFail($localityId);
+        $currentConfig = $locality->mailConfiguration;
+
         $validated = $request->validate([
             'mailer' => 'required|string',
             'host' => 'required|string',
             'port' => 'required|numeric',
             'username' => 'required|string',
-            'password' => 'required|string',
+            'password' => $currentConfig ? 'nullable|string' :'required|string',
             'encryption' => 'required|string',
             'from_name' => 'nullable|string',
         ]);
 
-        $locality = Locality::findOrFail($localityId);
+        if ($currentConfig && blank($validated['password'] ?? null)) {
+            unset($validated['password']);
+        }
 
-        $locality->mailConfiguration()->updateOrCreate([], $validated);
+        $locality->mailConfiguration()->updateOrCreate(
+            ['locality_id' => $locality->id],
+            $validated
+        );
 
         return redirect()->route('localities.index')->with('success', '¡Configuración de correo guardada!');
     }

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -35,12 +35,14 @@ class Locality extends Model implements HasMedia
         'openpay_webhook_user',
         'openpay_webhook_password',
         'openpay_sandbox',
-        'openpay_enabled'
+        'openpay_enabled',
+        'last_reminder_sent_at'
     ];
 
     protected $casts = [
         'openpay_sandbox' => 'boolean',
         'openpay_enabled' => 'boolean',
+        'last_reminder_sent_at' => 'datetime',
     ];
 
     public function setOpenpayPrivateKeyAttribute($value)
@@ -74,9 +76,9 @@ class Locality extends Model implements HasMedia
     }
     public function hasOpenPayEnabled(): bool
     {
-        return $this->openpay_enabled 
-            && !empty($this->openpay_merchant_id) 
-            && !empty($this->openpay_private_key) 
+        return $this->openpay_enabled
+            && !empty($this->openpay_merchant_id)
+            && !empty($this->openpay_private_key)
             && !empty($this->openpay_public_key);
     }
 
@@ -137,7 +139,7 @@ class Locality extends Model implements HasMedia
             $tokenValidation = Crypt::decrypt($this->token);
             $endDate = Carbon::parse($tokenValidation['data']['endDate'])->startOfDay();
             $today = now()->startOfDay();
-            
+
             return $today->lte($endDate) ? self::SUBSCRIPTION_ACTIVE : self::SUBSCRIPTION_EXPIRED;
         } catch (Exception $e) {
             return self::SUBSCRIPTION_NONE;
@@ -166,7 +168,7 @@ class Locality extends Model implements HasMedia
         ];
 
         $token = Crypt::encrypt($tokenData);
-        
+
         $this->token = $token;
         $this->saveQuietly();
 

--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -35,8 +35,7 @@ class Locality extends Model implements HasMedia
         'openpay_webhook_user',
         'openpay_webhook_password',
         'openpay_sandbox',
-        'openpay_enabled',
-        'last_reminder_sent_at'
+        'openpay_enabled'
     ];
 
     protected $casts = [

--- a/app/Models/MailConfiguration.php
+++ b/app/Models/MailConfiguration.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Contracts\Encryption\DecryptException;
 
 class MailConfiguration extends Model
 {
@@ -42,5 +44,27 @@ class MailConfiguration extends Model
             !empty($this->username) &&
             !empty($this->password) &&
             !empty($this->encryption);
+    }
+
+    public function setPasswordAttribute($value)
+    {
+        if (blank($value)) {
+            return;
+        }
+
+        $this->attributes['password'] = Crypt::encryptString($value);
+    }
+
+    public function getPasswordAttribute($value)
+    {
+        if (blank($value)) {
+            return null;
+        }
+
+        try {
+            return Crypt::decryptString($value);
+        } catch (DecryptException $e) {
+            return $value;
+        }
     }
 }

--- a/database/migrations/2026_04_17_185910_add_last_reminder_sent_at_to_localities_table.php
+++ b/database/migrations/2026_04_17_185910_add_last_reminder_sent_at_to_localities_table.php
@@ -26,7 +26,7 @@ class AddLastReminderSentAtToLocalitiesTable extends Migration
     public function down()
     {
         Schema::table('localities', function (Blueprint $table) {
-            //
+            $table->dropColumn('last_reminder_sent_at');
         });
     }
 }

--- a/database/migrations/2026_04_17_185910_add_last_reminder_sent_at_to_localities_table.php
+++ b/database/migrations/2026_04_17_185910_add_last_reminder_sent_at_to_localities_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLastReminderSentAtToLocalitiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('localities', function (Blueprint $table) {
+            $table->timestamp('last_reminder_sent_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('localities', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -106,9 +106,9 @@
                                                     <button type="button" class="btn bg-navy mr-2" data-toggle="modal" title="Fondo de reporte" data-target="#editPdfBackground{{$locality->id}}">
                                                             <i class="fas fa-fill-drip"></i>
                                                     </button>
-                                                    <button type="button" class="btn {{ $locality->hasOpenPayEnabled() ? 'btn-success' : 'btn-outline-success' }} mr-2" 
-                                                            data-toggle="modal" 
-                                                            title="{{ $locality->hasOpenPayEnabled() ? 'OpenPay configurado' : 'Configurar OpenPay' }}" 
+                                                    <button type="button" class="btn {{ $locality->hasOpenPayEnabled() ? 'btn-success' : 'btn-outline-success' }} mr-2"
+                                                            data-toggle="modal"
+                                                            title="{{ $locality->hasOpenPayEnabled() ? 'OpenPay configurado' : 'Configurar OpenPay' }}"
                                                             data-target="#openpayConfigModal{{$locality->id}}">
                                                         <i class="fas fa-credit-card"></i>
                                                     </button>
@@ -164,7 +164,7 @@
     </div>
 </section>
 @endsection
-@section('js')
+@push('js')
 <script>
     $(document).ready(function() {
         $('#localities').DataTable({
@@ -174,10 +174,10 @@
             searching: false
         });
 
-        var successMessage = "{{ session('success') }}".trim();
-        var errorMessage = "{{ session('error') }}".trim();
+        const successMessage = @json(session('success'));
+        const errorMessage = @json(session('error'));
 
-        if (successMessage && successMessage.length > 0) {
+        if (successMessage) {
             Swal.fire({
                 icon: 'success',
                 title: 'Éxito',
@@ -186,7 +186,7 @@
             });
         }
 
-        if (errorMessage && errorMessage.length > 0) {
+        if (errorMessage) {
             Swal.fire({
                 icon: 'error',
                 title: 'Error',
@@ -196,4 +196,4 @@
         }
     });
 </script>
-@endsection
+@endpush

--- a/resources/views/localities/mailConfiguration.blade.php
+++ b/resources/views/localities/mailConfiguration.blade.php
@@ -58,8 +58,14 @@
                                         </div>
                                         <div class="col-lg-6">
                                             <div class="form-group">
-                                                <label for="password{{ $locality->id }}">Contraseña(*)</label>
-                                                <input type="text" name="password" class="form-control" id="password{{ $locality->id }}" placeholder="Ingresa la contraseña" value="{{ old('password', $config?->password) }}" required>
+                                                <label for="password{{ $locality->id }}">Contraseña{{ $config ? '' : '(*)' }}</label>
+                                                <input type="password" name="password" class="form-control" id="password{{ $locality->id }}" placeholder="{{ $config ? 'Dejar vacío para conservar la contraseña actual' : 'Ingresa la contraseña' }}"
+                                                    value="{{ old('password') }}" {{ $config ? '' : 'required' }} autocomplete="new-password">
+                                                @if($config)
+                                                    <small class="text-muted">
+                                                        Deja este campo vacío si no deseas cambiar la contraseña actual.
+                                                    </small>
+                                                @endif
                                             </div>
                                         </div>
                                         <div class="col-lg-6">


### PR DESCRIPTION
## Overview ll
This PR improves the mail configuration security and controls the reminder email sending process.

## Changes

### Mail Configuration
- Password input changed to `type="password"` to hide sensitive data
- Password is no longer preloaded when editing
- Password is stored encrypted in the database (not plain text)
- Existing password is preserved if the field is left empty

### Validation & Security
- Added validation to ensure mail configuration is complete before sending emails
- Disabled "Send reminders" button when no valid configuration is available
- Added backend validation to prevent bypassing via direct requests

### Reminder Sending Control
- Implemented daily limit for sending reminder emails
- Added `last_reminder_sent_at` field to track last execution
- Prevents multiple sends within the same day

### Queue & Mail Handling
- Mail configuration is applied inside the Job
- Forced SMTP mailer usage inside the queue worker
- Cleared cached mailer instance to ensure correct configuration is used

## Result
- Improved security for mail credentials
- Prevented duplicate reminder emails
- Ensured proper mail configuration usage in queued jobs