### PR TITLE
Show all existing roles when creating a new user except the Client role

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -16,7 +16,7 @@ class UserController extends Controller
     {
         $currentUserId = auth()->id();
 
-        $roles = Role::whereIn('name', ['Supervisor', 'Secretaria'])->get();
+        $roles = Role::where('name', '!=', User::ROLE_CUSTOMER)->get();
 
         $localities = Locality::all();
 
@@ -123,7 +123,7 @@ class UserController extends Controller
         $userId = Crypt::decrypt($encryptedUserId);
         $user = User::findOrFail($userId);
 
-        $roles = Role::whereIn('name', ['Supervisor', 'Secretaria'])->get();
+        $roles = Role::where('name', '!=', User::ROLE_CUSTOMER)->get();
 
         return view('users.assignRole', compact('user', 'roles'));
     }


### PR DESCRIPTION
 **Role Filtering Update in UserController**  
   - Modified the logic in `UserController.php` to retrieve all roles except the **Client** role.  
   - Replaced the previous condition that explicitly listed roles (`Supervisor`, `Secretaria`) with a more flexible query that excludes `User::ROLE_CUSTOMER`.  
   - This ensures that when an Admin creates or edits a user, all roles are available for assignment except the Client role.

**Consistency Across Methods**  
   - Applied the same role filtering logic in both the `index()` and `edit()` methods of the controller.  
   - This guarantees consistent behavior across user management flows.