### PR TITLE
Hide graph PDF report button when no advance payment data exists

### DIFF
--- a/app/Http/Controllers/AdvancePaymentController.php
+++ b/app/Http/Controllers/AdvancePaymentController.php
@@ -18,12 +18,14 @@ class AdvancePaymentController extends Controller
     public function index(Request $request)
     {
         $chartData = $this->getChartData();
+        $hasChartData = collect($chartData['totals'])->sum() > 0;
 
         return view('advancePayments.index', [
             'payments' => $this->getAdvancePayments($request),
             'customers' => Customer::where('locality_id', auth()->user()->locality_id)->get(),
             'months' => $chartData['months'],
             'totals' => $chartData['totals'],
+            'hasChartData' => $hasChartData,
         ]);
     }
 

--- a/database/seeders/EmployeesTableSeeder.php
+++ b/database/seeders/EmployeesTableSeeder.php
@@ -42,7 +42,7 @@ class EmployeesTableSeeder extends Seeder
                 'name' => $faker->firstName,
                 'last_name' => $faker->lastName,
                 'email' => $faker->unique()->safeEmail,
-                'phone_number' => $faker->phoneNumber,
+                'phone_number' => $faker->numerify('##########'),
                 'salary' => $faker->numberBetween(10000, 50000),
                 'rol' => $faker->randomElement($roles),
                 'locality' => $faker->city,

--- a/resources/views/advancePayments/index.blade.php
+++ b/resources/views/advancePayments/index.blade.php
@@ -12,11 +12,13 @@
     <div class="row mb-3">
         <div class="col-lg-12">
             <div class="d-flex flex-wrap justify-content-end mb-2">
-                <button class="btn btn-primary mt-2 mx-1 mb-2" id="btnGenerateReportGraph" title="Generar PDF de Gráficos">
-                    <i class="fa fa-chart-pie"></i>
-                    <span class="d-none d-md-inline">Generar PDF de Gráficos</span>
-                    <span class="d-inline d-md-none">Gráficos</span>
-                </button>
+                @if($hasChartData)
+                    <button class="btn btn-primary mt-2 mx-1 mb-2" id="btnGenerateReportGraph" title="Generar PDF de Gráficos">
+                        <i class="fa fa-chart-pie"></i>
+                        <span class="d-none d-md-inline">Generar PDF de Gráficos</span>
+                        <span class="d-inline d-md-none">Gráficos</span>
+                    </button>
+                @endif
                 <button class="btn btn-success mt-2 mx-1 mb-2" data-toggle="modal"
                         data-target="#paymentHistoryModal" title="Historial de pagos">
                     <i class="fa fa-calendar"></i>


### PR DESCRIPTION
# Employee Phone Number Fix and Graph Report Button Visibility

## Summary

This PR introduces improvements to the **Employees** and **Advance Payments** modules to ensure data consistency and improve the user experience.

---

## Changes Made

### 1. Employee Phone Number Seeder Fix

* Replaced `Faker::phoneNumber()` with a controlled numeric generation method.
* Phone numbers are now generated using digits only, preventing special characters such as:

  * Hyphens (`-`)
  * Parentheses (`()`)
  * Spaces

#### Benefit

Prevents inconsistencies when editing employee records and ensures compatibility with validations that expect numeric values only.

---

### 2. Graph Report Button Visibility

* Added a validation to determine whether advance payment data exists for the current locality.
* The **"Generate Graph PDF Report"** button is displayed only when data is available for chart generation.

#### Benefit

* Prevents users from generating empty reports.
* Improves the user experience by displaying only available actions.
* Reduces unnecessary requests and potential errors.

---

## Expected Result

### Before

* Employee phone numbers could be generated with formats incompatible with edit forms.
* The graph PDF report button was displayed even when no advance payment data existed.

### After

* Employee phone numbers are stored in a consistent numeric format.
* The graph PDF report button is displayed only when advance payment records are available for the selected locality.

---

## Type of Change

* [x] Bug Fix
* [x] Enhancement
* [ ] New Feature
* [ ] Breaking Change

---

## Testing

* Verified that employee records can be edited correctly using phone numbers generated by the seeder.
* Confirmed that the graph PDF report button is hidden when no advance payment data exists and automatically appears when data becomes available.
