### PR TITLE
fix(discounts): use registered discounts.pdf route for PDF generation

### DIFF
--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -28,7 +28,7 @@
                                         <i class="fa fa-plus"></i> Registrar Descuento
                                     </button>
                                     @endcan
-                                    <a class="btn btn-secondary" target="_blank" title="Generar Lista" href="{{ route('discounts.pdfDiscounts', ['search' => request('search')]) }}">
+                                    <a class="btn btn-secondary" target="_blank" title="Generar Lista" href="{{ route('discounts.pdf', ['search' => request('search')]) }}">
                                         <i class="fas fa-file-pdf"></i> Generar Lista
                                     </a>
                                 </div>
@@ -38,7 +38,7 @@
                                         <i class="fa fa-plus"></i> Registrar
                                     </button>
                                     @endcan
-                                    <a class="btn btn-secondary btn-block mb-2" target="_blank" title="Generar Lista" href="{{ route('discounts.pdfDiscounts', ['search' => request('search')]) }}">
+                                    <a class="btn btn-secondary btn-block mb-2" target="_blank" title="Generar Lista" href="{{ route('discounts.pdf', ['search' => request('search')]) }}">
                                         <i class="fas fa-file-pdf"></i> Generar Lista
                                     </a>
                                 </div>


### PR DESCRIPTION
## Description

The route name used to generate the discounts PDF was corrected to match the route registered in the application.

## Changes made

- Updated the route reference in the discounts view.
- Replaced `discounts.pdfDiscounts` with `discounts.pdf`.
- Fixed access to PDF generation from the discounts module.

## Issue resolved

- Resolved the `Route [discounts.pdfDiscounts] not defined` exception.
- The PDF generation button now correctly redirects to the registered route.

## Evidence

- ✅ The discounts module loads without errors.
- ✅ The discounts PDF generates correctly from the index view.