### PR TITLE
Feature/add tabs to debt details modal

### DIFF
--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -38,13 +38,19 @@
                                             <div class="form-group">
                                                 <label>Estado</label>
                                                 <p class="form-control">
-                                                    @if ($waterConnectionDebt->status === 'pending')
-                                                        <span class="badge badge-danger">No pagada</span>
-                                                    @elseif ($waterConnectionDebt->status === 'partial')
-                                                        <span class="badge badge-warning">Abonada</span>
-                                                    @elseif ($waterConnectionDebt->status === 'paid')
-                                                        <span class="badge badge-success">Pagada</span>
-                                                    @endif
+                                                    @switch($waterConnectionDebt->status)
+                                                        @case('pending')
+                                                            <span class="badge badge-danger">No pagada</span>
+                                                            @break
+                                                        @case('partial')
+                                                            <span class="badge badge-warning">Abonada</span>
+                                                            @break
+                                                        @case('paid')
+                                                            <span class="badge badge-success">Pagada</span>
+                                                            @break
+                                                        @default
+                                                            <span class="badge badge-secondary">Desconocido</span>
+                                                    @endswitch
                                                 </p>
                                             </div>
                                         </div>

--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -1,3 +1,6 @@
+@php
+    use Carbon\Carbon;
+@endphp
 <div class="modal fade" id="viewDebt{{ $waterConnectionDebt->id }}" tabindex="-1" role="dialog" aria-labelledby="viewModalLabel{{ $waterConnectionDebt->id }}" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -99,13 +102,13 @@
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Inicio</label>
-                                                <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                                <input type="text" disabled class="form-control" value="{{ Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
                                             </div>
                                         </div>
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Fin</label>
-                                                <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                                <input type="text" disabled class="form-control" value="{{ Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
                                             </div>
                                         </div>
                                         <div class="col-lg-12">
@@ -154,7 +157,7 @@
                                                         <br>
                                                     @endif
                                                     <strong>Fecha:</strong>
-                                                    {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
+                                                    {{Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
                                                 </li>
                                             @empty
                                                 <li class="list-group-item">

--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -13,120 +13,197 @@
                 <div class="modal-body">
                     <div class="card">
                         <div class="card-body">
-                            <div class="row">
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label>ID</label>
-                                        <input type="text" disabled class="form-control" value="{{ $waterConnectionDebt->id }}" />
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label>Estado</label>
-                                        <p class="form-control">
-                                            @if ($waterConnectionDebt->status === 'pending')
-                                                <button class="badge badge-danger">No pagada</button>
-                                            @elseif ($waterConnectionDebt->status === 'partial')
-                                                <button class="badge badge-warning">Abonada</button>
-                                            @elseif ($waterConnectionDebt->status === 'paid')
-                                                <button class="badge badge-success">Pagada</button>
-                                            @endif
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label>Monto de la Deuda</label>
-                                        <div class="input-group">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text"><i class="fa fa-dollar-sign"></i></span>
+                            <ul class="nav nav-tabs mb-3" id="debtTabs{{ $waterConnectionDebt->id }}" role="tablist">
+                                <li class="nav-item">
+                                    <a class="nav-link active"
+                                        id="general-tab{{ $waterConnectionDebt->id }}"
+                                        data-toggle="tab"
+                                        href="#general{{ $waterConnectionDebt->id }}"
+                                        role="tab">
+                                        Información General
+                                    </a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link"
+                                        id="payments-tab{{ $waterConnectionDebt->id }}"
+                                        data-toggle="tab"
+                                        href="#payments{{ $waterConnectionDebt->id }}"
+                                        role="tab">
+                                        Historial de Pagos
+                                    </a>
+                                </li>
+                            </ul>
+
+                            <div class="tab-content pt-3">
+
+                                {{-- TAB INFORMACIÓN GENERAL --}}
+                                <div class="tab-pane fade show active"
+                                    id="general{{ $waterConnectionDebt->id }}"
+                                    role="tabpanel">
+
+                                    <div class="row">
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>ID</label>
+                                                <input type="text" disabled class="form-control"
+                                                    value="{{ $waterConnectionDebt->id }}">
                                             </div>
-                                            <input type="text" disabled class="form-control" value="{{ number_format($waterConnectionDebt->amount, 2) }}" />
                                         </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label>Cantidad Pagada</label>
-                                        <div class="input-group">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text"><i class="fa fa-dollar-sign"></i></span>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Estado</label>
+                                                <p class="form-control">
+                                                    @if ($waterConnectionDebt->status === 'pending')
+                                                        <span class="badge badge-danger">No pagada</span>
+                                                    @elseif ($waterConnectionDebt->status === 'partial')
+                                                        <span class="badge badge-warning">Abonada</span>
+                                                    @elseif ($waterConnectionDebt->status === 'paid')
+                                                        <span class="badge badge-success">Pagada</span>
+                                                    @endif
+                                                </p>
                                             </div>
-                                            <input type="text" disabled class="form-control" value="{{ number_format($waterConnectionDebt->debt_current, 2) }}" />
                                         </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-12">
-                                    <div class="form-group">
-                                        <label>Saldo pendiente</label>
-                                        <div class="input-group">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text"><i class="fa fa-dollar-sign"></i></span>
-                                            </div>
-                                            @php
-                                                $remainingAmount = $waterConnectionDebt->amount - $waterConnectionDebt->debt_current;
-                                            @endphp
-                                            <input type="text" disabled class="form-control" value="{{ number_format($remainingAmount , 2) }}" />
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label>Fecha de Inicio</label>
-                                        <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}" />
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label>Fecha de Fin</label>
-                                        <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}" />
-                                    </div>
-                                </div>
-                                <div class="col-lg-12">
-                                    <div class="form-group">
-                                        <label>Observación</label>
-                                        <textarea disabled class="form-control">{{ $waterConnectionDebt->note }}</textarea>
-                                    </div>
-                                </div>
-                                <div class="col-lg-12">
-                                    <div class="form-group">
-                                        <label>Registrada por</label>
-                                        <input type="text" disabled class="form-control" value="{{ $waterConnectionDebt->creator->name ?? 'Desconocido' }} {{ $waterConnectionDebt->creator->last_name ?? '' }}" />
-                                    </div>
-                                </div>
-                                <div class="col-lg-12 mt-4">
-                                    <label>Historial de Pagos</label>
-                                    <div class="payment-history" style="max-height: 110px; overflow-y: auto;">                                        <ul class="list-group">
-                                            @forelse ($waterConnectionDebt->payments as $payment)
-                                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                                    <div>
-                                                        <strong>Monto:</strong> ${{ number_format($payment->amount, 2) }} <br>
-                                                        @switch($payment->method)
-                                                            @case('cash')
-                                                                <strong>Método:</strong> Efectivo <br>
-                                                                @break
-                                                            @case('card')
-                                                            <strong>Método:</strong> Tarjeta <br>
-                                                                @break
-                                                            @case('transfer')
-                                                            <strong>Método:</strong> Transferencia <br>
-                                                                @break
-                                                            @default
-                                                                <strong>Método:</strong> Desconocido <br>
-                                                        @endswitch
-                                                        @if ($payment->note)
-                                                            <strong>Nota:</strong> {{ $payment->note }} <br>
-                                                        @endif
-                                                        <strong>Fecha:</strong> {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Monto de la Deuda</label>
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                        <span class="input-group-text">
+                                                            <i class="fa fa-dollar-sign"></i>
+                                                        </span>
                                                     </div>
+                                                    <input type="text" disabled class="form-control"
+                                                        value="{{ number_format($waterConnectionDebt->amount, 2) }}">
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Cantidad Pagada</label>
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                        <span class="input-group-text">
+                                                            <i class="fa fa-dollar-sign"></i>
+                                                        </span>
+                                                    </div>
+                                                    <input type="text" disabled class="form-control"
+                                                        value="{{ number_format($waterConnectionDebt->debt_current, 2) }}">
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-12">
+                                            <div class="form-group">
+                                                <label>Saldo pendiente</label>
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                        <span class="input-group-text">
+                                                            <i class="fa fa-dollar-sign"></i>
+                                                        </span>
+                                                    </div>
+
+                                                    @php
+                                                        $remainingAmount = $waterConnectionDebt->amount - $waterConnectionDebt->debt_current;
+                                                    @endphp
+
+                                                    <input type="text" disabled class="form-control"
+                                                        value="{{ number_format($remainingAmount, 2) }}">
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Fecha de Inicio</label>
+                                                <input type="text" disabled class="form-control"
+                                                    value="{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <div class="form-group">
+                                                <label>Fecha de Fin</label>
+                                                <input type="text" disabled class="form-control"
+                                                    value="{{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-12">
+                                            <div class="form-group">
+                                                <label>Observación</label>
+                                                <textarea disabled class="form-control">{{ $waterConnectionDebt->note }}</textarea>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-lg-12">
+                                            <div class="form-group">
+                                                <label>Registrada por</label>
+                                                <input type="text" disabled class="form-control"
+                                                    value="{{ $waterConnectionDebt->creator->name ?? 'Desconocido' }} {{ $waterConnectionDebt->creator->last_name ?? '' }}">
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                                {{-- TAB HISTORIAL DE PAGOS --}}
+                                <div class="tab-pane fade"
+                                    id="payments{{ $waterConnectionDebt->id }}"
+                                    role="tabpanel">
+
+                                    <div class="payment-history" style="max-height: 350px; overflow-y: auto;">
+                                        <ul class="list-group">
+                                            @forelse ($waterConnectionDebt->payments as $payment)
+                                                <li class="list-group-item">
+                                                    <strong>Monto:</strong>
+                                                    ${{ number_format($payment->amount, 2) }}
+                                                    <br>
+
+                                                    @switch($payment->method)
+                                                        @case('cash')
+                                                            <strong>Método:</strong> Efectivo
+                                                            <br>
+                                                        @break
+
+                                                        @case('card')
+                                                            <strong>Método:</strong> Tarjeta
+                                                            <br>
+                                                        @break
+
+                                                        @case('transfer')
+                                                            <strong>Método:</strong> Transferencia
+                                                            <br>
+                                                        @break
+
+                                                        @default
+                                                            <strong>Método:</strong> Desconocido
+                                                            <br>
+                                                    @endswitch
+
+                                                    @if ($payment->note)
+                                                        <strong>Nota:</strong>
+                                                        {{ $payment->note }}
+                                                        <br>
+                                                    @endif
+
+                                                    <strong>Fecha:</strong>
+                                                    {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
                                                 </li>
                                             @empty
-                                                <li class="list-group-item">No hay pagos registrados para esta deuda.</li>
+                                                <li class="list-group-item">
+                                                    No hay pagos registrados para esta deuda.
+                                                </li>
                                             @endforelse
                                         </ul>
                                     </div>
+
                                 </div>
+
                             </div>
+                            
                         </div>
                     </div>
                 </div>

--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -15,41 +15,25 @@
                         <div class="card-body">
                             <ul class="nav nav-tabs mb-3" id="debtTabs{{ $waterConnectionDebt->id }}" role="tablist">
                                 <li class="nav-item">
-                                    <a class="nav-link active"
-                                        id="general-tab{{ $waterConnectionDebt->id }}"
-                                        data-toggle="tab"
-                                        href="#general{{ $waterConnectionDebt->id }}"
-                                        role="tab">
+                                    <a class="nav-link active" id="general-tab{{ $waterConnectionDebt->id }}" data-toggle="tab" href="#general{{ $waterConnectionDebt->id }}" role="tab">
                                         Información General
                                     </a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link"
-                                        id="payments-tab{{ $waterConnectionDebt->id }}"
-                                        data-toggle="tab"
-                                        href="#payments{{ $waterConnectionDebt->id }}"
-                                        role="tab">
+                                    <a class="nav-link" id="payments-tab{{ $waterConnectionDebt->id }}" data-toggle="tab" href="#payments{{ $waterConnectionDebt->id }}" role="tab">
                                         Historial de Pagos
                                     </a>
                                 </li>
                             </ul>
-
                             <div class="tab-content pt-3">
-
-                                {{-- TAB INFORMACIÓN GENERAL --}}
-                                <div class="tab-pane fade show active"
-                                    id="general{{ $waterConnectionDebt->id }}"
-                                    role="tabpanel">
-
+                                <div class="tab-pane fade show active" id="general{{ $waterConnectionDebt->id }}" role="tabpanel">
                                     <div class="row">
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>ID</label>
-                                                <input type="text" disabled class="form-control"
-                                                    value="{{ $waterConnectionDebt->id }}">
+                                                <input type="text" disabled class="form-control" value="{{ $waterConnectionDebt->id }}">
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Estado</label>
@@ -64,7 +48,6 @@
                                                 </p>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Monto de la Deuda</label>
@@ -74,12 +57,10 @@
                                                             <i class="fa fa-dollar-sign"></i>
                                                         </span>
                                                     </div>
-                                                    <input type="text" disabled class="form-control"
-                                                        value="{{ number_format($waterConnectionDebt->amount, 2) }}">
+                                                    <input type="text" disabled class="form-control" value="{{ number_format($waterConnectionDebt->amount, 2) }}">
                                                 </div>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Cantidad Pagada</label>
@@ -89,12 +70,10 @@
                                                             <i class="fa fa-dollar-sign"></i>
                                                         </span>
                                                     </div>
-                                                    <input type="text" disabled class="form-control"
-                                                        value="{{ number_format($waterConnectionDebt->debt_current, 2) }}">
+                                                    <input type="text" disabled class="form-control" value="{{ number_format($waterConnectionDebt->debt_current, 2) }}">
                                                 </div>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-12">
                                             <div class="form-group">
                                                 <label>Saldo pendiente</label>
@@ -104,40 +83,31 @@
                                                             <i class="fa fa-dollar-sign"></i>
                                                         </span>
                                                     </div>
-
                                                     @php
                                                         $remainingAmount = $waterConnectionDebt->amount - $waterConnectionDebt->debt_current;
                                                     @endphp
-
-                                                    <input type="text" disabled class="form-control"
-                                                        value="{{ number_format($remainingAmount, 2) }}">
+                                                    <input type="text" disabled class="form-control" value="{{ number_format($remainingAmount, 2) }}">
                                                 </div>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Inicio</label>
-                                                <input type="text" disabled class="form-control"
-                                                    value="{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                                <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
                                             </div>
                                         </div>
-
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Fin</label>
-                                                <input type="text" disabled class="form-control"
-                                                    value="{{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                                <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
                                             </div>
                                         </div>
-
                                         <div class="col-lg-12">
                                             <div class="form-group">
                                                 <label>Observación</label>
                                                 <textarea disabled class="form-control">{{ $waterConnectionDebt->note }}</textarea>
                                             </div>
                                         </div>
-
                                         <div class="col-lg-12">
                                             <div class="form-group">
                                                 <label>Registrada por</label>
@@ -146,14 +116,8 @@
                                             </div>
                                         </div>
                                     </div>
-
                                 </div>
-
-                                {{-- TAB HISTORIAL DE PAGOS --}}
-                                <div class="tab-pane fade"
-                                    id="payments{{ $waterConnectionDebt->id }}"
-                                    role="tabpanel">
-
+                                <div class="tab-pane fade" id="payments{{ $waterConnectionDebt->id }}" role="tabpanel">
                                     <div class="payment-history" style="max-height: 350px; overflow-y: auto;">
                                         <ul class="list-group">
                                             @forelse ($waterConnectionDebt->payments as $payment)
@@ -161,34 +125,28 @@
                                                     <strong>Monto:</strong>
                                                     ${{ number_format($payment->amount, 2) }}
                                                     <br>
-
                                                     @switch($payment->method)
                                                         @case('cash')
                                                             <strong>Método:</strong> Efectivo
                                                             <br>
                                                         @break
-
                                                         @case('card')
                                                             <strong>Método:</strong> Tarjeta
                                                             <br>
                                                         @break
-
                                                         @case('transfer')
                                                             <strong>Método:</strong> Transferencia
                                                             <br>
                                                         @break
-
                                                         @default
                                                             <strong>Método:</strong> Desconocido
                                                             <br>
                                                     @endswitch
-
                                                     @if ($payment->note)
                                                         <strong>Nota:</strong>
                                                         {{ $payment->note }}
                                                         <br>
                                                     @endif
-
                                                     <strong>Fecha:</strong>
                                                     {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
                                                 </li>
@@ -199,11 +157,8 @@
                                             @endforelse
                                         </ul>
                                     </div>
-
                                 </div>
-
                             </div>
-                            
                         </div>
                     </div>
                 </div>

--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -1,6 +1,3 @@
-@php
-    use Carbon\Carbon;
-@endphp
 <div class="modal fade" id="viewDebt{{ $waterConnectionDebt->id }}" tabindex="-1" role="dialog" aria-labelledby="viewModalLabel{{ $waterConnectionDebt->id }}" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -102,13 +99,13 @@
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Inicio</label>
-                                                <input type="text" disabled class="form-control" value="{{ Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                                <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->start_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
                                             </div>
                                         </div>
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Fin</label>
-                                                <input type="text" disabled class="form-control" value="{{ Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
+                                                <input type="text" disabled class="form-control" value="{{ \Carbon\Carbon::parse($waterConnectionDebt->end_date)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}">
                                             </div>
                                         </div>
                                         <div class="col-lg-12">
@@ -157,7 +154,7 @@
                                                         <br>
                                                     @endif
                                                     <strong>Fecha:</strong>
-                                                    {{Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
+                                                    {{ \Carbon\Carbon::parse($payment->created_at)->locale('es')->isoFormat('D [de] MMMM [del] YYYY') }}
                                                 </li>
                                             @empty
                                                 <li class="list-group-item">


### PR DESCRIPTION
## Summary

This pull request enhances the Debt Details modal by introducing a tab-based interface that improves content organization, readability, and overall user experience.

## Changes Implemented

### Interface Improvements
- Reorganized the debt details modal into multiple tabs.
- Added an **Información General** tab to display the primary debt information.
- Added a **Historial de Pagos** tab to display all payment records associated with the debt.

### Experience Enhancements
- Reduced the modal's vertical length by separating content into logical sections.
- Improved navigation by allowing users to switch directly between debt details and payment history.
- Enhanced readability and information accessibility within the modal.

### Maintainability
- Structured the modal content in a more modular and scalable way, facilitating future additions or modifications to debt-related information.

## Benefits

- Cleaner and more professional interface.
- Better organization of debt-related data.
- Improved usability across different screen sizes.
- Reduced visual clutter and scrolling.
- More intuitive access to payment history records.

## Testing

- Verified correct tab navigation.
- Confirmed debt information is displayed correctly in the General Information tab.
- Confirmed payment history records are displayed correctly in the Payment History tab.
- Validated modal functionality and close actions remain unchanged.