### PR TITLE
Resolve openpay payment synchronization using webhooks

### DIFF
--- a/app/Http/Controllers/OpenPayController.php
+++ b/app/Http/Controllers/OpenPayController.php
@@ -57,7 +57,9 @@ class OpenPayController extends Controller
 
         DB::beginTransaction();
         try {
-            $debt = Debt::with(['customer', 'payments', 'waterConnection', 'locality'])->findOrFail($request->debt_id);
+            $debt = Debt::with(['customer', 'payments', 'waterConnection', 'locality'])
+                ->lockForUpdate()
+                ->findOrFail($request->debt_id);
 
             $locality = $debt->locality;
             if (!$locality) {
@@ -185,7 +187,7 @@ class OpenPayController extends Controller
             } elseif ($debt->debt_current > 0) {
                 $debt->status = 'partial';
             }
-            $debt->save();
+            $debt->save();  
 
             DB::commit();
 

--- a/app/Http/Controllers/OpenPayController.php
+++ b/app/Http/Controllers/OpenPayController.php
@@ -178,13 +178,9 @@ class OpenPayController extends Controller
                 ->whereNull('payment_id')
                 ->update(['payment_id' => $payment->id]);
 
-            $debt->refresh();
+            $debt->debt_current += $request->amount;
 
-            $debt->debt_current = $debt->total_paid;
-
-            $pendingAmount = $debt->remaining_amount;
-
-            if ($pendingAmount <= 0) {
+            if ($debt->debt_current >= $debt->amount) {
                 $debt->status = 'paid';
             } elseif ($debt->debt_current > 0) {
                 $debt->status = 'partial';

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -101,6 +101,11 @@ class Debt extends Model
         return max(0, $this->amount - $paid);
     }
 
+    public function getTotalPaidAttribute()
+    {
+        return $this->debt_current ?? $this->payments()->sum('amount') ?? 0;
+    }
+
     public function isPaid()
     {
         $paid = $this->debt_current ?? $this->payments()->sum('amount') ?? 0;

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -95,20 +95,31 @@ class Debt extends Model
         return $this->payments()->exists();
     }
 
+    protected function getPaidAmount(): float
+    {
+        $paymentsTotal = $this->payments()->sum('amount') ?? 0;
+
+        if ($this->debt_current > 0) {
+            return max($this->debt_current, $paymentsTotal);
+        }
+
+        return $paymentsTotal;
+    }
+
     public function getRemainingAmountAttribute()
     {
-        $paid = $this->debt_current ?? $this->payments()->sum('amount') ?? 0;
+        $paid = $this->getPaidAmount();
         return max(0, $this->amount - $paid);
     }
 
     public function getTotalPaidAttribute()
     {
-        return $this->debt_current ?? $this->payments()->sum('amount') ?? 0;
+        return $this->getPaidAmount();
     }
 
     public function isPaid()
     {
-        $paid = $this->debt_current ?? $this->payments()->sum('amount') ?? 0;
+        $paid = $this->getPaidAmount();
         return $paid >= $this->amount;
     }
 }


### PR DESCRIPTION
## description
this pr resolves the synchronization issue where processed openpay payments were not being reflected in the local "my payments" (`payments`) table. 

to fix this, an asynchronous webhook controller was implemented to listen for openpay's `charge.succeeded` event. additionally, the local `byUserLocality` global scope on the `debt` model was bypassed using `withoutGlobalScopes()` because webhook requests arrive anonymously (without an authenticated user session).
