### PR TITLE
Fix/prevent duplicate alonso customer

### DIFF
--- a/database/seeders/CustomersTableSeeder.php
+++ b/database/seeders/CustomersTableSeeder.php
@@ -61,7 +61,6 @@ class CustomersTableSeeder extends Seeder
         }
         $alonsoUser = DB::table('users')->where('email', 'alonso@gmail.com')->first();
         $alonsoCustomerExists = DB::table('customers')->where('email', 'alonso@gmail.com')->exists();
-
         if ($alonsoUser && !$alonsoCustomerExists) {
             DB::table('customers')->insert([
                 'user_id' => $alonsoUser->id,

--- a/database/seeders/CustomersTableSeeder.php
+++ b/database/seeders/CustomersTableSeeder.php
@@ -60,26 +60,27 @@ class CustomersTableSeeder extends Seeder
             ]);
         }
         $alonsoUser = DB::table('users')->where('email', 'alonso@gmail.com')->first();
-            
-            if ($alonsoUser) {
-                DB::table('customers')->insert([
-                    'user_id' => $alonsoUser->id,
-                    'name' => 'Alonso',
-                    'last_name' => 'Gutiérrez López',
-                    'email' => 'alonso@gmail.com',
-                    'locality' => 'Mexico City',
-                    'state' => 'CDMX',
-                    'zip_code' => '28001',
-                    'block' => 'A',
-                    'street' => 'Calle Principal',
-                    'exterior_number' => 123,
-                    'interior_number' => 1,
-                    'marital_status' => 1,
-                    'status' => 1,
-                    'responsible_name' => null,
-                    'locality_id' => $alonsoUser->locality_id,
-                    'created_by' => 1,
-                ]);
-            }
+        $alonsoCustomerExists = DB::table('customers')->where('email', 'alonso@gmail.com')->exists();
+
+        if ($alonsoUser && !$alonsoCustomerExists) {
+            DB::table('customers')->insert([
+                'user_id' => $alonsoUser->id,
+                'name' => 'Alonso',
+                'last_name' => 'Gutiérrez López',
+                'email' => 'alonso@gmail.com',
+                'locality' => 'Mexico City',
+                'state' => 'CDMX',
+                'zip_code' => '28001',
+                'block' => 'A',
+                'street' => 'Calle Principal',
+                'exterior_number' => 123,
+                'interior_number' => 1,
+                'marital_status' => 1,
+                'status' => 1,
+                'responsible_name' => null,
+                'locality_id' => $alonsoUser->locality_id,
+                'created_by' => 1,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Added validation to prevent duplicate customer creation during seeding.
- Ensured the customer Alonso (alonso@gmail.com) is not inserted multiple times.
- Improved seeder idempotency by checking for existing records before creating new ones.

## Testing
- Run php artisan migrate --seed multiple times.
- Verify that only one customer record exists for alonso@gmail.com.