### PR TITLE
modified the design of the 'Change Owner' modal

### DIFF
--- a/resources/views/waterConnections/transfer.blade.php
+++ b/resources/views/waterConnections/transfer.blade.php
@@ -10,79 +10,86 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form method="POST" action="{{ route('waterConnections.transfer.store', $connection->id) }}" enctype="multipart/form-data">
+            <form method="POST" action="{{ route('waterConnections.transfer.store', $connection->id) }}"
+                enctype="multipart/form-data">
                 @csrf
                 <div class="modal-body">
                     @if(session('error'))
-                        <div class="alert alert-danger">{{ session('error') }}</div>
+                    <div class="alert alert-danger">{{ session('error') }}</div>
                     @endif
-                    <div class="card">                        
+                    <div class="card">
                         <div class="card-body">
-                    <div class="p-3 mb-3 rounded border border-success" style="background:#e9f7ef;">
-                        <h5 class="mb-2">Información de la toma</h5>
-                        <p class="mb-1"><strong>Toma:</strong> {{ $connection->name }}</p>
-                        <p class="mb-0"><strong>Dirección:</strong> {{ $connection->street }} {{ $connection->exterior_number }} {{ $connection->interior_number }}</p>
-                    </div>
-                    <div class="p-3 mb-3 rounded border border-success" style="background:#e9f7ef;">
-                        <h5 class="mb-2">Titular actual (Fallecido)</h5>
-                        <p class="mb-0"><strong>Titular actual (Fallecido):</strong> {{ $connection->customer_name }} {{ $connection->customer_last_name }}</p>
-                    </div>
-                    <div class="form-group">
-                        <label for="new_customer_id_{{ $connection->id }}">Nuevo titular *</label>
-                        <select name="new_customer_id" id="new_customer_id_{{ $connection->id }}" class="form-control select2" required>
-                            <option value="">Selecciona una opción</option>
-                            @foreach($customers as $customer)
-                                @if((int)$customer->id !== (int)$connection->customer_id)
+                            <div class="p-3 mb-3 rounded border border-success" style="background:#e9f7ef;">
+                                <h5 class="mb-2">Información de la toma</h5>
+                                <p class="mb-1"><strong>Toma:</strong> {{ $connection->name }}</p>
+                                <p class="mb-0"><strong>Dirección:</strong> {{ $connection->street }}
+                                    {{ $connection->exterior_number }} {{ $connection->interior_number }}</p>
+                            </div>
+                            <div class="p-3 mb-3 rounded border border-success" style="background:#e9f7ef;">
+                                <h5 class="mb-2">Titular actual (Fallecido)</h5>
+                                <p class="mb-0"><strong>Titular actual (Fallecido):</strong>
+                                    {{ $connection->customer_name }} {{ $connection->customer_last_name }}</p>
+                            </div>
+                            <div class="form-group">
+                                <label for="new_customer_id_{{ $connection->id }}">Nuevo titular *</label>
+                                <select name="new_customer_id" id="new_customer_id_{{ $connection->id }}"
+                                    class="form-control select2" required>
+                                    <option value="">Selecciona una opción</option>
+                                    @foreach($customers as $customer)
+                                    @if((int)$customer->id !== (int)$connection->customer_id)
                                     <option value="{{ $customer->id }}">
                                         {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}
                                     </option>
-                                @endif
-                            @endforeach
-                        </select>
-                        <small class="text-muted">Solo se muestran clientes activos (con vida).</small>
-                        @error('new_customer_id')
-                            <small class="text-danger">{{ $message }}</small>
-                        @enderror
-                    </div>
-                    <div class="form-group mt-3">
-                        <label for="note_{{ $connection->id }}">Nota (opcional)</label>
-                        <textarea name="note" id="note_{{ $connection->id }}" class="form-control" rows="3">{{ old('note') }}</textarea>
-                        @error('note')
-                            <small class="text-danger">{{ $message }}</small>
-                        @enderror
-                    </div>
-                    <hr>
-                    <h5 class="mb-2">Documentos de verificación (obligatorios)</h5>
-                    <small class="text-muted d-block mb-3">
-                        La transferencia NO se completará si falta cualquiera de los documentos requeridos.
-                    </small>
-                    @php
-                        $docTypes = \App\Models\LogWaterConnectionTransfer::REQUIRED_DOCUMENT_TYPES;
-                        $docLabels = \App\Models\LogWaterConnectionTransfer::documentTypeLabels();
-                        $lastIndex = count($docTypes) - 1;
-                    @endphp
-                    <div class="row">
-                        @foreach ($docTypes as $index => $type)
-                            <div class="{{ $index === $lastIndex ? 'col-12' : 'col-12 col-md-6' }} mb-3">
-                                @php
+                                    @endif
+                                    @endforeach
+                                </select>
+                                <small class="text-muted">Solo se muestran clientes activos (con vida).</small>
+                                @error('new_customer_id')
+                                <small class="text-danger">{{ $message }}</small>
+                                @enderror
+                            </div>
+                            <div class="form-group mt-3">
+                                <label for="note_{{ $connection->id }}">Nota (opcional)</label>
+                                <textarea name="note" id="note_{{ $connection->id }}" class="form-control"
+                                    rows="3">{{ old('note') }}</textarea>
+                                @error('note')
+                                <small class="text-danger">{{ $message }}</small>
+                                @enderror
+                            </div>
+                            <hr>
+                            <h5 class="mb-2">Documentos de verificación (obligatorios)</h5>
+                            <small class="text-muted d-block mb-3">
+                                La transferencia NO se completará si falta cualquiera de los documentos requeridos.
+                            </small>
+                            @php
+                            $docTypes = \App\Models\LogWaterConnectionTransfer::REQUIRED_DOCUMENT_TYPES;
+                            $docLabels = \App\Models\LogWaterConnectionTransfer::documentTypeLabels();
+                            $lastIndex = count($docTypes) - 1;
+                            @endphp
+                            <div class="row">
+                                @foreach ($docTypes as $index => $type)
+                                <div class="{{ $index === $lastIndex ? 'col-12' : 'col-12 col-md-6' }} mb-3">
+                                    @php
                                     $label = $docLabels[$type] ?? $type;
                                     preg_match('/^(.*?)(\s*\((.*)\))?$/u', $label, $m);
                                     $main = trim($m[1] ?? $label);
                                     $extra = isset($m[3]) ? trim($m[3]) : null;
-                                @endphp
-                                <label class="form-label mb-1">{{ $main }} <span class="text-danger">*</span></label>
-                                @if($extra)
+                                    @endphp
+                                    <label class="form-label mb-1">{{ $main }} <span
+                                            class="text-danger">*</span></label>
+                                    @if($extra)
                                     <small class="text-muted d-block mb-2">{{ $extra }}</small>
-                                @else
+                                    @else
                                     <div style="height: 18px;" class="mb-2"></div>
-                                @endif
-                                <input type="file" name="documents[{{ $type }}]" class="form-control @error("documents.$type") is-invalid @enderror" required accept=".pdf,.jpg,.jpeg,.png">
-                                @error("documents.$type")
+                                    @endif
+                                    <input type="file" name="documents[{{ $type }}]" class="form-control @error("
+                                        documents.$type") is-invalid @enderror" required accept=".pdf,.jpg,.jpeg,.png">
+                                    @error("documents.$type")
                                     <small class="text-danger">{{ $message }}</small>
-                                @enderror
+                                    @enderror
+                                </div>
+                                @endforeach
                             </div>
-                        @endforeach
-                    </div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/waterConnections/transfer.blade.php
+++ b/resources/views/waterConnections/transfer.blade.php
@@ -2,10 +2,10 @@
     <div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
         <div class="modal-content">
             <div class="modal-header bg-success text-white">
-                <h4 class="modal-title">
+                <h5 class="modal-title">
                     Cambio de Propietario (Fallecimiento)
                     <small>&nbsp;(*) Campos requeridos</small>
-                </h4>
+                </h5>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -16,6 +16,8 @@
                     @if(session('error'))
                         <div class="alert alert-danger">{{ session('error') }}</div>
                     @endif
+                    <div class="card">                        
+                        <div class="card-body">
                     <div class="p-3 mb-3 rounded border border-success" style="background:#e9f7ef;">
                         <h5 class="mb-2">Información de la toma</h5>
                         <p class="mb-1"><strong>Toma:</strong> {{ $connection->name }}</p>
@@ -80,6 +82,8 @@
                                 @enderror
                             </div>
                         @endforeach
+                    </div>
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/resources/views/waterConnections/transfer.blade.php
+++ b/resources/views/waterConnections/transfer.blade.php
@@ -15,7 +15,7 @@
                 @csrf
                 <div class="modal-body">
                     @if(session('error'))
-                    <div class="alert alert-danger">{{ session('error') }}</div>
+                        <div class="alert alert-danger">{{ session('error') }}</div>
                     @endif
                     <div class="card">
                         <div class="card-body">
@@ -36,16 +36,16 @@
                                     class="form-control select2" required>
                                     <option value="">Selecciona una opción</option>
                                     @foreach($customers as $customer)
-                                    @if((int)$customer->id !== (int)$connection->customer_id)
-                                    <option value="{{ $customer->id }}">
-                                        {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}
-                                    </option>
-                                    @endif
+                                        @if((int)$customer->id !== (int)$connection->customer_id)
+                                            <option value="{{ $customer->id }}">
+                                                {{ $customer->id }} - {{ $customer->name }} {{ $customer->last_name }}
+                                            </option>
+                                        @endif
                                     @endforeach
                                 </select>
                                 <small class="text-muted">Solo se muestran clientes activos (con vida).</small>
                                 @error('new_customer_id')
-                                <small class="text-danger">{{ $message }}</small>
+                                    <small class="text-danger">{{ $message }}</small>
                                 @enderror
                             </div>
                             <div class="form-group mt-3">
@@ -53,7 +53,7 @@
                                 <textarea name="note" id="note_{{ $connection->id }}" class="form-control"
                                     rows="3">{{ old('note') }}</textarea>
                                 @error('note')
-                                <small class="text-danger">{{ $message }}</small>
+                                    <small class="text-danger">{{ $message }}</small>
                                 @enderror
                             </div>
                             <hr>
@@ -62,32 +62,32 @@
                                 La transferencia NO se completará si falta cualquiera de los documentos requeridos.
                             </small>
                             @php
-                            $docTypes = \App\Models\LogWaterConnectionTransfer::REQUIRED_DOCUMENT_TYPES;
-                            $docLabels = \App\Models\LogWaterConnectionTransfer::documentTypeLabels();
-                            $lastIndex = count($docTypes) - 1;
+                                $docTypes = \App\Models\LogWaterConnectionTransfer::REQUIRED_DOCUMENT_TYPES;
+                                $docLabels = \App\Models\LogWaterConnectionTransfer::documentTypeLabels();
+                                $lastIndex = count($docTypes) - 1;
                             @endphp
                             <div class="row">
                                 @foreach ($docTypes as $index => $type)
-                                <div class="{{ $index === $lastIndex ? 'col-12' : 'col-12 col-md-6' }} mb-3">
-                                    @php
-                                    $label = $docLabels[$type] ?? $type;
-                                    preg_match('/^(.*?)(\s*\((.*)\))?$/u', $label, $m);
-                                    $main = trim($m[1] ?? $label);
-                                    $extra = isset($m[3]) ? trim($m[3]) : null;
-                                    @endphp
-                                    <label class="form-label mb-1">{{ $main }} <span
-                                            class="text-danger">*</span></label>
-                                    @if($extra)
-                                    <small class="text-muted d-block mb-2">{{ $extra }}</small>
-                                    @else
-                                    <div style="height: 18px;" class="mb-2"></div>
-                                    @endif
-                                    <input type="file" name="documents[{{ $type }}]" class="form-control @error("
-                                        documents.$type") is-invalid @enderror" required accept=".pdf,.jpg,.jpeg,.png">
-                                    @error("documents.$type")
-                                    <small class="text-danger">{{ $message }}</small>
-                                    @enderror
-                                </div>
+                                    <div class="{{ $index === $lastIndex ? 'col-12' : 'col-12 col-md-6' }} mb-3">
+                                        @php
+                                            $label = $docLabels[$type] ?? $type;
+                                            preg_match('/^(.*?)(\s*\((.*)\))?$/u', $label, $m);
+                                            $main = trim($m[1] ?? $label);
+                                            $extra = isset($m[3]) ? trim($m[3]) : null;
+                                        @endphp
+                                        <label class="form-label mb-1">{{ $main }} <span
+                                                class="text-danger">*</span></label>
+                                        @if($extra)
+                                            <small class="text-muted d-block mb-2">{{ $extra }}</small>
+                                        @else
+                                            <div style="height: 18px;" class="mb-2"></div>
+                                        @endif
+                                        <input type="file" name="documents[{{ $type }}]" class="form-control @error("
+                                            documents.$type") is-invalid @enderror" required accept=".pdf,.jpg,.jpeg,.png">
+                                        @error("documents.$type")
+                                            <small class="text-danger">{{ $message }}</small>
+                                        @enderror
+                                    </div>
                                 @endforeach
                             </div>
                         </div>


### PR DESCRIPTION
🔄 The recent modifications to `transfer.blade.php` represent a structural and stylistic enhancement of the modal **"Change Owner (Deceased)"**.

- 🏷️ **Title Adjustment** → The modal heading was updated from `<h4>` to `<h5>`. This subtle change improves the semantic hierarchy of the page, ensuring that the modal title is visually consistent with other sections and better aligned with accessibility standards.

- 🗂️ **Card Integration** → A new `<div class="card">` wrapper and its corresponding `<div class="card-body">` were introduced. This encapsulation provides a cleaner, more professional layout, mirroring the design style used in the **"Enter water connection data"** section. By reusing this familiar card-based structure, the modal gains visual coherence with the rest of the application.