### PR TITLE
add reset button in Localities modal to restore AquaControl report ba…

### DIFF
--- a/app/Http/Controllers/LocalityController.php
+++ b/app/Http/Controllers/LocalityController.php
@@ -205,4 +205,27 @@ class LocalityController extends Controller
 
         return redirect()->route('localities.index')->with('success', 'Fondos de reportes actualizados correctamente.');
     }
+
+    public function resetPdfBackground(Request $request, $id)
+    {
+        $locality = Locality::find($id);
+
+        if (!$locality) {
+            return redirect()->back()->with('error', 'Localidad no encontrada.');
+        }
+
+        $type = $request->input('type');
+
+        if ($type === 'vertical') {
+            $locality->clearMediaCollection('pdfBackgroundVertical');
+            return redirect()->route('localities.index')->with('success', 'Fondo de reporte vertical reseteado correctamente.');
+        }
+
+        if ($type === 'horizontal') {
+            $locality->clearMediaCollection('pdfBackgroundHorizontal');
+            return redirect()->route('localities.index')->with('success', 'Fondo de reporte horizontal reseteado correctamente.');
+        }
+
+        return redirect()->back()->with('error', 'Tipo de fondo no válido.');
+    }
 }

--- a/resources/views/localities/editPdfBackground.blade.php
+++ b/resources/views/localities/editPdfBackground.blade.php
@@ -25,6 +25,11 @@
                                     alt="Fondo Vertical" style="width: 200px; height: 280px; border-radius: 10px; margin-bottom: 10px;">
                                 <input type="file" accept="image/*" name="pdf_background_vertical"
                                     class="form-control" onchange="previewImageEdit(event, 'vertical', {{ $locality->id }})">
+                                @if($locality->getFirstMediaUrl('pdfBackgroundVertical'))
+                                    <button type="button" class="btn btn-primary btn-sm mt-2" onclick="document.getElementById('reset-vertical-form-{{ $locality->id }}').submit();">
+                                        <i class="fas fa-redo"></i> Restablecer
+                                    </button>
+                                @endif
                             </div>
                         </div>
                         <div class="card">
@@ -40,6 +45,11 @@
                                     alt="Fondo Horizontal" style="width: 280px; height: 200px; border-radius: 10px; margin-bottom: 10px;">
                                 <input type="file" accept="image/*" name="pdf_background_horizontal"
                                     class="form-control" onchange="previewImageEdit(event, 'horizontal', {{ $locality->id }})">
+                                @if($locality->getFirstMediaUrl('pdfBackgroundHorizontal'))
+                                    <button type="button" class="btn btn-primary btn-sm mt-2" onclick="document.getElementById('reset-horizontal-form-{{ $locality->id }}').submit();">
+                                        <i class="fas fa-redo"></i> Restablecer
+                                    </button>
+                                @endif
                             </div>
                         </div>
                     </div>
@@ -47,6 +57,15 @@
                         <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="resetForm({{ $locality->id }})">Cancelar</button>
                         <button type="submit" class="btn bg-navy">Actualizar</button>
                     </div>
+                </form>
+                <form action="{{ route('localities.resetPdfBackground', $locality->id) }}" method="POST" id="reset-vertical-form-{{ $locality->id }}" style="display: none;">
+                    @csrf
+                    <input type="hidden" name="type" value="vertical">
+                </form>
+
+                <form action="{{ route('localities.resetPdfBackground', $locality->id) }}" method="POST" id="reset-horizontal-form-{{ $locality->id }}" style="display: none;">
+                    @csrf
+                    <input type="hidden" name="type" value="horizontal">
                 </form>
             </div>
         </div>

--- a/resources/views/localities/editPdfBackground.blade.php
+++ b/resources/views/localities/editPdfBackground.blade.php
@@ -62,7 +62,6 @@
                     @csrf
                     <input type="hidden" name="type" value="vertical">
                 </form>
-
                 <form action="{{ route('localities.resetPdfBackground', $locality->id) }}" method="POST" id="reset-horizontal-form-{{ $locality->id }}" style="display: none;">
                     @csrf
                     <input type="hidden" name="type" value="horizontal">

--- a/routes/web.php
+++ b/routes/web.php
@@ -139,6 +139,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::put('/localities/{locality}/mailConfiguration', [MailConfigurationController::class, 'createOrUpdateMailConfigurations'])->name('mailConfigurations.createOrUpdate');
         Route::post('/localities/generateTeoken', [LocalityController::class, 'generateToken'])->name('localities.generateToken');
         Route::post('/localities/{locality}/update-pdf-background', [LocalityController::class, 'updatePdfBackground'])->name('localities.updatePdfBackground');
+        Route::post('/localities/{locality}/reset-pdf-background', [LocalityController::class, 'resetPdfBackground'])->name('localities.resetPdfBackground');
         Route::get('/reports/movements/generate', [MovementHistoryController::class, 'generatePDF'])->name('reports.generatePdfMovementsHistory');
         
         Route::put('/localities/{locality}/openpay', [LocalityOpenPayController::class, 'update'])->name('localities.openpay.update');


### PR DESCRIPTION
## ⚙️ Changes Implemented

### 1. Controller (`LocalityController.php`)
- Added the **resetPdfBackground** method:
  - Finds the locality by ID.
  - Accepts a `type` parameter (`vertical` or `horizontal`).
  - Clears the corresponding media collection (`pdfBackgroundVertical` or `pdfBackgroundHorizontal`).
  - Returns success or error messages depending on the action.

### 2. View (`editPdfBackground.blade.php`)
- Added **Reset** buttons next to each background (vertical and horizontal).
- Buttons trigger hidden forms that submit the reset action to the controller.
- Buttons are only displayed if a background exists for the locality.
- Included hidden forms with `@csrf` and a `type` field to differentiate between vertical and horizontal resets.

### 3. Routes (`web.php`)
- Registered a new route:
  ```php
  Route::post('/localities/{locality}/reset-pdf-background', [LocalityController::class, 'resetPdfBackground'])->name('localities.resetPdfBackground');
