### PR TITLE
Add locality report file and integrate URL for button

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -91,7 +91,8 @@ class IncidentController extends Controller
             }
         }
 
-        return redirect()->route('incidents.index')->with('success', 'Incidente creado exitosamente.');
+        $redirectRoute = $authUser->hasRole(User::ROLE_CUSTOMER) ? 'customerIncidents.index' : 'incidents.index';
+        return redirect()->route($redirectRoute)->with('success', 'Incidente creado exitosamente.');
     }
 
     public function show($id)

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -6,6 +6,7 @@ use App\Models\Locality;
 use App\Models\Membership;
 use App\Models\Token;
 use App\Models\MailConfiguration;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Http\Request; 
 use Illuminate\Support\Facades\Crypt;
 
@@ -34,6 +35,36 @@ class LocalityController extends Controller
         ];
 
         return view('localities.index', compact('localities','mailExamples', 'memberships'));
+    }
+
+    public function pdfLocalities(Request $request)
+    {
+        $authUser = auth()->user();
+
+        $query = Locality::query()->orderBy('name');
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->whereRaw("CONCAT(name, ' ', municipality, ' ', zip_code) LIKE ?", ["%{$search}%"]);
+        }
+
+        $localities = $query->get();
+        $localitiesPerFirstPage = 26;
+        $localitiesPerNextPages = 40;
+
+        $firstPageLocalities = $localities->take($localitiesPerFirstPage);
+        $remainingLocalities = $localities->slice($localitiesPerFirstPage);
+        $otherPagesLocalities = $remainingLocalities->chunk($localitiesPerNextPages);
+
+        $totalPages = 1 + ceil(max(0, $localities->count() - $localitiesPerFirstPage) / $localitiesPerNextPages);
+
+        $pdf = Pdf::loadView('reports.pdfLocalities', compact(
+            'authUser',
+            'firstPageLocalities',
+            'otherPagesLocalities',
+            'totalPages'
+        ))->setPaper('A4', 'portrait');
+
+        return $pdf->stream('localities.pdf');
     }
 
     public function store(Request $request)

--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -37,7 +37,7 @@ class LocalityController extends Controller
         return view('localities.index', compact('localities','mailExamples', 'memberships'));
     }
 
-    public function pdfLocalities(Request $request)
+    public function generatepdfLocalities(Request $request)
     {
         $authUser = auth()->user();
 

--- a/resources/views/localities/index.blade.php
+++ b/resources/views/localities/index.blade.php
@@ -18,7 +18,7 @@
                                 <button class="btn btn-success mr-2" data-toggle='modal' data-target="#createLocality">
                                     <i class="fa fa-plus"></i> Registrar Localidad
                                 </button>
-                                <a type="button" class="btn btn-secondary mr-2" target="_blank" title="Localities" href="#">
+                                <a type="button" class="btn btn-secondary mr-2" target="_blank" title="Localidades" href="{{ route('localities.pdfLocalities', ['search' => request('search')]) }}">
                                     <i class="fas fa-map"></i> Generar Lista
                                 </a>
                                 <a type="button" class="btn btn-info" href="{{ asset('docs/GUIA_PARA_REGISTRAR.pdf') }}" target="_blank" title="Ver guía de registro">

--- a/resources/views/reports/pdfLocalities.blade.php
+++ b/resources/views/reports/pdfLocalities.blade.php
@@ -1,0 +1,327 @@
+@php
+    $locality = Auth::user()->locality ?? null;
+    $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+        ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+        : public_path('img/backgroundReport.png');
+@endphp
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Lista de Localidades</title>
+        <style>
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
+
+            html, body {
+                margin: 0;
+                padding: 0;
+                font-family: 'Montserrat', sans-serif;
+            }
+
+            body {
+                margin: 0;
+                padding: 0;
+                background: none;
+            }
+
+            .report-page {
+                position: relative;
+                width: 100%;
+                height: 1122px;
+                overflow: hidden;
+                box-sizing: border-box;
+            }
+
+            .page-break {
+                page-break-before: always;
+            }
+
+            .page-bg {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                z-index: 1;
+            }
+
+            .page-bg img {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+
+            .page-content {
+                position: absolute;
+                top: 24px;
+                left: 18px;
+                right: 18px;
+                bottom: 42px;
+                z-index: 2;
+            }
+
+            .page-inner {
+                width: 89%;
+                margin-left: 3%;
+                margin-right: 11%;
+            }
+
+            .report-footer {
+                position: absolute;
+                left: 16px;
+                right: 16px;
+                bottom: 8px;
+                text-align: center;
+                z-index: 3;
+            }
+
+            .text_infoE {
+                font-size: 10pt;
+                color: white;
+                text-decoration: none;
+                display: inline-block;
+            }
+
+            .page-number {
+                font-weight: bold;
+                font-size: 10pt;
+                letter-spacing: 0.5px;
+            }
+
+            .footer-branding {
+                color: #0B1C80 !important;
+            }
+
+            .footer-branding img {
+                filter: brightness(0) saturate(100%) invert(5%) sepia(100%) saturate(10000%) hue-rotate(200deg);
+            }
+
+            .first-page-header {
+                margin-top: 0;
+                margin-bottom: 12px;
+            }
+
+            .first-page-logo-row {
+                width: 100%;
+                position: relative;
+                margin-bottom: 8px;
+            }
+
+            .first-page-logo {
+                text-align: left;
+                padding-left: 74px;
+            }
+
+            .first-page-logo img {
+                width: 112px;
+                height: 112px;
+                border-radius: 50%;
+                display: block;
+            }
+
+            .first-page-title-block {
+                margin-top: 114px;
+                text-align: center;
+            }
+
+            .first-page-title {
+                color: #0B1C80;
+                font-size: 18pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                margin: 0 0 10px 0;
+                line-height: 1.18;
+                text-align: center;
+            }
+
+            .first-page-subtitle {
+                color: #0B1C80;
+                font-size: 14pt;
+                font-weight: bold;
+                margin: 28px 0 6px 0;
+                text-align: center;
+            }
+
+            .inner-page-header {
+                width: 100%;
+                margin-top: 18px;
+                margin-bottom: 14px;
+                padding-bottom: 0;
+            }
+
+            .inner-page-committee {
+                color: #ffffff;
+                font-size: 8.5pt;
+                text-align: center;
+                margin: 0 0 4px 0;
+                line-height: 1.2;
+            }
+
+            .inner-page-title {
+                color: #ffffff;
+                font-size: 12pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                text-align: center;
+                margin: 0;
+            }
+
+            .report-table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 8px;
+                table-layout: fixed;
+            }
+
+            .report-table thead th {
+                background: #0B1C80;
+                color: #FFF;
+                padding: 6px 5px;
+                font-size: 10pt;
+                text-align: center;
+            }
+
+            .report-table tbody tr {
+                border-top: 1px solid #bfc9ff;
+            }
+
+            .report-table td {
+                background-color: transparent;
+                text-align: center;
+                font-size: 9pt;
+                padding: 4px 6px;
+                word-wrap: break-word;
+                line-height: 1.15;
+            }
+
+            .report-table th:nth-child(1),
+            .report-table td:nth-child(1) {
+                width: 8%;
+            }
+
+            .report-table th:nth-child(2),
+            .report-table td:nth-child(2) {
+                width: 32%;
+            }
+
+            .report-table th:nth-child(3),
+            .report-table td:nth-child(3) {
+                width: 20%;
+            }
+
+            .report-table th:nth-child(4),
+            .report-table td:nth-child(4) {
+                width: 20%;
+            }
+
+            .report-table th:nth-child(5),
+            .report-table td:nth-child(5) {
+                width: 20%;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="report-page">
+            <div class="page-bg">
+                <img src="file://{{ $verticalBgPath }}" alt="Background">
+            </div>
+            <div class="page-content">
+                <div class="page-inner">
+                    <div class="first-page-header">
+                        <div class="first-page-logo-row">
+                            <div class="first-page-logo">
+                                @if ($authUser->locality && $authUser->locality->hasMedia('localityGallery'))
+                                    <img src="{{ $authUser->locality->getFirstMediaUrl('localityGallery') }}" alt="Photo of {{ $authUser->locality->name }}">
+                                @else
+                                    <img src="{{ public_path('img/localityDefault.png') }}" alt="Default Photo">
+                                @endif
+                            </div>
+                        </div>
+                        <div class="first-page-title-block">
+                            <p class="first-page-title">REPORTE DE LOCALIDADES</p>
+                            <p class="first-page-subtitle">LISTA DE LOCALIDADES</p>
+                        </div>
+                    </div>
+                    <table class="report-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>NOMBRE</th>
+                                <th>MUNICIPIO</th>
+                                <th>ESTADO</th>
+                                <th>C.P.</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($firstPageLocalities as $locality)
+                                <tr>
+                                    <td>{{ $locality->id }}</td>
+                                    <td>{{ $locality->name }}</td>
+                                    <td>{{ $locality->municipality }}</td>
+                                    <td>{{ $locality->state }}</td>
+                                    <td>{{ $locality->zip_code }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="report-footer">
+                <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                <span class="text_infoE"> | </span>
+                <span class="text_infoE page-number">Página 1 de {{ $totalPages }}</span>
+                <span class="text_infoE"> | </span>
+                <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+            </div>
+        </div>
+
+        @foreach ($otherPagesLocalities as $pageLocalities)
+            <div class="report-page page-break">
+                <div class="page-bg">
+                    <img src="file://{{ $verticalBgPath }}" alt="Background">
+                </div>
+                <div class="page-content">
+                    <div class="page-inner">
+                        <div class="inner-page-header">
+                            <p class="inner-page-committee">REPORTE DE LOCALIDADES</p>
+                            <p class="inner-page-title">LISTA DE LOCALIDADES</p>
+                        </div>
+                        <table class="report-table">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>NOMBRE</th>
+                                    <th>MUNICIPIO</th>
+                                    <th>ESTADO</th>
+                                    <th>C.P.</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($pageLocalities as $locality)
+                                    <tr>
+                                        <td>{{ $locality->id }}</td>
+                                        <td>{{ $locality->name }}</td>
+                                        <td>{{ $locality->municipality }}</td>
+                                        <td>{{ $locality->state }}</td>
+                                        <td>{{ $locality->zip_code }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="report-footer">
+                    <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                    <span class="text_infoE"> | </span>
+                    <span class="text_infoE page-number">Página {{ $loop->iteration + 1 }} de {{ $totalPages }}</span>
+                    <span class="text_infoE"> | </span>
+                    <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                    <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+                </div>
+            </div>
+        @endforeach
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -133,6 +133,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
 
     Route::group(['middleware' => ['can:viewLocality']], function () {
         Route::get('/localities', [LocalityController::class, 'index'])->name('localities.index');
+        Route::get('/report/pdfLocalities', [LocalityController::class, 'pdfLocalities'])->name('localities.pdfLocalities');
         Route::resource('localities', LocalityController::class);
         Route::post('/localities/{locality}/update-logo', [LocalityController::class, 'updateLogo'])->name('localities.updateLogo');
         Route::get('/locality-earnings', [DashboardController::class, 'getEarningsByLocality'])->name('locality.earnings');

--- a/routes/web.php
+++ b/routes/web.php
@@ -133,7 +133,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
 
     Route::group(['middleware' => ['can:viewLocality']], function () {
         Route::get('/localities', [LocalityController::class, 'index'])->name('localities.index');
-        Route::get('/report/pdfLocalities', [LocalityController::class, 'pdfLocalities'])->name('localities.pdfLocalities');
+        Route::get('/report/pdfLocalities', [LocalityController::class, 'generatepdfLocalities'])->name('localities.pdfLocalities');
         Route::resource('localities', LocalityController::class);
         Route::post('/localities/{locality}/update-logo', [LocalityController::class, 'updateLogo'])->name('localities.updateLogo');
         Route::get('/locality-earnings', [DashboardController::class, 'getEarningsByLocality'])->name('locality.earnings');


### PR DESCRIPTION
- Implemented a PDF report generator for localities, providing structured output with pagination and search filtering.
- Previously, there was no dedicated report file for localities, which limited the ability to export and review locality data in a formal document format.
  - Generates a PDF with locality information ordered by name.
  - Supports search input to filter results dynamically.
  - Handles pagination with different limits for the first page and subsequent pages.
  - Streams the report as `localities.pdf` in A4 portrait format.
