### PR TITLE
 Standardize green modals with 'Close' and 'Save' buttons and unify m…

### DIFF
--- a/resources/views/debtCategories/create.blade.php
+++ b/resources/views/debtCategories/create.blade.php
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Categoría de Deuda (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Categoría de Deuda <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close"
                     style="opacity:1;">
                     <span aria-hidden="true">&times;</span>

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -30,10 +30,10 @@
                                         <span class="d-inline d-lg-none">Asignar a Todos</span>
                                     </button>
                                     <button type="button" class="btn btn-success mx-1" data-toggle="modal"
-                                            title="Crear Deuda" data-target="#createDebt">
+                                            title="Registrar Deuda" data-target="#createDebt">
                                         <i class="fa fa-plus"></i>
-                                        <span class="d-none d-lg-inline">Crear Deuda</span>
-                                        <span class="d-inline d-lg-none">Crear Deuda</span>
+                                        <span class="d-none d-lg-inline">Registrar Deuda</span>
+                                        <span class="d-inline d-lg-none">Registrar Deuda</span>
                                     </button>
                                     <a type="button" class="btn btn-secondary mx-1" target="_blank"
                                     title="Clientes con deudas" href="{{ route('report.with-debts') }}">

--- a/resources/views/earningTypes/create.blade.php
+++ b/resources/views/earningTypes/create.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Tipo de Ingreso (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Tipo de Ingreso <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/employeePositions/create.blade.php
+++ b/resources/views/employeePositions/create.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Posición de Empleado (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Posición de Empleado <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/expenseTypes/create.blade.php
+++ b/resources/views/expenseTypes/create.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Tipo de Gasto (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Tipo de Gasto <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/incidentCategories/create.blade.php
+++ b/resources/views/incidentCategories/create.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Categoría de Incidencia (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Categoría de Incidencia <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/incidentStatuses/create.blade.php
+++ b/resources/views/incidentStatuses/create.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Estatus de Incidencia (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Estatus de Incidencia <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/inventoryCategories/create.blade.php
+++ b/resources/views/inventoryCategories/create.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-success">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Agregar Categoría de Inventario (*) Campos requeridos</h5>
+                <h4 class="card-title">Agregar Categoría de Inventario <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/localityNotices/create.blade.php
+++ b/resources/views/localityNotices/create.blade.php
@@ -59,8 +59,8 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
-                        <button type="submit" class="btn btn-success" id="createBtn">Guardar Aviso</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                        <button type="submit" class="btn btn-success" id="createBtn">Guardar</button>
                     </div>
                 </form>
             </div>

--- a/resources/views/sections/create.blade.php
+++ b/resources/views/sections/create.blade.php
@@ -49,7 +49,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
                     <button type="submit" class="btn btn-success">Guardar</button>
                 </div>
             </form>


### PR DESCRIPTION
 Updated modal titles to ensure consistent size and style across the system.  

- Standardized button labels so that creation/registration modals only display **"Cerrar"** and **"Guardar"**, replacing any previous variations like "Cancelar".  
- Adjusted wording in certain actions to use clearer and more user-friendly terms (e.g., changing "Create" to "Register").  
- Overall, these changes improve design consistency, readability, and user experience in the system’s modals.