### PR TITLE
Enhance discount reports with new layout and additional columns

### DIFF
--- a/app/Http/Controllers/DiscountHistoryController.php
+++ b/app/Http/Controllers/DiscountHistoryController.php
@@ -18,7 +18,7 @@ class DiscountHistoryController extends Controller
         $endDate = $request->input('end_date');
         $showModuleColumn = $request->boolean('show_module_column');
         $locality = Locality::find($localityId);
-        $includeAllModules = $module === 'todos';
+        $includeAllModules = $module === 'all';
         $dbModule = $this->normalizeModuleForStorage($module);
         $moduleNames = [
             'pagos' => 'Pagos',

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -495,9 +495,10 @@ class PaymentController extends Controller
         $customer = Customer::with('user')->findOrFail($customerId);
         $authUser = auth()->user();
 
-        $payments = Payment::whereHas('debt.waterConnection', function ($query) use ($customerId) {
-            $query->where('customer_id', $customerId);
-        })
+        $payments = Payment::with(['debt.waterConnection', 'discount'])
+            ->whereHas('debt.waterConnection', function ($query) use ($customerId) {
+                $query->where('customer_id', $customerId);
+            })
             ->whereBetween('created_at', [$startDate, $endDate])
             ->get();
 
@@ -523,7 +524,8 @@ class PaymentController extends Controller
             ->where('customer_id', $customerId)
             ->firstOrFail();
 
-        $payments = Payment::select('id', 'debt_id', 'amount', 'created_at')
+        $payments = Payment::select('id', 'debt_id', 'amount', 'created_at', 'discount_id')
+            ->with(['debt', 'discount'])
             ->where('locality_id', $authUser->locality_id)
             ->whereHas('debt', function ($query) use ($waterConnectionId) {
                 $query->where('water_connection_id', $waterConnectionId);

--- a/resources/views/discounts/discountHistoryModal.blade.php
+++ b/resources/views/discounts/discountHistoryModal.blade.php
@@ -14,7 +14,7 @@
                         <label for="discount_history_module">Módulo</label>
                         <select name="module" id="discount_history_module" class="form-control" required>
                             <option value="">Selecciona un módulo</option>
-                            <option value="todos">Todos los módulos</option>
+                            <option value="all">Todos los módulos</option>
                             <option value="pagos">Pagos</option>
                             <option value="deudas">Deudas</option>
                         </select>
@@ -48,7 +48,7 @@
             const selectedValue = $(this).val();
             const $checkbox = $('#discount_history_show_module_column');
 
-            const shouldEnableGrouping = selectedValue === 'todos';
+            const shouldEnableGrouping = selectedValue === 'all';
 
             $checkbox.prop('disabled', !shouldEnableGrouping);
 

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -177,7 +177,7 @@
     }
     table#discounts th,
     table#discounts td {
-        text-align: center;
+        text-align: left !important;
         vertical-align: middle;
     }
     .dataTables_wrapper {

--- a/resources/views/reports/clientPayments.blade.php
+++ b/resources/views/reports/clientPayments.blade.php
@@ -259,20 +259,28 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                         <th class="textable">Folio</th>
                         <th class="textable">Toma de agua</th>
                         <th class="textable">Fecha del pago</th>
+                        <th class="textable">Descuento aplicado</th>
                         <th class="textable">Cantidad</th>
                     </tr>
                 </thead>
                 <tbody id="detalle_productos">'
                     @foreach ($payments as $payment)
+                        @php
+                            $discountText = 'No aplica';
+                            if ($payment->discount) {
+                                $discountText = $payment->discount->name . ' (' . number_format($payment->discount->percentage, 2) . '%)';
+                            }
+                        @endphp
                         <tr>
                             <td class="textcenter">{{ $payment->id }}</td>
-                            <td class="textcenter">{{ $payment->debt->waterConnection->name}}
+                            <td class="textcenter">{{ $payment->debt->waterConnection->name}}</td>
                             <td class="textcenter">{{ \Carbon\Carbon::parse($payment->created_at)->translatedFormat('j \d\e F \d\e Y') }}</td>
+                            <td class="textcenter">{{ $discountText }}</td>
                             <td class="textcenter">$ {{ $payment->amount }}</td>
                         </tr>
                     @endforeach
                     <tr>
-                        <td colspan="3" class="total_payment"><strong>Total:</strong></td>
+                        <td colspan="4" class="total_payment"><strong>Total:</strong></td>
                         <td class="textcenter"><strong>$ {{ number_format($totalPayments, 2) }}</strong></td>
                     </tr>
                 </tbody>

--- a/resources/views/reports/pdfDiscountHistory.blade.php
+++ b/resources/views/reports/pdfDiscountHistory.blade.php
@@ -248,6 +248,22 @@
     </style>
 </head>
 <body>
+    @php
+        $selectedModule = request('module');
+        $isGrouped = (string) request('show_module_column') === '1';
+        $reportTitle = 'HISTORIAL DE DESCUENTOS';
+        if ($selectedModule === 'todos' && $isGrouped) {
+            $reportTitle = 'HISTORIAL DE DESCUENTOS POR MÓDULO';
+        }
+        if ($selectedModule === 'todos' && !$isGrouped) {
+            $reportTitle = 'HISTORIAL DE DESCUENTOS';
+        }
+        if (!empty($selectedModule) && $selectedModule !== 'todos') {
+            $moduleNameLabel = $moduleNames[$selectedModule] ?? $selectedModule;
+            $formattedModule = mb_strtoupper($moduleNameLabel);
+            $reportTitle = "HISTORIAL DE DESCUENTOS DEL MÓDULO {$formattedModule}";
+        }
+    @endphp
     @if(isset($error))
         <div class="report-page">
             <div class="page-bg">
@@ -276,7 +292,7 @@
             </div>
         </div>
     @endif
-    @if(!isset($error) && $reportType === 'all-modules-grouped' && (!empty($groupedByDay) || !empty($groupedByModule)))
+    @if(!isset($error) && $selectedModule === 'todos' && $isGrouped && (!empty($groupedByDay) || !empty($groupedByModule)))
         @foreach($groupedByModule as $moduleName => $days)
             <div class="report-page {{ !$loop->first ? 'page-break' : '' }}">
                 <div class="page-bg">
@@ -301,7 +317,7 @@
                                         COMITÉ DEL SISTEMA DE AGUA POTABLE DE<br>
                                         {{ $authUserLocality->name ?? '-' }}, {{ $authUserLocality->municipality ?? '-' }}, {{ $authUserLocality->state ?? '-' }}
                                     </p>
-                                    <p class="first-page-subtitle">{{ $reportTitles[$reportType] ?? 'HISTORIAL DE DESCUENTOS' }}</p>
+                                    <p class="first-page-subtitle">{{ $reportTitle }}</p>
                                     @if($startDate || $endDate)
                                         <p class="date-range">
                                             @if($startDate) Desde: {{ \Carbon\Carbon::parse($startDate)->format('d/m/Y') }} @endif
@@ -316,7 +332,7 @@
                                 <p class="inner-page-committee">
                                     COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ $authUserLocality->name ?? '-' }}, {{ $authUserLocality->municipality ?? '-' }}, {{ $authUserLocality->state ?? '-' }}
                                 </p>
-                                <p class="inner-page-title">{{ $reportTitles[$reportType] ?? 'HISTORIAL DE DESCUENTOS' }}</p>
+                                <p class="inner-page-title">{{ $reportTitle }}</p>
                             </div>
                         @endif
                         <div class="report-section">
@@ -368,7 +384,7 @@
             </div>
         @endforeach
     @endif
-    @if(!isset($error) && $reportType === 'single-module' && (!empty($groupedByDay) || !empty($groupedByModule)))
+    @if(!isset($error) && ($selectedModule !== 'todos' || !$isGrouped) && (!empty($groupedByDay) || !empty($groupedByModule)))
         <div class="report-page">
             <div class="page-bg">
                 <img src="file://{{ $verticalBgPath }}" alt="Background">
@@ -391,7 +407,7 @@
                                 COMITÉ DEL SISTEMA DE AGUA POTABLE DE<br>
                                 {{ $authUserLocality->name ?? '-' }}, {{ $authUserLocality->municipality ?? '-' }}, {{ $authUserLocality->state ?? '-' }}
                             </p>
-                            <p class="first-page-subtitle">{{ $reportTitles[$reportType] ?? 'HISTORIAL DE DESCUENTOS' }}</p>
+                            <p class="first-page-subtitle">{{ $reportTitle }}</p>
                             @if($startDate || $endDate)
                                 <p class="date-range">
                                     @if($startDate) Desde: {{ \Carbon\Carbon::parse($startDate)->format('d/m/Y') }} @endif

--- a/resources/views/reports/pdfDiscountHistory.blade.php
+++ b/resources/views/reports/pdfDiscountHistory.blade.php
@@ -252,13 +252,13 @@
         $selectedModule = request('module');
         $isGrouped = (string) request('show_module_column') === '1';
         $reportTitle = 'HISTORIAL DE DESCUENTOS';
-        if ($selectedModule === 'todos' && $isGrouped) {
+        if ($selectedModule === 'all' && $isGrouped) {
             $reportTitle = 'HISTORIAL DE DESCUENTOS POR MÓDULO';
         }
-        if ($selectedModule === 'todos' && !$isGrouped) {
+        if ($selectedModule === 'all' && !$isGrouped) {
             $reportTitle = 'HISTORIAL DE DESCUENTOS';
         }
-        if (!empty($selectedModule) && $selectedModule !== 'todos') {
+        if (!empty($selectedModule) && $selectedModule !== 'all') {
             $moduleNameLabel = $moduleNames[$selectedModule] ?? $selectedModule;
             $formattedModule = mb_strtoupper($moduleNameLabel);
             $reportTitle = "HISTORIAL DE DESCUENTOS DEL MÓDULO {$formattedModule}";
@@ -292,7 +292,7 @@
             </div>
         </div>
     @endif
-    @if(!isset($error) && $selectedModule === 'todos' && $isGrouped && (!empty($groupedByDay) || !empty($groupedByModule)))
+    @if(!isset($error) && $selectedModule === 'all' && $isGrouped && (!empty($groupedByDay) || !empty($groupedByModule)))
         @foreach($groupedByModule as $moduleName => $days)
             <div class="report-page {{ !$loop->first ? 'page-break' : '' }}">
                 <div class="page-bg">
@@ -384,7 +384,7 @@
             </div>
         @endforeach
     @endif
-    @if(!isset($error) && ($selectedModule !== 'todos' || !$isGrouped) && (!empty($groupedByDay) || !empty($groupedByModule)))
+    @if(!isset($error) && ($selectedModule !== 'all' || !$isGrouped) && (!empty($groupedByDay) || !empty($groupedByModule)))
         <div class="report-page">
             <div class="page-bg">
                 <img src="file://{{ $verticalBgPath }}" alt="Background">

--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -210,6 +210,12 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                 <p>FOLIO. {{ $payment->debt->id }}</p>
                 <p>Fecha de la deuda: {{ \Carbon\Carbon::parse($payment->debt->start_date)->locale('es')->isoFormat('D [de ]MMMM [del] YYYY') }}</p>
                 <p>Fecha de vencimiento: {{ \Carbon\Carbon::parse($payment->debt->end_date)->locale('es')->isoFormat('D [de ]MMMM [del] YYYY') }}</p>
+                 @if($payment->discount)
+                    <p>
+                        <strong>Descuento aplicado:</strong>
+                        {{ $payment->discount->name }} - {{ $payment->discount->percentage }}%
+                    </p>
+                @endif
             </div>
             <div class="payment-info">
                 <h4>Datos del pago</h4>

--- a/resources/views/reports/waterConnectionPayments.blade.php
+++ b/resources/views/reports/waterConnectionPayments.blade.php
@@ -273,22 +273,30 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                         <th class="textable">Folio</th>
                         <th class="textable">Fecha del Pago</th>
                         <th class="textable">Folio Deuda</th>
+                        <th class="textable">Descuento aplicado</th>
                         <th class="textable">Cantidad</th>
                     </tr>
                 </thead>
                 <tbody id="detalle_productos">'
                     @foreach($payments as $debtId => $debtPayments)
                         @foreach($debtPayments as $payment)
+                            @php
+                                $discountText = 'No aplica';
+                                if ($payment->discount) {
+                                    $discountText = $payment->discount->name . ' (' . number_format($payment->discount->percentage, 2) . '%)';
+                                }
+                            @endphp
                             <tr>
                                 <td class="textcenter">{{ $payment->id }}</td>
                                 <td class="textcenter">{{ \Carbon\Carbon::parse($payment->created_at)->translatedFormat('j \d\e F \d\e Y') }}</td>
                                 <td class="textcenter">{{ $payment->debt->id }}</td>
+                                <td class="textcenter">{{ $discountText }}</td>
                                 <td class="textcenter">$ {{ $payment->amount }}</td>
                             </tr>
                         @endforeach
                     @endforeach
                     <tr>
-                        <td colspan="3" class="total_payment"><strong>Total:</strong></td>
+                        <td colspan="4" class="total_payment"><strong>Total:</strong></td>
                         <td class="textcenter"><strong>$ {{ number_format($totalPayments, 2) }}</strong></td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
 **Discount history report titles**
  - Logic adjusted to correctly display:
    - "HISTORIAL DE DESCUENTOS" for general reports.
    - "HISTORIAL DE DESCUENTOS POR MÓDULO" for grouped reports.
    - "HISTORIAL DE DESCUENTOS DEL MÓDULO (MODULE)" for single-module reports.
- **Discount module layout**
  - Content centered in tables for improved presentation.
- **Client and water connection payment reports**
  - Added a new column **“Applied Discount”** showing the discount name and percentage.
  - If no discount exists, the text **“No aplica”** is displayed.