### PR TITLE
fix(discounts): prevent editing discount percentage and block deletio…

### DIFF
--- a/app/Http/Controllers/DiscountController.php
+++ b/app/Http/Controllers/DiscountController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Discount;
 use App\Models\MovementHistory;
+use App\Models\Payment;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
@@ -117,6 +118,13 @@ class DiscountController extends Controller
     public function destroy(Discount $discount)
     {
         $this->authorizeDiscount($discount);
+
+        $hasPayments = Payment::where('discount_id', $discount->id)->exists();
+
+        if ($hasPayments) {
+            return redirect()->route('discounts.index')
+                ->with('error', 'No es posible eliminar el descuento porque tiene pagos asociados.');
+        }
 
         $before = $discount->toArray();
 

--- a/app/Http/Controllers/DiscountController.php
+++ b/app/Http/Controllers/DiscountController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Discount;
 use App\Models\MovementHistory;
 use App\Models\Payment;
+use App\Models\Debt;    
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
@@ -120,10 +121,13 @@ class DiscountController extends Controller
         $this->authorizeDiscount($discount);
 
         $hasPayments = Payment::where('discount_id', $discount->id)->exists();
+        $hasDebts = Debt::where('discount_id', $discount->id)->exists();
 
-        if ($hasPayments) {
-            return redirect()->route('discounts.index')
-                ->with('error', 'No es posible eliminar el descuento porque tiene pagos asociados.');
+        if ($hasPayments || $hasDebts) {
+            return redirect()->back()->with(
+                'error',
+                'No es posible eliminar el descuento porque está siendo utilizado en pagos o deudas.'
+            );
         }
 
         $before = $discount->toArray();

--- a/app/Models/Discount.php
+++ b/app/Models/Discount.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Payment;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -32,5 +33,15 @@ class Discount extends Model
     public function creator()
     {
         return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+
+    public function hasDependencies()
+    {
+        return $this->payments()->exists();
     }
 }

--- a/app/Models/Discount.php
+++ b/app/Models/Discount.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Payment;
+use App\Models\DiscountHistory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -42,6 +43,7 @@ class Discount extends Model
 
     public function hasDependencies()
     {
-        return $this->payments()->exists() || $this->debts()->exists();
+        return $this->payments()->exists();
+        return $this->payments()->exists() || DiscountHistory::where('discount_id', $this->id) ->where('module', 'debt') ->exists();
     }
 }

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -27,10 +27,15 @@
                                         <i class="fa fa-plus"></i>
                                         Asignar a Todos
                                     </button>
-                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mx-0 mx-lg-1 w-100 w-lg-auto" data-toggle="modal" title="Registrar Deuda" data-target="#createDebt">
+                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mx-0 mx-lg-1 w-100 w-lg-auto" data-toggle="modal"
+                                     title="Registrar Deuda" data-target="#createDebt">
                                         <i class="fa fa-plus"></i>
                                         <span class="d-none d-lg-inline">Registrar Deuda</span>
                                         <span class="d-inline d-lg-none">Registrar Deuda</span>
+                                    </button>
+                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mr-lg-2 w-100 w-lg-auto" data-toggle="modal" title="Crear Deuda" data-target="#createDebt">
+                                        <i class="fa fa-plus"></i>
+                                        Crear Deuda
                                     </button>
                                     <a class="btn btn-secondary w-100 w-lg-auto" target="_blank" title="Clientes con deudas" href="{{ route('report.with-debts') }}">
                                         <i class="fas fa-file-pdf"></i>

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -27,12 +27,11 @@
                                         <i class="fa fa-plus"></i>
                                         Asignar a Todos
                                     </button>
-                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mx-0 mx-lg-1 w-100 w-lg-auto" data-toggle="modal"
-                                     title="Registrar Deuda" data-target="#createDebt">
+                                    <button type="button" class="btn btn-success mx-1" data-toggle="modal"
+                                            title="Registrar Deuda" data-target="#createDebt">
                                         <i class="fa fa-plus"></i>
                                         <span class="d-none d-lg-inline">Registrar Deuda</span>
                                         <span class="d-inline d-lg-none">Registrar Deuda</span>
-                                    </button>
                                     <button type="button" class="btn btn-success mb-2 mb-lg-0 mr-lg-2 w-100 w-lg-auto" data-toggle="modal" title="Crear Deuda" data-target="#createDebt">
                                         <i class="fa fa-plus"></i>
                                         Crear Deuda

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -32,9 +32,6 @@
                                         <i class="fa fa-plus"></i>
                                         <span class="d-none d-lg-inline">Registrar Deuda</span>
                                         <span class="d-inline d-lg-none">Registrar Deuda</span>
-                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mr-lg-2 w-100 w-lg-auto" data-toggle="modal" title="Crear Deuda" data-target="#createDebt">
-                                        <i class="fa fa-plus"></i>
-                                        Crear Deuda
                                     </button>
                                     <a class="btn btn-secondary w-100 w-lg-auto" target="_blank" title="Clientes con deudas" href="{{ route('report.with-debts') }}">
                                         <i class="fas fa-file-pdf"></i>

--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -27,8 +27,7 @@
                                         <i class="fa fa-plus"></i>
                                         Asignar a Todos
                                     </button>
-                                    <button type="button" class="btn btn-success mx-1" data-toggle="modal"
-                                            title="Registrar Deuda" data-target="#createDebt">
+                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mx-0 mx-lg-1 w-100 w-lg-auto" data-toggle="modal" title="Registrar Deuda" data-target="#createDebt">
                                         <i class="fa fa-plus"></i>
                                         <span class="d-none d-lg-inline">Registrar Deuda</span>
                                         <span class="d-inline d-lg-none">Registrar Deuda</span>

--- a/resources/views/discounts/edit.blade.php
+++ b/resources/views/discounts/edit.blade.php
@@ -39,7 +39,7 @@
                                         <div class="form-group">
                                             <label>Porcentaje (*)</label>
                                             <div class="input-group">
-                                                <input type="number" class="form-control" name="percentage" min="1" max="100" step="0.01" value="{{ old('percentage',$discount->percentage) }}" required>
+                                                <input type="number" name="percentage" class="form-control" value="{{ old('percentage', $discount->percentage) }}" readonly>
                                                 <div class="input-group-append">
                                                     <span class="input-group-text">%</span>
                                                 </div>

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -84,17 +84,18 @@
                                                                 <i class="fas fa-edit"></i>
                                                             </button>
                                                             @endcan
+                                                            @can('deleteDiscount')
                                                             @if ($discount->hasDependencies())
                                                                 <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen pagos asociados con este descuento." disabled>
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>
                                                             @endif
-
                                                             @if (! $discount->hasDependencies())
                                                                 <button type="button" class="btn btn-danger mr-2" title="Eliminar Registro" data-toggle="modal" data-target="#deleteDiscount{{ $discount->id }}">
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>
                                                             @endif
+                                                            @endcan
                                                         @endif
                                                     </div>
                                                 </td>

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -84,12 +84,17 @@
                                                                 <i class="fas fa-edit"></i>
                                                             </button>
                                                             @endcan
+                                                            @if ($discount->hasDependencies())
+                                                                <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen pagos asociados con este descuento." disabled>
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
+                                                            @endif
 
-                                                            @can('deleteDiscount')
-                                                            <button type="button" class="btn btn-danger mr-2" title="Eliminar Registro" data-toggle="modal" data-target="#delete{{ $discount->id }}">
-                                                                <i class="fas fa-trash-alt"></i>
-                                                            </button>
-                                                            @endcan
+                                                            @if (! $discount->hasDependencies())
+                                                                <button type="button" class="btn btn-danger mr-2" title="Eliminar Registro" data-toggle="modal" data-target="#deleteDiscount{{ $discount->id }}">
+                                                                    <i class="fas fa-trash-alt"></i>
+                                                                </button>
+                                                            @endif
                                                         @endif
                                                     </div>
                                                 </td>

--- a/resources/views/payments/show.blade.php
+++ b/resources/views/payments/show.blade.php
@@ -65,7 +65,13 @@
                                         @endswitch
                                     </div>
                                 </div>
-                                <div class="col-lg-6">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Descuento</label>
+                                        <input type="text" class="form-control" value="{{ $payment->discount ? $payment->discount->name.' - '.$payment->discount->percentage.'%' : 'Sin descuento' }}" readonly>
+                                    </div>
+                                </div>
+                                <div class="col-lg-12">
                                     <div class="form-group">
                                         <label>Registrado por</label>
                                         <input type="text" disabled class="form-control" value="{{ $payment->creator->name ?? 'Desconocido' }} {{ $payment->creator->last_name ?? '' }}" />

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -230,6 +230,12 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                             @break
                     @endswitch
                 </p>
+                @if($payment->discount)
+                    <p>
+                        <strong>Descuento aplicado:</strong>
+                        {{ $payment->discount->name }} - {{ $payment->discount->percentage }}%
+                    </p>
+                @endif
                 @if($payment->isOpenPayPayment())
                     <p><strong>ID de Transacción: </strong>{{ $payment->openpay_transaction_id }}</p>
                 @endif


### PR DESCRIPTION
## Description

This PR includes improvements to the Discounts module to prevent modifications and deletions that could compromise data integrity.

### Changes made

- Disabled editing of the discount percentage in the edit form, setting it to read-only.
- Added validation to prevent the deletion of discounts that have associated payments.
- Disabled the delete button when the discount has dependencies and added an informational message for the user.
- Retained controller-level validation to prevent deletions via direct requests.
- Added a section for the discount to the receipt.

### Evidence

- The discount percentage can no longer be modified from the edit view.
- Discounts with associated payments cannot be deleted, and the delete button remains disabled.
- Discounts without associated payments can be deleted normally.

### Change type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring