### PR TITLE
Add missing Spanish translations for role permission modules

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -45,6 +45,9 @@ class RoleController extends Controller
             'Earningtype' => 'Tipos de ingresos',
             'Generalearning' => 'Ingresos generales',
             'Graficsearningsannual' => 'Gráficas de ingresos',
+            'Debtcategorie' => 'Categorías de Deuda',
+            'Customerincident' => 'Incidentes de Clientes',
+            'Employeeposition' => 'Puestos de Empleados',
         ];
     }
 


### PR DESCRIPTION
## Summary
Added missing Spanish translations for permission module names displayed in role creation and edit screens.

## Changes
- Added translation for Debtcategorie → Categorías de Deuda.
- Added translation for Customerincident → Incidentes de Clientes.
- Added translation for Employeeposition → Puestos de Empleados.
- Improved readability of permission groups in role management views.

## Testing
- Verified role creation modal displays translated module names.
- Verified role edit page displays translated module names.
- Confirmed existing module translations remain unchanged.