### PR TITLE
Fixed issue where seeder migration generated excessive duplicate records

### DIFF
--- a/database/seeders/DebtCategoriesTableSeeder.php
+++ b/database/seeders/DebtCategoriesTableSeeder.php
@@ -25,6 +25,11 @@ class DebtCategoriesTableSeeder extends Seeder
         );
 
         $localityIds = DB::table('localities')->pluck('id');
+        $localitiesWithCategories = DB::table('debt_categories')
+            ->whereNotNull('locality_id')
+            ->distinct()
+            ->pluck('locality_id')
+            ->toArray();
         $usersByLocality = DB::table('users')
             ->join('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
             ->join('roles', 'model_has_roles.role_id', '=', 'roles.id')
@@ -54,6 +59,9 @@ class DebtCategoriesTableSeeder extends Seeder
         $data = [];
 
         foreach ($localityIds as $localityId) {
+            if (in_array($localityId, $localitiesWithCategories)) {
+                continue;
+            }
             $createdBy = $usersByLocality[$localityId]->first()->id ?? $defaultUser;
 
             foreach ($baseCategories as $category) {
@@ -66,11 +74,12 @@ class DebtCategoriesTableSeeder extends Seeder
                 ];
             }
         }
-
+        if (!empty($data)) {
         DB::table('debt_categories')->upsert(
             $data,
             ['name', 'locality_id'],
             []
         );
+        }
     }
 }


### PR DESCRIPTION
Prevent duplicate records when running the debt categories seeder, ensuring consistent and valid data per locality.

## ⚙️ Changes Made
- Retrieved **locality IDs** and identified those that already had categories registered.  
- Added a validation to **skip localities** that already contain categories, avoiding duplication.  
- Implemented a condition so the **upsert** process only runs if the data array is not empty.  
- Preserved the logic for associating categories with users per locality, now with stricter control over record creation.  

## 📊 Expected Result
- The seeder generates debt categories **only for localities without existing categories**.  
- Excessive repetition of data is avoided, keeping the database cleaner and more coherent.  
- The migration process becomes more reliable and aligned with business rules.  
