### PR TITLE
Ensure reliable status saving for incidents and paginate debts

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -21,6 +21,24 @@ class DebtController extends Controller
         $authUser = auth()->user();
         $localityId = $authUser->locality_id;
 
+        $debts = Customer::where('locality_id', $localityId)
+            ->whereHas('waterConnections.debts', function ($query) {
+                $query->where('status', '!=', 'paid');
+            })
+            ->when($search, function ($query, $search) {
+                $query->where(function ($q) use ($search) {
+                    $q->where('id', 'like', "%{$search}%")
+                        ->orWhere('name', 'like', "%{$search}%")
+                        ->orWhere('last_name', 'like', "%{$search}%")
+                        ->orWhereRaw("CONCAT(name, ' ', last_name) LIKE ?", ["%{$search}%"]);
+                });
+            })
+            ->with(['waterConnections.debts' => function ($query) {
+                $query->where('status', '!=', 'paid');
+            }])
+            ->orderBy('id', 'desc')
+            ->paginate(10);
+
         $customers = Customer::where('customers.locality_id', $localityId)
             ->select('customers.id', 'customers.name', 'customers.last_name', 'customers.locality_id')
             ->where(function ($query) use ($search) {
@@ -29,7 +47,6 @@ class DebtController extends Controller
                     ->orWhere('customers.last_name', 'like', "%{$search}%")
                     ->orWhereRaw("CONCAT(customers.name, ' ', customers.last_name) LIKE ?", ["%{$search}%"]);
             })
-
             ->groupBy('customers.id', 'customers.name', 'customers.last_name', 'customers.locality_id')
             ->get();
 
@@ -37,34 +54,7 @@ class DebtController extends Controller
             ->where('locality_id', $localityId)
             ->get();
 
-        $debts = Debt::with(['waterConnection.customer', 'creator', 'debtCategory'])
-            ->whereHas('waterConnection', function ($query) use ($search, $localityId) {
-                $query->where('locality_id', $localityId)
-                    ->whereHas('customer', function ($query) use ($search) {
-                        $query->where(function ($query) use ($search) {
-                            $query->where('customers.id', 'like', "%{$search}%")
-                                ->orWhere('customers.name', 'like', "%{$search}%")
-                                ->orWhere('customers.last_name', 'like', "%{$search}%")
-                                ->orWhereRaw("CONCAT(customers.name, ' ', customers.last_name) LIKE ?", ["%{$search}%"]);
-                        });
-                    });
-            })
-            ->selectRaw('water_connection_id, debts.created_at, SUM(amount) as total_amount, MAX(debt_category_id) as debt_category_id')
-            ->where('status', '!=', 'paid')
-            ->groupBy('water_connection_id', 'debts.created_at')
-            ->orderByDesc('debts.created_at')
-            ->paginate(10);
         $totalDebts = [];
-        foreach ($debts as $debt) {
-            $customerId = $debt->waterConnection->customer_id;
-            if (!isset($totalDebts[$customerId])) {
-                $totalDebts[$customerId] = 0;
-            }
-
-            $totalDebtAmount = Debt::where('water_connection_id', $debt->water_connection_id)->sum('amount');
-            $totalDebtPaid = Debt::where('water_connection_id', $debt->water_connection_id)->sum('debt_current');
-            $totalDebts[$customerId] = $totalDebtAmount - $totalDebtPaid;
-        }
         $user = auth()->user();
         $debtCategoriesQuery = DebtCategory::query();
         $debtCategoriesQuery->where(function ($q) use ($user) {

--- a/resources/views/debts/delete.blade.php
+++ b/resources/views/debts/delete.blade.php
@@ -15,7 +15,7 @@
                     ¿Estás seguro de eliminar la deuda del periodo <strong>{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [de] YYYY') }} - {{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [de] YYYY') }} ?</strong>
                     Recuerda que si la deuda tiene pagos asociados se eliminaran.
                 </div>
-                <input type="hidden" name="modal_id" value="view{{ $debt->customer->id }}">
+                <input type="hidden" name="modal_id" value="viewDebts{{ $debt->waterConnection->customer->id }}">
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" onclick="closeCurrentModal('#deleteDebt{{ $waterConnectionDebt->id }}')">Cancelar</button>
                     <button type="submit" class="btn btn-danger">Confirmar</button>

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -61,38 +61,30 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @php
-                                            $shownCustomers = [];
-                                        @endphp
-                                        @forelse ($debts as $debt)
-                                            @if (!in_array($debt->waterConnection->customer_id, $shownCustomers))
-                                                <tr>
-                                                    <td>{{ $debt->waterConnection->customer->id }}</td>
-                                                    <td>{{ $debt->waterConnection->customer->name }} {{ $debt->waterConnection->customer->last_name }}</td>
-                                                    <td>
-                                                        @php
-                                                            $unpaidDebts = collect($debt->waterConnection->customer->waterConnections)->flatMap(function ($waterConnection) {
-                                                                return $waterConnection->debts->where('status', '!=', 'paid');
-                                                            });
-                                                            $totalDebt = $unpaidDebts->sum('amount');
-                                                            $totalPaid = $unpaidDebts->sum('debt_current');
-                                                            $pendingBalance = $totalDebt - $totalPaid;
-                                                        @endphp
-                                                        ${{ number_format($pendingBalance, 2, '.', ',') }}
-                                                    </td>
-                                                    <td>
-                                                        <div class="btn-group" role="group" aria-label="Opciones">
-                                                            <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles"
-                                                                data-target="#viewDebts{{ $debt->waterConnection->customer_id }}"> <i class="fas fa-eye"></i>
-                                                            </button>
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                                @include('debts.showDebts')
-                                                @php
-                                                    $shownCustomers[] = $debt->waterConnection->customer_id;
-                                                @endphp
-                                            @endif
+                                        @forelse ($debts as $customer)
+                                            <tr>
+                                                <td>{{ $customer->id }}</td>
+                                                <td>{{ $customer->name }} {{ $customer->last_name }}</td>
+                                                <td>
+                                                    @php
+                                                        $unpaidDebts = collect($customer->waterConnections)->flatMap(function ($waterConnection) {
+                                                            return $waterConnection->debts->where('status', '!=', 'paid');
+                                                        });
+                                                        $totalDebt = $unpaidDebts->sum('amount');
+                                                        $totalPaid = $unpaidDebts->sum('debt_current');
+                                                        $pendingBalance = $totalDebt - $totalPaid;
+                                                    @endphp
+                                                    ${{ number_format($pendingBalance, 2, '.', ',') }}
+                                                </td>
+                                                <td>
+                                                    <div class="btn-group" role="group" aria-label="Opciones">
+                                                        <button type="button" class="btn btn-info mr-2" data-toggle="modal" title="Ver Detalles"
+                                                            data-target="#viewDebts{{ $customer->id }}"> <i class="fas fa-eye"></i>
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            @include('debts.showDebts', ['debt' => (object)['waterConnection' => (object)['customer' => $customer]]])
                                         @empty
                                             <tr>
                                                 <td colspan="5">No hay deudas registradas.</td>

--- a/resources/views/incidents/changeStatusModal.blade.php
+++ b/resources/views/incidents/changeStatusModal.blade.php
@@ -77,7 +77,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
-                        <button type="button" id="saveStatus" class="btn btn-success">Guardar</button>
+                        <button type="submit" id="saveStatus" class="btn btn-success">Guardar</button>
                     </div>
                 </form>
             </div>
@@ -119,10 +119,11 @@
             });
         });
 
-        saveBtn.addEventListener('click', function () {
-            const formData = new FormData(form);
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const formData = new FormData(this);
 
-            fetch(form.action, {
+            fetch(this.action, {
                 method: 'POST',
                 body: formData,
                 headers: {

--- a/resources/views/incidents/index.blade.php
+++ b/resources/views/incidents/index.blade.php
@@ -168,7 +168,6 @@
                                             @endforeach
                                         </tbody>
                                     </table>
-                                    @include('incidents.changeStatusModal')
                                     <div class="d-flex justify-content-center">
                                         {!! $incidents->links('pagination::bootstrap-4') !!}
                                     </div>
@@ -181,6 +180,7 @@
         </div>
     </section>
     @include('incidents.create')
+    @include('incidents.changeStatusModal')
 
 @endsection
 
@@ -333,39 +333,6 @@
                 width: '100%',
                 dropdownParent: $(this).closest('.modal')
             });
-        });
-    });
-
-    $('#changeStatusForm').on('submit', function(e) {
-        e.preventDefault();
-
-        var form = $(this);
-        var formData = form.serialize();
-
-        $.ajax({
-            url: "{{ route('incidents.updateStatus') }}",
-            type: 'POST',
-            data: formData,
-            success: function(response) {
-                if (response.success) {
-                    Swal.fire({
-                        icon: 'success',
-                        title: 'Éxito',
-                        text: response.message,
-                        confirmButtonText: 'Aceptar'
-                    }).then(() => {
-                        location.reload();
-                    });
-                }
-            },
-            error: function(xhr) {
-                Swal.fire({
-                    icon: 'error',
-                    title: 'Error',
-                    text: 'Ocurrió un error al actualizar el estatus',
-                    confirmButtonText: 'Aceptar'
-                });
-            }
         });
     });
 </script>


### PR DESCRIPTION
## 🛠 Incidents Module
- Fixed the issue in the options section where changing the status of an incident (internal or external) did not store the data correctly.  
- The **Save button** now reliably executes the save action in a single click, registering status changes without failures.  

## 💰 Debts Module
- Adjusted pagination so that each page consistently displays **exactly 10 records**.  
- Previously, irregular amounts were shown (8 or 12 records).  
- Only the **index function** was modified, keeping the rest of the design and logic intact.  
