### PR TITLE
add warning alert indicator next to send reminders button

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -143,6 +143,8 @@ class DashboardController extends Controller
 
         $mailConfig = $authUser->locality?->mailConfiguration;
         $hasMailConfig = $mailConfig && $mailConfig->isComplete();
+        $locality = $authUser->locality;
+        $remindersSentToday = $locality && $locality->last_reminder_sent_at && $locality->last_reminder_sent_at->isToday();
 
         $waterConnections = $authUser->customer?->waterConnections ?? collect();
         $totalDebts = $waterConnections->flatMap->debts->count();
@@ -186,8 +188,9 @@ class DashboardController extends Controller
             'totalUsers',
             'totalLocalities',
             'totalMemberships',
-            'membershipDistribution'
-            , 'membershipStatusCounts'
+            'membershipDistribution',
+            'remindersSentToday',
+            'membershipStatusCounts'
         ));
     }
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -305,14 +305,21 @@
                                 <div class="col-12 col-md-10">
                                     <h3 class="card-title m-0">Períodos Próximos a Vencer</h3>
                                 </div>
-                                <div class="col-12 col-md-auto mt-2 mt-md-0 ms-md-auto">
-                                    <form action="{{ route('dashboard.sendEmailsForDebtsExpiringSoon') }}" method="POST" class="w-100">
-                                        @csrf
-                                        <button type="submit" class="btn {{ $hasMailConfig ? 'btn-primary' : 'btn-secondary disabled' }} btn-sm w-100 w-md-auto" title="{{ $hasMailConfig
-                                                ? 'Enviar correos de recordatorio' : 'Para enviar recordatorios configura tu correo, contáctanos' }}" {{ $hasMailConfig ? '' : 'disabled' }}>
-                                            <i class="fas fa-envelope"></i> Enviar recordatorios
-                                        </button>
-                                    </form>
+                                <div class="col-12 col-md-auto mt-2 mt-md-0 ms-md-auto d-flex align-items-center">
+                                    @if($remindersSentToday)
+                                        <div class="text-warning d-flex align-items-center" title="Los recordatorios ya fueron enviados el día de hoy">
+                                            <i class="fas fa-exclamation-circle fa-lg mr-2"></i>
+                                            <span class="font-weight-bold">Ya se enviaron recordatorios</span>
+                                        </div>
+                                    @else
+                                        <form action="{{ route('dashboard.sendEmailsForDebtsExpiringSoon') }}" method="POST" class="w-100" id="sendRemindersForm">
+                                            @csrf
+                                            <button type="submit" class="btn {{ $hasMailConfig ? 'btn-primary' : 'btn-secondary disabled' }} btn-sm w-100 w-md-auto" title="{{ $hasMailConfig
+                                                    ? 'Enviar correos de recordatorio' : 'Para enviar recordatorios configura tu correo, contáctanos' }}" {{ $hasMailConfig ? '' : 'disabled' }}>
+                                                <i class="fas fa-envelope"></i> Enviar recordatorios
+                                            </button>
+                                        </form>
+                                    @endif
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## 🛠 DashboardController.php
The `index()` method was updated to include a validation that checks whether reminders have already been sent during the current day. This is achieved by retrieving the authenticated user’s locality and evaluating the `last_reminder_sent_at` property with the `isToday()` method. The result is stored in the `$remindersSentToday` boolean, which is then passed to the dashboard view.

## 🖥️ dashboard.blade.php
The **“Períodos Próximos a Vencer”** section was restructured using a Blade `@if` conditional to adapt the interface based on the computed flag.  
- If reminders were already sent today, the submission form is hidden and a flexible container is displayed with a yellow warning icon and the message **“Ya se enviaron recordatorios.”**  
- Otherwise, the system preserves its original behavior, rendering the standard button to trigger the notification action.
