### PR TITLE
translate memberships to spanish and fix duplication bug in seeders

### DIFF
--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -23,7 +23,7 @@ class LocalitiesTableSeeder extends Seeder
                 'municipality' => 'Smallville',
                 'state' => 'Kansas',
                 'zip_code' => '66002',
-                'membership_name' => 'Plan Premium', // cambiado a español
+                'membership_name' => 'Plan Premium',
                 'token_expired' => false,
             ],
             [
@@ -31,7 +31,7 @@ class LocalitiesTableSeeder extends Seeder
                 'municipality' => 'Springfield',
                 'state' => 'Oregon',
                 'zip_code' => '97477',
-                'membership_name' => 'Plan Empresarial', // cambiado a español
+                'membership_name' => 'Plan Empresarial',
                 'token_expired' => false,
             ],
             [
@@ -39,7 +39,7 @@ class LocalitiesTableSeeder extends Seeder
                 'municipality' => 'Scranton',
                 'state' => 'Pennsylvania',
                 'zip_code' => '18503',
-                'membership_name' => 'Plan Básico', // cambiado a español
+                'membership_name' => 'Plan Básico',
                 'token_expired' => true,
             ],
         ];

--- a/database/seeders/LocalitiesTableSeeder.php
+++ b/database/seeders/LocalitiesTableSeeder.php
@@ -23,7 +23,7 @@ class LocalitiesTableSeeder extends Seeder
                 'municipality' => 'Smallville',
                 'state' => 'Kansas',
                 'zip_code' => '66002',
-                'membership_name' => 'Premium Plan - 6 Months',
+                'membership_name' => 'Plan Premium', // cambiado a español
                 'token_expired' => false,
             ],
             [
@@ -31,7 +31,7 @@ class LocalitiesTableSeeder extends Seeder
                 'municipality' => 'Springfield',
                 'state' => 'Oregon',
                 'zip_code' => '97477',
-                'membership_name' => 'Enterprise Plan - 12 Months',
+                'membership_name' => 'Plan Empresarial', // cambiado a español
                 'token_expired' => false,
             ],
             [
@@ -39,7 +39,7 @@ class LocalitiesTableSeeder extends Seeder
                 'municipality' => 'Scranton',
                 'state' => 'Pennsylvania',
                 'zip_code' => '18503',
-                'membership_name' => 'Basic Plan - 3 Months',
+                'membership_name' => 'Plan Básico', // cambiado a español
                 'token_expired' => true,
             ],
         ];

--- a/database/seeders/MembershipsTableSeeder.php
+++ b/database/seeders/MembershipsTableSeeder.php
@@ -21,21 +21,21 @@ class MembershipsTableSeeder extends Seeder
 
         $memberships = [
             [
-                'name' => 'Basic Plan - 3 Months',
+                'name' => 'Plan Básico',
                 'price' => 299.00,
                 'term_months' => 3,
                 'water_connections_number' => 1000,
                 'users_number' => 1,
             ],
             [
-                'name' => 'Premium Plan - 6 Months',
+                'name' => 'Plan Premium',
                 'price' => 499.00,
                 'term_months' => 6,
                 'water_connections_number' => 4000,
                 'users_number' => 3,
             ],
             [
-                'name' => 'Enterprise Plan - 12 Months',
+                'name' => 'Plan Empresarial',
                 'price' => 899.00,
                 'term_months' => 12,
                 'water_connections_number' => 10000,


### PR DESCRIPTION
## description
translated membership plan names from english to spanish within the database seeders and updated the locality seeder references to match. 

this change also prevents data duplication issues caused by the `upsert` and `firstOrCreate` methods when switching language structures.

## changes
* **`membershipsstableseeder.php`**: updated plan names to spanish ('plan básico', 'plan premium', 'plan empresarial').
* **`localitiestableseeder.php`**: updated locality membership references to match the new spanish names.

## how to test
1. switch to this branch.
2. run the database migration and fresh seeding:
```bash
   php artisan migrate:fresh --seed