### PR TITLE
resolved user profile inspection error

### DIFF
--- a/resources/views/profile/editPaymentConfig.blade.php
+++ b/resources/views/profile/editPaymentConfig.blade.php
@@ -29,7 +29,7 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="openpay_webhook_user">
-                                            Correo de OpenPay <span class="text-danger">*</span>                                           
+                                            Correo de OpenPay <span class="text-danger">*</span>
                                             @if($authUser->locality?->openpay_webhook_user)
                                                 <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurado</span>
                                             @endif
@@ -43,7 +43,7 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="openpay_webhook_password">
-                                            Contraseña de OpenPay <span class="text-danger">*</span>                                        
+                                            Contraseña de OpenPay <span class="text-danger">*</span>
                                             @if($authUser->locality?->openpay_webhook_password)
                                                 <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurada</span>
                                             @endif
@@ -56,7 +56,7 @@
                                                 </button>
                                             </div>
                                         </div>
-                                        <small class="text-muted">                                     
+                                        <small class="text-muted">
                                             {{ $authUser->locality?->openpay_webhook_password ? 'Deja en blanco para mantener la contraseña actual' : 'Ingresa la contraseña de tu cuenta de OpenPay' }}
                                         </small>
                                     </div>
@@ -91,7 +91,7 @@
                                 <i class="fas fa-shield-alt mr-2"></i>Estado del Webhook
                             </h6>
                         </div>
-                        <div class="card-body">                        
+                        <div class="card-body">
                             @if($authUser->locality && $authUser->locality->openpay_webhook_user && $authUser->locality->openpay_webhook_password)
                                 <div class="alert alert-success mb-0">
                                     <i class="fas fa-check-circle mr-2"></i>

--- a/resources/views/profile/editPaymentConfig.blade.php
+++ b/resources/views/profile/editPaymentConfig.blade.php
@@ -8,7 +8,7 @@
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
-            </div>
+            </div>           
             @if($authUser->hasRole(['Supervisor', 'Secretaria']))
             <form id="webhookConfigForm" action="{{ route('profile.webhook-config.update') }}" method="POST">
                 @csrf
@@ -29,22 +29,22 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="openpay_webhook_user">
-                                            Correo de OpenPay <span class="text-danger">*</span>
-                                            @if($authUser->locality->openpay_webhook_user)
+                                            Correo de OpenPay <span class="text-danger">*</span>                                           
+                                            @if($authUser->locality?->openpay_webhook_user)
                                                 <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurado</span>
                                             @endif
                                         </label>
                                         <input type="email" class="form-control" name="openpay_webhook_user" id="openpay_webhook_user" placeholder="tu-email@example.com">
                                         <small class="text-muted">
-                                            {{ $authUser->locality->openpay_webhook_user ? 'Deja en blanco para mantener el correo actual' : 'Ingresa el correo de tu cuenta de OpenPay' }}
+                                            {{ $authUser->locality?->openpay_webhook_user ? 'Deja en blanco para mantener el correo actual' : 'Ingresa el correo de tu cuenta de OpenPay' }}
                                         </small>
                                     </div>
                                 </div>
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="openpay_webhook_password">
-                                            Contraseña de OpenPay <span class="text-danger">*</span>
-                                            @if($authUser->locality->openpay_webhook_password)
+                                            Contraseña de OpenPay <span class="text-danger">*</span>                                        
+                                            @if($authUser->locality?->openpay_webhook_password)
                                                 <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurada</span>
                                             @endif
                                         </label>
@@ -56,8 +56,8 @@
                                                 </button>
                                             </div>
                                         </div>
-                                        <small class="text-muted">
-                                            {{ $authUser->locality->openpay_webhook_password ? 'Deja en blanco para mantener la contraseña actual' : 'Ingresa la contraseña de tu cuenta de OpenPay' }}
+                                        <small class="text-muted">                                     
+                                            {{ $authUser->locality?->openpay_webhook_password ? 'Deja en blanco para mantener la contraseña actual' : 'Ingresa la contraseña de tu cuenta de OpenPay' }}
                                         </small>
                                     </div>
                                 </div>
@@ -91,18 +91,18 @@
                                 <i class="fas fa-shield-alt mr-2"></i>Estado del Webhook
                             </h6>
                         </div>
-                        <div class="card-body">
-                            @if($authUser->locality->openpay_webhook_user && $authUser->locality->openpay_webhook_password)
+                        <div class="card-body">                        
+                            @if($authUser->locality && $authUser->locality->openpay_webhook_user && $authUser->locality->openpay_webhook_password)
                                 <div class="alert alert-success mb-0">
                                     <i class="fas fa-check-circle mr-2"></i>
                                     <strong>Webhook Configurado</strong>
-                                    <p class="mb-0 mt-2 small">Los Supervisores o Secretarias han configurado el webhook para esta localidad. Si necesitas cambiar estas credenciales, solicita que lo hagan desde sus perfiles.</p>
+                                    <p class="mb-0 mt-2 small">Los responsables han configurado el webhook para esta localidad.</p>
                                 </div>
                             @else
                                 <div class="alert alert-warning mb-0">
                                     <i class="fas fa-exclamation-circle mr-2"></i>
                                     <strong>Webhook No Configurado</strong>
-                                    <p class="mb-0 mt-2 small">Los Supervisores o Secretarias deben configurar el correo y contraseña de OpenPay desde sus perfiles para activar las notificaciones de webhooks.</p>
+                                    <p class="mb-0 mt-2 small">Los responsables deben configurar las credenciales de OpenPay desde sus perfiles.</p>
                                 </div>
                             @endif
                         </div>

--- a/resources/views/profile/editPaymentConfig.blade.php
+++ b/resources/views/profile/editPaymentConfig.blade.php
@@ -8,7 +8,7 @@
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
-            </div>           
+            </div>
             @if($authUser->hasRole(['Supervisor', 'Secretaria']))
             <form id="webhookConfigForm" action="{{ route('profile.webhook-config.update') }}" method="POST">
                 @csrf
@@ -29,7 +29,7 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="openpay_webhook_user">
-                                            Correo de OpenPay <span class="text-danger">*</span>
+                                            Correo de OpenPay<span class="text-danger">*</span>
                                             @if($authUser->locality?->openpay_webhook_user)
                                                 <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurado</span>
                                             @endif
@@ -45,7 +45,7 @@
                                         <label for="openpay_webhook_password">
                                             Contraseña de OpenPay <span class="text-danger">*</span>
                                             @if($authUser->locality?->openpay_webhook_password)
-                                                <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurada</span>
+                                            <span class="badge badge-success ml-2"><i class="fas fa-check mr-1"></i>Configurada</span>
                                             @endif
                                         </label>
                                         <div class="input-group">
@@ -96,13 +96,13 @@
                                 <div class="alert alert-success mb-0">
                                     <i class="fas fa-check-circle mr-2"></i>
                                     <strong>Webhook Configurado</strong>
-                                    <p class="mb-0 mt-2 small">Los responsables han configurado el webhook para esta localidad.</p>
+                                    <p class="mb-0 mt-2 small">Los Supervisores o Secretarias han configurado el webhook para esta localidad. Si necesitas cambiar estas credenciales, solicita que lo hagan desde sus perfiles.</p>
                                 </div>
                             @else
                                 <div class="alert alert-warning mb-0">
                                     <i class="fas fa-exclamation-circle mr-2"></i>
                                     <strong>Webhook No Configurado</strong>
-                                    <p class="mb-0 mt-2 small">Los responsables deben configurar las credenciales de OpenPay desde sus perfiles.</p>
+                                    <p class="mb-0 mt-2 small">Los Supervisores o Secretarias deben configurar el correo y contraseña de OpenPay desde sus perfiles para activar las notificaciones de webhooks.</p>
                                 </div>
                             @endif
                         </div>


### PR DESCRIPTION
 Admin profile inspection error via PHP Nullsafe operators and alert refinement.

Null-safe Operator Implementation: Replaced `$authUser->locality->...` with `$authUser->locality?->...` in the Supervisor/Secretary forms. 
 Modified File
- `resources/views/profile/editPaymentConfig.blade.php`
-removed unnecessary whitespace and restored original text