### PR TITLE
Add 'attention date' and 'category' fields to report

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -196,6 +196,8 @@ class IncidentController extends Controller
             ->get();
 
         foreach ($incidents as $incident) {
+            $latestLog = $incident->getstatusChangeLogs->first();
+            $incident->last_status_date = $latestLog ? $latestLog->created_at : null;
             $latest = $incident->getLatestStatus();
             $incident->current_status_name = $latest ? strtoupper($latest) : 'SIN ESTATUS';
             $incident->current_status_color = '#6c757d';

--- a/resources/views/reports/generateIncidentListReport.blade.php
+++ b/resources/views/reports/generateIncidentListReport.blade.php
@@ -119,6 +119,12 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                 padding: 5px;
             }
 
+            #detailedReport th:nth-child(3),
+            #detailedReport td:nth-child(3) {
+                width: 150px;
+                max-width: 150px;
+            }
+
             #statusDetails tr {
                 border-top: 1px solid #bfc9ff;
                 min-height: 60px;
@@ -172,12 +178,15 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                 font-weight: bold;
                 font-size: 9pt;
                 border-radius: 18px;
-                padding: 3px 12px;
+                padding: 4px 12px;
                 margin: 0 2px;
-                min-width: 70px;
+                min-width: 90px;
+                max-width: 150px;
                 text-align: center;
                 box-shadow: 0 1px 3px rgba(0,0,0,0.2);
                 line-height: 1.2;
+                word-wrap: break-word;
+                white-space: normal;
             }
         </style>
     </head>

--- a/resources/views/reports/generateIncidentListReport.blade.php
+++ b/resources/views/reports/generateIncidentListReport.blade.php
@@ -210,8 +210,9 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                         <th class="text_table">ID</th>
                         <th class="text_table">NOMBRE</th>
                         <th class="text_table">ESTATUS</th>
-                        <th class="text_table">CATEGORIA</th>
-                        <th class="text_table">FECHA INICIO</th>
+                        <th class="text_table">CATEGORÍA</th>
+                        <th class="text_table">FECHA REPORTE</th>
+                        <th class="text_table">FECHA ATENCIÓN</th>
                     </tr>
                 </thead>
                 <tbody id="statusDetails">
@@ -224,8 +225,15 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                                     {{ $incident->current_status_name }}
                                 </span>
                             </td>
-                            <td class="text_center">{{ $incident->incidentCategory->name}}</td>
+                            <td class="text_center" style="vertical-align:middle;">
+                                <span class="oval_color" style="background-color: {{ pdf_color($incident->incidentCategory->color ?? '#6c757d') }} !important;">
+                                    {{ $incident->incidentCategory->name }}
+                                </span>
+                            </td>
                             <td class="text_center">{{ \Carbon\Carbon::parse($incident->start_date)->format('d/m/Y') }}</td>
+                            <td class="text_center">
+                                {{ $incident->last_status_date ? \Carbon\Carbon::parse($incident->last_status_date)->format('d/m/Y') : '---' }}
+                            </td>
                         </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
Table Header Updates
- The incident report table was expanded to include new fields:
  - **Category** (with color-coded labels for better visualization).
  - **Report Date** (to track when the incident was created).
  - **Attention Date** (to display the date of the latest status update).

Table Data Enhancements
- The **Category** field now uses a colored oval span element:
  - Dynamically applies the category color using `pdf_color()`.
  - Displays the category name for clearer identification.
- A new **Attention Date** column was added:
  - Shows the last status date of the incident.
  - Formats the date as `dd/mm/yyyy` using Carbon.
  - Displays `---` if no status date is available.

Controller Logic Updates
- In `IncidentController.php`, the `generateIncidentListReport()` method was updated:
  - Retrieves the latest status change log for each incident.
  - Assigns the **last_status_date** based on the log’s `created_at`.
  - Ensures incidents without logs default to `null`.
  - Normalizes the **current_status_name** to uppercase or sets it to `"SIN ESTATUS"` if missing.
  - Provides a default color (`#6c757d`) for statuses without a defined color.