### PR TITLE
Fix preview and dynamic color for discounts

### DIFF
--- a/resources/views/discounts/create.blade.php
+++ b/resources/views/discounts/create.blade.php
@@ -41,7 +41,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-lg-6">
+                                    <div class="col-lg-12">
                                         <div class="form-group">
                                             <label for="color">Color(*)</label>
                                             <div class="d-flex align-items-center" style="gap: 0;">

--- a/resources/views/discounts/create.blade.php
+++ b/resources/views/discounts/create.blade.php
@@ -24,7 +24,7 @@
                             </div>
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-lg-6">
+                                    <div class="col-lg-12">
                                         <div class="form-group">
                                             <label for="name" class="form-label">Nombre(*)</label>
                                             <input type="text" class="form-control" name="name" placeholder="Ingrese el nombre del descuento" value="{{ old('name') }}" required>
@@ -41,7 +41,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-lg-12">
+                                    <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="color">Color(*)</label>
                                             <div class="d-flex align-items-center" style="gap: 0;">

--- a/resources/views/discounts/edit.blade.php
+++ b/resources/views/discounts/edit.blade.php
@@ -45,7 +45,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-lg-6">
+                                    <div class="col-lg-12">
                                         <div class="form-group">
                                             <label>Color (*)</label>
                                             <div class="d-flex align-items-center">

--- a/resources/views/discounts/edit.blade.php
+++ b/resources/views/discounts/edit.blade.php
@@ -28,7 +28,7 @@
                             </div>
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-lg-6">
+                                    <div class="col-lg-12">
                                         <div class="form-group">
                                             <label>Nombre (*)</label>
                                             <input type="text" class="form-control" name="name" placeholder="Ingrese el nombre del descuento" value="{{ old('name',$discount->name) }}" required>
@@ -45,7 +45,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-lg-12">
+                                    <div class="col-lg-6">
                                         <div class="form-group">
                                             <label>Color (*)</label>
                                             <div class="d-flex align-items-center">

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -49,20 +49,16 @@
                                     <thead>
                                         <tr>
                                             <th>ID</th>
-                                            <th>LOCALIDAD</th>
                                             <th>DESCUENTO</th>
                                             <th>DESCRIPCIÓN</th>
                                             <th>PORCENTAJE</th>
-                                            <th>CREADO POR</th>
                                             <th class="not-export">OPCIONES</th>
                                         </tr>
                                     </thead>
-
                                     <tbody>
                                         @forelse($discounts as $discount)
                                             <tr>
                                                 <td>{{ $discount->id }}</td>
-                                                <td>{{ optional($discount->locality)->name ?? 'Sin localidad' }}</td>
                                                 <td>
                                                     <span class="badge text-white" style="background-color: {{ $discount->color ?? '#6c757d' }};">
                                                         {{ $discount->name }}
@@ -70,7 +66,6 @@
                                                 </td>
                                                 <td>{{ $discount->description ?? 'Sin descripción' }}</td>
                                                 <td>{{ number_format($discount->percentage,2) }}%</td>
-                                                <td>{{ optional($discount->creator)->name ?? 'N/D' }}</td>
                                                 <td>
                                                     <div class="btn-group" role="group" aria-label="Opciones">
                                                         <button type="button" class="btn btn-info mr-2" data-toggle="modal" data-target="#viewDiscount{{ $discount->id }}" title="Ver Detalles">
@@ -128,34 +123,78 @@
         opacity:1!important;
         box-shadow:0 2px 5px rgba(0,0,0,.25);
     }
-
     .color-badge:hover{
         transform:translateY(-2px);
         box-shadow:0 4px 8px rgba(0,0,0,.25);
     }
-
     @media(max-width:767px){
         .table-responsive{
             overflow-x:auto;
             -webkit-overflow-scrolling:touch;
         }
-
         table.dataTable th,
         table.dataTable td{
             white-space:nowrap;
         }
-
         td .btn-group{
             display:flex;
             flex-wrap:wrap;
             gap:3px;
         }
     }
+    .card-box.table-responsive {
+        width: 100%;
+        margin: 0 auto;
+        padding-right: 0;
+    }
+    table#discounts {
+        width: 100% !important;
+        table-layout: auto;
+        white-space: normal;
+    }
+    table#discounts th,
+    table#discounts td {
+        text-align: center;
+        vertical-align: middle;
+    }
+    .dataTables_wrapper {
+        overflow-x: hidden !important;
+    }
 </style>
 @endsection
 
 @section('js')
 <script>
+     $(document).ready(function(){Expand commentComment on line L159Resolved
+
+        $('#discounts').DataTable({
+            responsive:true,
+            buttons:[
+                {
+                    extend:'csv',
+                    charset:'utf-8',
+                    bom:true,
+                    exportOptions:{
+                        columns:':not(.not-export)'
+                    }
+                },
+                {
+                    extend:'excel',
+                    exportOptions:{
+                        columns:':not(.not-export)'
+                    }
+                },
+                {
+                    extend:'print',
+                    exportOptions:{
+                        columns:':not(.not-export)'
+                    }
+                }
+            ],
+            dom:'Bfrtip',
+            paging:false,
+            info:false,
+            searching:false
     document.addEventListener('DOMContentLoaded', function () {
         const colorSelect = document.getElementById('color');
         const previewBox = document.createElement('div');
@@ -175,6 +214,26 @@
             const selectedColor = colorSelect.value;
             previewBox.style.backgroundColor = selectedColor;
         });
+
+        let successMessage="{{ session('success') }}";
+        let errorMessage="{{ session('error') }}";
+
+        if(successMessage){Expand commentComment on line L194Resolved
+            Swal.fire({
+                icon:'success',
+                title:'Éxito',
+                text:successMessage,
+                confirmButtonText:'Aceptar'
+            });
+        }
+        if(errorMessage){
+            Swal.fire({
+                icon:'error',
+                title:'Error',
+                text:errorMessage,
+                confirmButtonText:'Aceptar'
+            });
+        }
 
         const form = document.querySelector('#createDiscount form');
         form.addEventListener('submit', function (e) {

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -165,7 +165,8 @@
 
 @section('js')
 <script>
-     $(document).ready(function(){Expand commentComment on line L159Resolved
+    $(document).ready(function(){
+        $(document).ready(function(){
 
         $('#discounts').DataTable({
             responsive:true,
@@ -195,6 +196,9 @@
             paging:false,
             info:false,
             searching:false
+            });
+        });
+    });
     document.addEventListener('DOMContentLoaded', function () {
         const colorSelect = document.getElementById('color');
         const previewBox = document.createElement('div');

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -222,7 +222,7 @@
         let successMessage="{{ session('success') }}";
         let errorMessage="{{ session('error') }}";
 
-        if(successMessage){Expand commentComment on line L194Resolved
+        if(successMessage){
             Swal.fire({
                 icon:'success',
                 title:'Éxito',

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -64,7 +64,7 @@
                                                 <td>{{ $discount->id }}</td>
                                                 <td>{{ optional($discount->locality)->name ?? 'Sin localidad' }}</td>
                                                 <td>
-                                                    <span class="badge text-white color-badge" style="background:{{ $discount->color }};color:#fff !important;">
+                                                    <span class="badge text-white" style="background-color: {{ $discount->color ?? '#6c757d' }};">
                                                         {{ $discount->name }}
                                                     </span>
                                                 </td>
@@ -156,59 +156,39 @@
 
 @section('js')
 <script>
-    $(document).ready(function(){
+    document.addEventListener('DOMContentLoaded', function () {
+        const colorSelect = document.getElementById('color');
+        const previewBox = document.createElement('div');
 
-        $('#discounts').DataTable({
-            responsive:true,
-            buttons:[
-                {
-                    extend:'csv',
-                    charset:'utf-8',
-                    bom:true,
-                    exportOptions:{
-                        columns:':not(.not-export)'
-                    }
-                },
-                {
-                    extend:'excel',
-                    exportOptions:{
-                        columns:':not(.not-export)'
-                    }
-                },
-                {
-                    extend:'print',
-                    exportOptions:{
-                        columns:':not(.not-export)'
-                    }
-                }
-            ],
-            dom:'Bfrtip',
-            paging:false,
-            info:false,
-            searching:false
+        previewBox.style.width = '40px';
+        previewBox.style.height = '40px';
+        previewBox.style.borderRadius = '5px';
+        previewBox.style.border = '1px solid #ccc';
+        previewBox.style.marginLeft = '10px';
+        previewBox.style.display = 'inline-block';
+        previewBox.style.verticalAlign = 'middle';
+        previewBox.style.backgroundColor = '#6c757d';
+
+        colorSelect.parentNode.appendChild(previewBox);
+
+        colorSelect.addEventListener('change', function () {
+            const selectedColor = colorSelect.value;
+            previewBox.style.backgroundColor = selectedColor;
         });
 
-        let successMessage="{{ session('success') }}";
-        let errorMessage="{{ session('error') }}";
-
-        if(successMessage){
-            Swal.fire({
-                icon:'success',
-                title:'Éxito',
-                text:successMessage,
-                confirmButtonText:'Aceptar'
-            });
-        }
-
-        if(errorMessage){
-            Swal.fire({
-                icon:'error',
-                title:'Error',
-                text:errorMessage,
-                confirmButtonText:'Aceptar'
-            });
-        }
-
+        const form = document.querySelector('#createDiscount form');
+        form.addEventListener('submit', function (e) {
+            const selectedColor = colorSelect.value;
+            if (!selectedColor) {
+                e.preventDefault();
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Error',
+                    text: 'Por favor selecciona un color para el descuento.',
+                    confirmButtonText: 'Aceptar'
+                });
+            }
+        });
     });
 </script>
 @endsection


### PR DESCRIPTION
# Fix: Dynamic Color Preview and Display for Discounts

## Description
This PR introduces improvements to the Discounts module, focusing on color handling and UI consistency:

- Added a color preview in the `create` modal, ensuring users can visualize the selected color before saving.
- Corrected the default option to display “Select a color” with a neutral gray preview until a choice is made.
- Updated the index view to render the discount name with the exact color chosen in the modal (using hex values instead of Bootstrap classes).
- Cleaned up redundant script references and ensured proper initialization of Select2 within the modal.
- Improved validation with SweetAlert to prevent saving without a color selection.

## Visual Impact
- Discounts now display their name with the chosen color badge in the index table.
- The modal provides a clear and intuitive color selection experience.
- UI consistency matches the style of other modules (e.g., Expenses).

## Testing
- Verified that the modal opens with “Select a color” as the default option.
- Confirmed that the preview updates dynamically when a color is selected.
- Ensured that discounts saved with a color render correctly in the index table.
- Checked responsiveness and Select2 integration inside the modal.

## Next Steps
- Merge into `main` after review.
- Deploy to staging for user acceptance testing.
- Consider extending color options or mapping to Bootstrap utility classes for broader customization.
