### PR TITLE
Fix add membership button visibility

### DIFF
--- a/resources/views/memberships/index.blade.php
+++ b/resources/views/memberships/index.blade.php
@@ -24,6 +24,18 @@
                                         </div>
                                     </form>
                                     <div class="d-flex flex-wrap justify-content-end gap-2 w-100 w-md-auto">
+                                        @can('createMemberships')
+                                            <button type="button"
+                                                    class="btn btn-success"
+                                                    data-toggle="modal"
+                                                    data-target="#createMembership"
+                                                    style="white-space: nowrap;">
+
+                                                <i class="fas fa-plus"></i>
+                                                Agregar Membresía
+
+                                            </button>
+                                        @endcan
                                     </div>
                                 </div>
                             </div>
@@ -97,6 +109,7 @@
                                             @endif
                                         </tbody>
                                     </table>
+                                    @include('memberships.create')
                                     <div class="d-flex justify-content-center">
                                         {!! $memberships->links('pagination::bootstrap-4') !!}
                                     </div>


### PR DESCRIPTION
### **Fix Membership Create Permission and Add Button Visibility**
### Description

- This PR fixes the visibility issue of the "Add Membership" button in the memberships module.
 
- The button was wrapped inside the following permission check:
 
- @can('createMemberships')
 
- However, the createMemberships permission did not exist in the system, causing the button to remain hidden even for authorized users.