### PR TITLE
design height and resizing of the membership info box

### DIFF
--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -24,9 +24,9 @@
     @endphp
     <section class="content">
         <div class="container-fluid">
-            <div class="row">
+            <div class="row d-flex align-items-stretch">
                 <div class="col-md-3">
-                    <div class="card card-primary">
+                    <div class="card card-primary h-100 mb-0">
                         <div class="card-header">
                             <h3 class="card-title">Foto de perfil</h3>
                         </div>
@@ -50,7 +50,7 @@
                     </div>
                 </div>
                 <div class="col-md-9">
-                    <div class="card card-primary">
+                    <div class="card card-primary h-100 mb-0">
                         <div class="card-header">
                             <h3 class="card-title">Editar perfil</h3>
                         </div>
@@ -150,8 +150,12 @@
                             </div>
                         </div>
                     </div>
-                    @can('viewDashboardCards')
-                    <div class="col-md-12">
+                </div>
+            </div>
+                        
+            @can('viewDashboardCards')
+            <div class="row mt-3">
+                <div class="col-md-12">
                         <div class="card card-info">
                             <div class="card-header">
                                 <h3 class="card-title">Información de Membresía</h3>
@@ -266,9 +270,8 @@
                             </div>
                         </div>
                     </div>
-                    @endcan
-                </div>
             </div>
+            @endcan
         </div>
     </section>
     @include('profile.editImage')

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -151,8 +151,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
-                        
+            </div>                        
             @can('viewDashboardCards')
             <div class="row mt-3">
                 <div class="col-md-12">


### PR DESCRIPTION
## 🔧 Changes Summary
- Added `d-flex align-items-stretch` to the main row → ensures equal height alignment between cards.  
- Updated cards for **Profile Photo** and **Edit Profile** with `h-100 mb-0` → uniform height and removed bottom margin.  
- Moved **Membership Information** section into a new row (`row mt-3`) → provides longer space and better layout distribution.  
- Preserved `@can` permission logic → only adjusted necessary tags and classes.

### ✅ Result
- **Edit Profile** now matches the height of **Profile Photo**.  
- **Membership Information** displays with extended length and improved organization.  
