### PR TITLE
remove quantity field from component edit form

### DIFF
--- a/resources/views/inventory/edit.blade.php
+++ b/resources/views/inventory/edit.blade.php
@@ -25,7 +25,7 @@
                             </div>
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-lg-12">
+                                    <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="nameUpdate{{ $component->id }}" class="form-label">Nombre del Componente(*)</label>
                                             <input type="text" class="form-control" name="name" id="nameUpdate{{ $component->id }}" value="{{ $component->name }}" required>

--- a/resources/views/inventory/edit.blade.php
+++ b/resources/views/inventory/edit.blade.php
@@ -33,12 +33,6 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="amountUpdate{{ $component->id }}" class="form-label">Cantidad(*)</label>
-                                            <input type="number" min="0" class="form-control" name="amount" id="amountUpdate{{ $component->id }}" value="{{ $component->amount }}" required>
-                                        </div>
-                                    </div>
-                                    <div class="col-lg-6">
-                                        <div class="form-group">
                                             <label for="inventory_category_idUpdate{{ $component->id }}" class="form-label">Categoría(*)</label>
                                             <select class="form-control select2" id="inventory_category_idUpdate{{ $component->id }}" name="inventory_category_id" required style="width: 100%;">
                                                 <option value="">Selecciona la categoría</option>


### PR DESCRIPTION
### Description
This pull request removes the "Quantity" field from the component editing form in the AquaControl system.

### Changes Made
* Removal of the quantity input field from the edit modal's Blade file.

* Updated form validation to exclude the quantity field rule.

* Adjusted the controller to skip processing this field during updates.

## Change Type
- [x] Bug fixes
- [x] Interface improvements