### PR TITLE
Update receipt to show electronic payment message and hide 'Set up pa…

### DIFF
--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -140,7 +140,7 @@
                                         <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#editPassword">
                                             Cambiar contraseña
                                         </button>
-                                        @if($authUser->hasRole(['Supervisor', 'Secretaria', 'Admin']))
+                                        @if($authUser->hasRole(['Supervisor', 'Secretaria']))
                                         <button type="button" class="btn btn-info" data-toggle="modal" data-target="#editPaymentConfig">
                                             <i class="fas fa-credit-card mr-1"></i>Configurar Pagos
                                         </button>

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -239,8 +239,13 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
             </div>
         </div>
         <div class="signature">
-            _________________________________
-            <p>{{ $payment->creator->name }} {{ $payment->creator->last_name }}</p>
+            @if ($payment->isOpenPayPayment())
+                <p>Este comprobante corresponde a un pago electrónico autorizado por la plataforma de pagos.</p>
+            @endif
+            @if (!$payment->isOpenPayPayment())
+                _________________________________
+                <p>{{ $payment->creator->name }} {{ $payment->creator->last_name }}</p>
+            @endif
         </div>
         <div class="footer_last_page">
             <div class="info_bottom">


### PR DESCRIPTION
**Payment Receipt Update**  
   - Modified the signature section in `receiptPayment.blade.php`.  
   - When the payment is processed through OpenPay, the receipt now displays the message:  
     *"Este comprobante corresponde a un pago electrónico autorizado por la plataforma de pagos."*  
   - If the payment is not processed through OpenPay, the creator’s name and last name are shown instead.

**Role-Based Button Visibility**  
   - Updated `index.blade.php` to remove the **Admin** role from the condition that allowed access to the "Configurar Pago" button.  
   - Now, only **Supervisor** and **Secretaria** roles can see and use this button.