### PR TITLE
Add two-attempt validation with block display on failure

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -5,14 +5,21 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Cache;
 use Carbon\Carbon;
 
 class LoginController extends Controller
-{   
+{
     private const WARNING_DAY_FIRST_NOTICE = 12;
     private const WARNING_DAY_FINAL_NOTICE = 3;
+    private const MAX_ATTEMPTS   = 2;
+    private const LOCKOUT_SECONDS = 300;
+
+    private function throttleKey(Request $request): string
+    {
+        return 'login_attempts_' . md5($request->ip() . '|' . strtolower($request->input('email', '')));
+    }
 
     public function showLoginForm()
     {
@@ -26,9 +33,23 @@ class LoginController extends Controller
             'password' => 'required',
         ]);
 
-        $credentials = $request->only('email', 'password');
+        $key = $this->throttleKey($request);
 
-        if (Auth::attempt($credentials)) {
+        if (Cache::has($key . '_locked')) {
+            $secondsLeft = (int) Cache::get($key . '_locked') - time();
+            if ($secondsLeft > 0) {
+                return back()->withErrors([
+                    'email' => "Demasiados intentos fallidos. Por favor espera {$secondsLeft} segundos antes de intentarlo de nuevo.",
+                ])->withInput($request->only('email'));
+            }
+            Cache::forget($key . '_locked');
+            Cache::forget($key . '_count');
+        }
+
+        if (Auth::attempt($request->only('email', 'password'))) {
+            Cache::forget($key . '_count');
+            Cache::forget($key . '_locked');
+
             $user = Auth::user();
             $locality = $user->locality;
 
@@ -55,9 +76,23 @@ class LoginController extends Controller
             return redirect()->intended('dashboard');
         }
 
+        $attempts = (int) Cache::get($key . '_count', 0) + 1;
+        Cache::put($key . '_count', $attempts, self::LOCKOUT_SECONDS + 60);
+
+        if ($attempts >= self::MAX_ATTEMPTS) {
+            Cache::put($key . '_locked', time() + self::LOCKOUT_SECONDS, self::LOCKOUT_SECONDS + 60);
+            Cache::put($key . '_count', 0, self::LOCKOUT_SECONDS + 60);
+
+            return back()->withErrors([
+                'email' => 'Demasiados intentos fallidos. Por favor espera ' . self::LOCKOUT_SECONDS . ' segundos antes de intentarlo de nuevo.',
+            ])->withInput($request->only('email'));
+        }
+
+        $remaining = self::MAX_ATTEMPTS - $attempts;
+
         return back()->withErrors([
-            'email' => 'Las credenciales proporcionadas no coinciden con nuestros registros.',
-        ]);
+            'email' => "Las credenciales proporcionadas no coinciden con nuestros registros. Te queda(n) {$remaining} intento(s).",
+        ])->withInput($request->only('email'));
     }
 
     public function logout()

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\RateLimiter;
 use Carbon\Carbon;
 
 class LoginController extends Controller
@@ -35,20 +36,17 @@ class LoginController extends Controller
 
         $key = $this->throttleKey($request);
 
-        if (Cache::has($key . '_locked')) {
-            $secondsLeft = (int) Cache::get($key . '_locked') - time();
-            if ($secondsLeft > 0) {
-                return back()->withErrors([
-                    'email' => "Demasiados intentos fallidos. Por favor espera {$secondsLeft} segundos antes de intentarlo de nuevo.",
-                ])->withInput($request->only('email'));
-            }
-            Cache::forget($key . '_locked');
-            Cache::forget($key . '_count');
+        if (RateLimiter::tooManyAttempts($key, self::MAX_ATTEMPTS)) {
+            $secondsLeft = RateLimiter::availableIn($key);
+            session()->flash('lockout_seconds', $secondsLeft);
+            return back()->withErrors([
+                'email' => "Demasiados intentos fallidos. Por favor espera {$secondsLeft} segundos antes de intentarlo de nuevo.",
+            ])->withInput($request->only('email'));
         }
 
         if (Auth::attempt($request->only('email', 'password'))) {
-            Cache::forget($key . '_count');
-            Cache::forget($key . '_locked');
+            $request->session()->regenerate();
+            RateLimiter::clear($key);
 
             $user = Auth::user();
             $locality = $user->locality;
@@ -76,18 +74,16 @@ class LoginController extends Controller
             return redirect()->intended('dashboard');
         }
 
-        $attempts = (int) Cache::get($key . '_count', 0) + 1;
-        Cache::put($key . '_count', $attempts, self::LOCKOUT_SECONDS + 60);
+        RateLimiter::hit($key, self::LOCKOUT_SECONDS);
 
-        if ($attempts >= self::MAX_ATTEMPTS) {
-            Cache::put($key . '_locked', time() + self::LOCKOUT_SECONDS, self::LOCKOUT_SECONDS + 60);
-            Cache::put($key . '_count', 0, self::LOCKOUT_SECONDS + 60);
-
+        if (RateLimiter::tooManyAttempts($key, self::MAX_ATTEMPTS)) {
+            session()->flash('lockout_seconds', self::LOCKOUT_SECONDS);
             return back()->withErrors([
                 'email' => 'Demasiados intentos fallidos. Por favor espera ' . self::LOCKOUT_SECONDS . ' segundos antes de intentarlo de nuevo.',
             ])->withInput($request->only('email'));
         }
 
+        $attempts = RateLimiter::attempts($key);
         $remaining = self::MAX_ATTEMPTS - $attempts;
 
         return back()->withErrors([

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -4,13 +4,7 @@
 @section('auth_body')
 
     @php
-        $lockoutSeconds = 0;
-        foreach ($errors->all() as $error) {
-            if (preg_match('/(\d+)\s*segundo/', $error, $m)) {
-                $lockoutSeconds = (int) $m[1];
-                break;
-            }
-        }
+        $lockoutSeconds = session('lockout_seconds', 0);
         $isLocked = $lockoutSeconds > 0;
     @endphp
 
@@ -67,7 +61,7 @@
             <span id="timer-display"
                   style="display:inline-block;background:#1e293b;color:#fff;border-radius:6px;
                          padding:2px 10px;font-size:1.1rem;font-weight:700;letter-spacing:2px;">
-                05:00
+                {{ sprintf('%02d:%02d', floor($lockoutSeconds / 60), $lockoutSeconds % 60) }}
             </span>
         </div>
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -2,61 +2,105 @@
 @section('auth_header', 'Iniciar Sesión')
 
 @section('auth_body')
-    <form action="{{ route('login') }}" method="post">
+
+    @php
+        $lockoutSeconds = 0;
+        foreach ($errors->all() as $error) {
+            if (preg_match('/(\d+)\s*segundo/', $error, $m)) {
+                $lockoutSeconds = (int) $m[1];
+                break;
+            }
+        }
+        $isLocked = $lockoutSeconds > 0;
+    @endphp
+
+    <form action="{{ route('login') }}" method="post" id="login-form">
         @csrf
-
-        <div class="form-group">
-            <label class="form-label">Correo electrónico</label>
-            <div class="input-group">
-                <i class="fas fa-envelope input-icon"></i>
-                <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                        value="{{ old('email') }}" placeholder="tui@email.com" autofocus>
-                @error('email')
-                    <span class="invalid-feedback" role="alert">
-                        <strong>{{ $message }}</strong>
-                    </span>
-                @enderror
+        <div class="input-group mb-3">
+            <input type="email"
+                   name="email"
+                   id="input-email"
+                   class="form-control @error('email') is-invalid @enderror"
+                   placeholder="Email"
+                   value="{{ old('email') }}"
+                   {{ $isLocked ? 'readonly' : '' }}
+                   autofocus>
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    <span class="fas fa-envelope"></span>
+                </div>
             </div>
+            @error('email')
+                <span class="invalid-feedback d-block w-100" role="alert">
+                    <strong>{{ $message }}</strong>
+                </span>
+            @enderror
         </div>
-
-        <div class="form-group">
-            <label class="form-label">Contraseña</label>
-            <div class="input-group">
-                <i class="fas fa-lock input-icon"></i>
-                <input type="password" name="password" class="form-control @error('password') is-invalid @enderror"
-                        placeholder="Ingresa tu contraseña">
-                @error('password')
-                    <span class="invalid-feedback" role="alert">
-                        <strong>{{ $message }}</strong>
-                    </span>
-                @enderror
+        <div class="input-group mb-3">
+            <input type="password"
+                   name="password"
+                   id="input-password"
+                   class="form-control @error('password') is-invalid @enderror"
+                   placeholder="Contraseña"
+                   {{ $isLocked ? 'readonly' : '' }}>
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    <span class="fas fa-lock"></span>
+                </div>
             </div>
+            @error('password')
+                <span class="invalid-feedback d-block w-100" role="alert">
+                    <strong>{{ $message }}</strong>
+                </span>
+            @enderror
         </div>
-
-        <div class="remember-forgot">
-            <label class="custom-checkbox">
-                <input type="checkbox" name="remember" id="remember">
-                <span class="checkbox-label">Recordar sesión</span>
-            </label>
-            <div>
-                @if (Route::has('password.request'))
-                    <a href="{{ route('password.request') }}" class="forgot-link">
-                        ¿Olvidaste tu contraseña?
-                    </a>
-                @endif
-            </div>
-        </div>
-
-        <button type="submit" class="btn-login">
-            <i class="fas fa-sign-in-alt"></i>
-            Iniciar sesión
+        <button type="submit" id="btn-submit" class="btn-login" {{ $isLocked ? 'disabled' : '' }}>
+            <i class="fas fa-sign-in-alt"></i> Acceder
         </button>
     </form>
 
-    <div class="auth-links">
-        <p class="auth-text">¿No tienes una cuenta?</p>
-        @if (Route::has('register'))
-            <a href="{{ route('register') }}" class="register-link">Solicitar acceso</a>
-        @endif
-    </div>
+    @if ($isLocked)
+        <div id="lockout-timer" class="alert alert-danger text-center mt-3">
+            <i class="fas fa-user-lock mr-2"></i>
+            <strong>Acceso Bloqueado</strong><br>
+            Reintento en:
+            <span id="timer-display"
+                  style="display:inline-block;background:#1e293b;color:#fff;border-radius:6px;
+                         padding:2px 10px;font-size:1.1rem;font-weight:700;letter-spacing:2px;">
+                05:00
+            </span>
+        </div>
+
+        <script>
+            (function () {
+                let secondsLeft = {{ $lockoutSeconds }};
+
+                const btn      = document.getElementById('btn-submit');
+                const emailIn  = document.getElementById('input-email');
+                const passIn   = document.getElementById('input-password');
+                const timerBox = document.getElementById('lockout-timer');
+                const display  = document.getElementById('timer-display');
+
+                function pad(n) { return n < 10 ? '0' + n : String(n); }
+
+                display.textContent = pad(Math.floor(secondsLeft / 60)) + ':' + pad(secondsLeft % 60);
+
+                const interval = setInterval(function () {
+                    secondsLeft--;
+
+                    if (secondsLeft <= 0) {
+                        clearInterval(interval);
+                        timerBox.className = 'alert alert-success text-center mt-3';
+                        timerBox.innerHTML = '<i class="fas fa-unlock mr-2"></i> <strong>Puedes intentarlo de nuevo.</strong>';
+                        btn.disabled      = false;
+                        emailIn.readOnly  = false;
+                        passIn.readOnly   = false;
+                        return;
+                    }
+
+                    display.textContent = pad(Math.floor(secondsLeft / 60)) + ':' + pad(secondsLeft % 60);
+                }, 1000);
+            })();
+        </script>
+    @endif
 @stop

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -1,0 +1,1 @@
+@extends('adminlte::auth.login')

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -1,1 +1,0 @@
-@extends('adminlte::auth.login')

--- a/resources/views/vendor/adminlte/auth/auth-page.blade.php
+++ b/resources/views/vendor/adminlte/auth/auth-page.blade.php
@@ -48,6 +48,34 @@
             backdrop-filter: blur(10px);
             min-height: 520px;
         }
+        @media (max-width: 640px) {
+           .unified-login-container {
+            flex-direction: column;
+            border-radius: 14px;
+            min-height: unset;
+        }
+
+        .info-section {
+            padding: 25px 20px;
+            flex: unset;
+        }
+
+       .features-list {
+            display: none;
+        }   
+
+       .login-section {
+            flex: unset;
+            width: 100%;
+            padding: 25px 20px;
+        }
+
+        .login-page, .register-page {
+            align-items: flex-start;
+            padding: 12px;
+        }
+     }
+
 
         .info-section {
             flex: 1;

--- a/resources/views/vendor/adminlte/auth/auth-page.blade.php
+++ b/resources/views/vendor/adminlte/auth/auth-page.blade.php
@@ -76,7 +76,6 @@
         }
      }
 
-
         .info-section {
             flex: 1;
             background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,7 +54,7 @@ use App\Http\Controllers\LocalityOpenPayController;
 */
 
 Route::view('/', 'home')->name('home');
-Route::view('/login', 'login')->name('login');
+Route::view('/login', 'auth.login')->name('login');
 Route::post('/contact', [ContactController::class, 'send'])->name('contact.send');
 
 Route::get('/dashboard', function () {


### PR DESCRIPTION
  The login module was updated to include a validation mechanism that allows only two consecutive login attempts.  

- **New functionality:**  
  If the user fails both attempts, the system automatically displays a blocking message along with the corresponding lockout, preventing further access until the restriction is lifted.  

- **Reason for change:**  
  This adjustment was implemented to strengthen security measures, reduce brute-force login attempts, and ensure that users are aware of failed authentication attempts.  

- **Impact of the update:**  
  - Enhances system security by limiting repeated failed login attempts.  
  - Provides clear feedback to users through a visible block message.  
  - Improves overall reliability of the authentication process by enforcing stricter validation rules.
