### PR TITLE
Feature/standardize sidebar menu colors

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -311,7 +311,7 @@ return [
     [
         'text' => 'Panel',
         'url' => '/dashboard',
-        'icon' => 'fas fa-fw fa-home',
+        'icon' => 'fas fa-fw fa-home text-white',
     ],
     [
         'text' => 'Gestión de Pagos',

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -311,7 +311,7 @@ return [
     [
         'text' => 'Panel',
         'url' => '/dashboard',
-        'icon' => 'fas fa-fw fa-home text-white',
+        'icon' => 'fas fa-fw fa-home',
     ],
     [
         'text' => 'Gestión de Pagos',
@@ -515,31 +515,31 @@ return [
         'text' => 'Mis Pagos',
         'url' => '/viewCustomerPayments',
         'can' => 'viewCustomerPayments',
-        'icon' => 'fas fa-fw fa-dollar-sign text-white',
+        'icon' => 'fas fa-fw fa-dollar-sign',
     ],
     [
         'text' => 'Mis Deudas',
         'url' => '/viewCustomerDebts',
         'can'  => 'viewCustomerDebts',
-        'icon' => 'fas fa-fw fa-exclamation-circle text-white',
+        'icon' => 'fas fa-fw fa-exclamation-circle',
     ],
     [
         'text' => 'Mis Tarjetas',
         'url' => '/customerCards',
         'can'  => 'viewCustomerDebts',
-        'icon' => 'fas fa-fw fa-credit-card text-white',
+        'icon' => 'fas fa-fw fa-credit-card',
     ],
     [
         'text' => 'Mis Tomas de Agua',
         'url' => '/viewCustomerWaterConnections',
         'can' => 'viewWaterConnections',
-        'icon' => 'fas fa-fw fa-water text-white',
+        'icon' => 'fas fa-fw fa-water',
     ],
     [
         'text' => 'Mis Incidencias',
         'url' => '/customerIncidents',
         'can' => 'viewCustomerFaultReports',
-        'icon' => 'fa fa-exclamation-triangle text-white',
+        'icon' => 'fa fa-exclamation-triangle',
     ],
     [
         'text' => 'Avisos',


### PR DESCRIPTION
### **📋 Description**

This PR standardizes the appearance of the user sidebar menu by removing the text-white class from menu icons.

**✅ Changes Made**

Removed text-white from user module icons:

- Mis Pagos
- Mis Deudas
- Mis Tarjetas
- Mis Tomas de Agua
- Mis Incidencias

Unified icon styling across the user sidebar.
Improved visual consistency and readability.

**🎯 Result**

All user sidebar menu items now follow the same color scheme, eliminating visual inconsistencies caused by manually applied icon colors.