### PR TITLE
The title size was changed and the 'close' buttons are now 'cancel'

### DIFF
--- a/resources/views/debtCategories/edit.blade.php
+++ b/resources/views/debtCategories/edit.blade.php
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Categoría (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Categoría<small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close"
                     style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
@@ -91,7 +91,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>

--- a/resources/views/earningTypes/edit.blade.php
+++ b/resources/views/earningTypes/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Tipo de Ingreso (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Tipo de Ingreso<small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -60,7 +60,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>

--- a/resources/views/employeePositions/edit.blade.php
+++ b/resources/views/employeePositions/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Posición de Empleado (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Posición de Empleado<small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -60,7 +60,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>

--- a/resources/views/expenseTypes/edit.blade.php
+++ b/resources/views/expenseTypes/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Tipo de Gasto (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Tipo de Gasto <small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -60,7 +60,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>

--- a/resources/views/incidentCategories/edit.blade.php
+++ b/resources/views/incidentCategories/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Categoría (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Categoría<small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -60,7 +60,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>

--- a/resources/views/incidentStatuses/edit.blade.php
+++ b/resources/views/incidentStatuses/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Estatus (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Estatus<small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -59,7 +59,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>

--- a/resources/views/inventoryCategories/edit.blade.php
+++ b/resources/views/inventoryCategories/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content card-warning">
             <div class="modal-header bg-warning text-white">
-                <h5 class="modal-title">Actualizar Categoría de Inventario (*) Campos requeridos</h5>
+                <h4 class="card-title">Actualizar Categoría de Inventario<small>&nbsp;(*) Campos requeridos</small></h4>
                 <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close" style="opacity:1;">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -61,7 +61,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-warning">Actualizar</button>
                 </div>
             </form>


### PR DESCRIPTION
- The **Edit modal** was updated to align with the design standards applied previously to the creation modals.  
- The title element was changed from `<h5>` to `<h4>`, ensuring that all modal headers now share the same size and visual hierarchy across the system. This adjustment improves readability and provides a consistent look and feel for users navigating different modals.  
- Button labels were standardized: those that previously displayed **"Close"** have now been replaced with **"Cancel"**, while the **"Save"** button remains as the primary action. This change clarifies the intent of each button, making the interface more intuitive and reducing possible confusion for users.  
- Overall, these modifications enhance design uniformity, strengthen usability, and ensure that both creation and editing workflows deliver a seamless and predictable experience.