### PR TITLE
resolved display debt discount details in debt info section

### DIFF
--- a/resources/views/reports/receiptPayment.blade.php
+++ b/resources/views/reports/receiptPayment.blade.php
@@ -210,10 +210,10 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                 <p>FOLIO. {{ $payment->debt->id }}</p>
                 <p>Fecha de la deuda: {{ \Carbon\Carbon::parse($payment->debt->start_date)->locale('es')->isoFormat('D [de ]MMMM [del] YYYY') }}</p>
                 <p>Fecha de vencimiento: {{ \Carbon\Carbon::parse($payment->debt->end_date)->locale('es')->isoFormat('D [de ]MMMM [del] YYYY') }}</p>
-                 @if($payment->discount)
+                @if($payment->debt->discount)
                     <p>
                         <strong>Descuento aplicado:</strong>
-                        {{ $payment->discount->name }} - {{ $payment->discount->percentage }}%
+                        {{ $payment->debt->discount->name }} - {{ $payment->debt->discount->percentage }}%
                     </p>
                 @endif
             </div>


### PR DESCRIPTION
Fixes the discount display logic within the receipt's "Datos de la deuda" (Debt Information) section.

Changes Made:

Updated the conditional check in the debt info section to evaluate $payment->debt->discount instead of the undefined $discount->payment property.

Ensured the receipt dynamically retrieves and renders the correct discount name and percentage associated with the debt.