### PR TITLE
Remove 'edit data' button for customer users

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -22,6 +22,8 @@ class ProfileController extends Controller
             }
         ]);
 
+        $canEditProfile = !$authUser->hasRole(User::ROLE_CUSTOMER);
+
         $membershipStats = [
             'users_count' => $authUser->locality && $authUser->locality->membership ?
                 DB::table('memberships as m')
@@ -40,7 +42,7 @@ class ProfileController extends Controller
             'membership_name' => $authUser->locality && $authUser->locality->membership ? $authUser->locality->membership->name : 'Sin membresía'
         ];
 
-        return view('profile.index', compact('authUser', 'membershipStats'));
+        return view('profile.index', compact('authUser', 'membershipStats', 'canEditProfile'));
     }
 
     public function profileUpdate(Request $request)

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -38,12 +38,10 @@
                                     @else
                                         <img class="profile-user-img" style="width: 150px; height: 150px; border-radius: 50%;" src="{{ asset('img/userDefault.png') }}">
                                     @endif
-                                    @if(!$authUser->hasRole(\App\Models\User::ROLE_CUSTOMER))
                                     <button href="#" class="btn btn-outline-primary btn-sm edit-profile-pic" data-toggle="modal" data-target="#updateImage"
                                         style="position: absolute; bottom: 5px; right: 5px; background: white; border-radius: 10%; padding: 5px;">
                                         <i class="fas fa-camera"></i>
                                     </button>
-                                    @endif
                                 </div>
                             </div>
                             <h3 class="profile-username text-center">{{ $authUser->name }} {{ $authUser->last_name }}</h3>
@@ -134,7 +132,7 @@
                                 </div>
                                 <div class="offset-sm-2 col-sm-10">
                                     <div class="text-center">
-                                        @if(!$authUser->hasRole(\App\Models\User::ROLE_CUSTOMER))
+                                        @if($canEditProfile)
                                         <button type="submit" class="btn btn-success" id="updateInformation" name="updateInformation">
                                             Editar datos
                                         </button>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -38,10 +38,12 @@
                                     @else
                                         <img class="profile-user-img" style="width: 150px; height: 150px; border-radius: 50%;" src="{{ asset('img/userDefault.png') }}">
                                     @endif
+                                    @if(!$authUser->hasRole(\App\Models\User::ROLE_CUSTOMER))
                                     <button href="#" class="btn btn-outline-primary btn-sm edit-profile-pic" data-toggle="modal" data-target="#updateImage"
                                         style="position: absolute; bottom: 5px; right: 5px; background: white; border-radius: 10%; padding: 5px;">
                                         <i class="fas fa-camera"></i>
                                     </button>
+                                    @endif
                                 </div>
                             </div>
                             <h3 class="profile-username text-center">{{ $authUser->name }} {{ $authUser->last_name }}</h3>
@@ -132,9 +134,11 @@
                                 </div>
                                 <div class="offset-sm-2 col-sm-10">
                                     <div class="text-center">
+                                        @if(!$authUser->hasRole(\App\Models\User::ROLE_CUSTOMER))
                                         <button type="submit" class="btn btn-success" id="updateInformation" name="updateInformation">
                                             Editar datos
                                         </button>
+                                        @endif
                                         <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#editPassword">
                                             Cambiar contraseña
                                         </button>


### PR DESCRIPTION
- **Change applied:**  
  In the user profile section, the **"Edit Data"** button was removed for customer users.  

- **Reason for change:**  
  This adjustment ensures that customer users cannot modify their profile data directly, maintaining consistency and preventing unauthorized edits.  

- **Impact of the update:**  
  - Improves control over customer data management.  
  - Enhances security by restricting editing capabilities to authorized roles.  

