### PR TITLE
Add locality-specific balance sheet with income, expenses, and profits

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Customer;
 use App\Models\Debt;
+use App\Models\GeneralEarning;
+use App\Models\GeneralExpense;
 use App\Models\Locality;
 use App\Models\Payment;
 use App\Models\LocalityNotice;
@@ -85,17 +87,45 @@ class DashboardController extends Controller
                 $query->where('status', '!=', 'paid');
             })->count();
 
-        $monthlyEarnings = Payment::selectRaw('SUM(amount) as total, MONTH(created_at) as month')
+        $monthlyPayments = Payment::selectRaw('SUM(amount) as total, MONTH(created_at) as month')
             ->where('locality_id', $authUser->locality_id)
             ->whereYear('created_at', Carbon::now()->year)
             ->groupBy('month')
             ->orderBy('month')
             ->get();
 
-        $earningsPerMonth = array_fill(1, 12, 0);
+        $monthlyGeneralEarnings = GeneralEarning::selectRaw('SUM(amount) as total, MONTH(earning_date) as month')
+            ->where('locality_id', $authUser->locality_id)
+            ->whereYear('earning_date', Carbon::now()->year)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get();
 
-        foreach ($monthlyEarnings as $earning) {
-            $earningsPerMonth[$earning->month] = $earning->total;
+        $monthlyExpensesData = GeneralExpense::selectRaw('SUM(amount) as total, MONTH(expense_date) as month')
+            ->where('locality_id', $authUser->locality_id)
+            ->whereYear('expense_date', Carbon::now()->year)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get();
+
+        $monthlyIncomes = array_fill(1, 12, 0);
+        $monthlyExpenses = array_fill(1, 12, 0);
+        $monthlyGains = array_fill(1, 12, 0);
+
+        foreach ($monthlyPayments as $payment) {
+            $monthlyIncomes[$payment->month] += $payment->total;
+        }
+
+        foreach ($monthlyGeneralEarnings as $earning) {
+            $monthlyIncomes[$earning->month] += $earning->total;
+        }
+
+        foreach ($monthlyExpensesData as $expense) {
+            $monthlyExpenses[$expense->month] = $expense->total;
+        }
+
+        foreach ($monthlyIncomes as $month => $income) {
+            $monthlyGains[$month] = $income - $monthlyExpenses[$month];
         }
 
         $currentMonth = Carbon::now();
@@ -133,7 +163,9 @@ class DashboardController extends Controller
             'customersWithoutDebts' => $customersWithoutDebts,
             'noDebtsForCurrentMonth' => $noDebtsForCurrentMonth,
             'months' => $months,
-            'earningsPerMonth' => array_values($earningsPerMonth),
+            'monthlyIncomes' => array_values($monthlyIncomes),
+            'annualExpenses' => array_values($monthlyExpenses),
+            'annualGains' => array_values($monthlyGains),
             'localities' => $localities,
             'paidDebtsExpiringSoon' => $this->getPaidDebtsExpiringSoon($authUser->locality_id),
             'membershipDistribution' => $membershipDistribution,
@@ -161,21 +193,51 @@ class DashboardController extends Controller
     {
         $localityId = $request->input('locality_id');
 
-        $monthlyEarnings = Payment::selectRaw('SUM(amount) as total, MONTH(created_at) as month')
-        ->where('locality_id', $localityId)
-        ->whereYear('created_at', Carbon::now()->year)
-        ->groupBy('month')
-        ->orderBy('month')
-        ->get();
+        $monthlyPayments = Payment::selectRaw('SUM(amount) as total, MONTH(created_at) as month')
+            ->where('locality_id', $localityId)
+            ->whereYear('created_at', Carbon::now()->year)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get();
 
-        $earningsPerMonth = array_fill(1, 12, 0);
+        $monthlyGeneralEarnings = GeneralEarning::selectRaw('SUM(amount) as total, MONTH(earning_date) as month')
+            ->where('locality_id', $localityId)
+            ->whereYear('earning_date', Carbon::now()->year)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get();
 
-        foreach ($monthlyEarnings as $earning) {
-            $earningsPerMonth[$earning->month] = $earning->total;
+        $monthlyExpenses = GeneralExpense::selectRaw('SUM(amount) as total, MONTH(expense_date) as month')
+            ->where('locality_id', $localityId)
+            ->whereYear('expense_date', Carbon::now()->year)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get();
+
+        $incomes = array_fill(1, 12, 0);
+        $expenses = array_fill(1, 12, 0);
+        $gains = array_fill(1, 12, 0);
+
+        foreach ($monthlyPayments as $payment) {
+            $incomes[$payment->month] += $payment->total;
+        }
+
+        foreach ($monthlyGeneralEarnings as $earning) {
+            $incomes[$earning->month] += $earning->total;
+        }
+
+        foreach ($monthlyExpenses as $expense) {
+            $expenses[$expense->month] = $expense->total;
+        }
+
+        foreach ($incomes as $month => $income) {
+            $gains[$month] = $income - $expenses[$month];
         }
 
         return response()->json([
-            'earningsPerMonth' => array_values($earningsPerMonth),
+            'incomes' => array_values($incomes),
+            'expenses' => array_values($expenses),
+            'gains' => array_values($gains),
             'months' => collect(range(1, 12))->map(function ($month) {
                 return ucfirst(Carbon::create()->month($month)->locale('es')->monthName);
             })

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -277,7 +277,7 @@
                         <div class="col-md-4">
                             <div class="card">
                                 <div class="card-header">
-                                    <h3 class="card-title">Ingresos Anuales por Mes<span id="localityInfoAnnual"></h3>
+                                    <h3 class="card-title">Balance General<span id="localityInfoAnnual"></span></h3>
                                 </div>
                                 <div class="card-body chart-card-body">
                                     <canvas id="annualEarningsChart"></canvas>
@@ -382,10 +382,12 @@
                         type: 'GET',
                         data: { locality_id: localityId},
                         success: function(response){
-                            earningsChart.data.datasets[0].data = response.earningsPerMonth;
+                            earningsChart.data.datasets[0].data = response.incomes;
                             earningsChart.update();
 
-                            annualEarningsChart.data.datasets[0].data = response.earningsPerMonth;
+                            annualEarningsChart.data.datasets[0].data = response.incomes;
+                            annualEarningsChart.data.datasets[1].data = response.expenses;
+                            annualEarningsChart.data.datasets[2].data = response.gains;
                             annualEarningsChart.update();
                         },
                         error: function(xhr) {
@@ -399,6 +401,8 @@
                     earningsChart.update();
 
                     annualEarningsChart.data.datasets[0].data = Array(12).fill(0);
+                    annualEarningsChart.data.datasets[1].data = Array(12).fill(0);
+                    annualEarningsChart.data.datasets[2].data = Array(12).fill(0);
                     annualEarningsChart.update();
 
                     $('#localityInfoMonthly').text('');
@@ -447,7 +451,7 @@
                 labels: @json($data['months']),
                 datasets: [{
                     label: 'Ingresos en $',
-                    data: @json($data['earningsPerMonth']),
+                    data: @json($data['monthlyIncomes']),
                     backgroundColor: 'rgba(54, 162, 235, 0.5)',
                     borderColor: 'rgba(54, 162, 235, 1)',
                     borderWidth: 1
@@ -469,20 +473,46 @@
             type: 'line',
             data: {
                 labels: @json($data['months']),
-                datasets: [{
-                    label: 'Ingresos Anuales en $',
-                    data: @json($data['earningsPerMonth']),
-                    backgroundColor: 'rgba(255, 99, 132, 0.5)',
-                    borderColor: 'rgba(255, 99, 132, 1)',
-                    borderWidth: 2
-                }]
+                datasets: [
+                    {
+                        label: 'Ingresos',
+                        data: @json($data['monthlyIncomes']),
+                        backgroundColor: 'rgba(54, 162, 235, 0.4)',
+                        borderColor: 'rgba(54, 162, 235, 1)',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.2
+                    },
+                    {
+                        label: 'Gastos',
+                        data: @json($data['annualExpenses']),
+                        backgroundColor: 'rgba(236, 125, 41, 0.99)',
+                        borderColor: 'rgb(248, 84, 34)',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.2
+                    },
+                    {
+                        label: 'Ganancias',
+                        data: @json($data['annualGains']),
+                        backgroundColor: 'rgba(75, 192, 192, 0.4)',
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.2
+                    }
+                ]
             },
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
                 scales: {
                     y: {
-                        beginAtZero: true
+                        beginAtZero: true,
+                        suggestedMax: 4500,
+                        ticks: {
+                            stepSize: 500
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Configured the chart to show **three lines**:
  - **Income** = Payments + Income from the income module  
  - **Expenses** = Expenses from the expenses module  
  - **Profit** = Income - Expenses  
- Ensured charts are **unique per locality**, guaranteeing coherent and specific data.  
- Implemented logic so the **Admin can switch charts** based on the selected locality in the dropdown.  
- Updated the chart title to: **Balance Sheet**.  

## 📊 Expected Result
- A line chart with three clear financial indicators (**Income, Expenses, Profit**).  
- Horizontal axis with months from **January to December**.  
- Vertical axis with values from **0 to 4,500 in intervals of 500**.  
