### PR TITLE
Active state on roles sidebar menu in edit view

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -443,7 +443,8 @@ return [
         'text' => 'Roles',
         'url' => '/roles',
         'icon' => 'fas fa-fw fa-user-shield',
-        'can'  => 'viewRoles'
+        'can'  => 'viewRoles',
+        'active' => ['/roles*'],
     ],
     [
         'text' => 'Clientes',


### PR DESCRIPTION
## Description
This PR fixes the sidebar active state for the Roles module.

Previously, the Roles menu item was not highlighted when accessing the edit role view because the active condition only matched the main roles route.

## Changes Made
- Updated the sidebar active condition to support nested role routes.