### PR TITLE
add report generation button and layout PDF with charts and data

### DIFF
--- a/app/Http/Controllers/DiscountDashboardController.php
+++ b/app/Http/Controllers/DiscountDashboardController.php
@@ -97,9 +97,15 @@ class DiscountDashboardController extends Controller
                       ->orWhereNull('discounts.locality_id');
                 }
             })
-            ->leftJoin('discount_histories as dh', function ($join) {
+            ->leftJoin('discount_histories as dh', function ($join) use ($authUser) {
                 $join->on('discounts.id', '=', 'dh.discount_id')
                      ->whereNull('dh.deleted_at');
+                if ($authUser && $authUser->locality_id) {
+                    $join->where(function ($q) use ($authUser) {
+                        $q->where('dh.locality_id', $authUser->locality_id)
+                          ->orWhereNull('dh.locality_id');
+                    });
+                }
             })
             ->select(
                 'discounts.id',

--- a/app/Http/Controllers/DiscountDashboardController.php
+++ b/app/Http/Controllers/DiscountDashboardController.php
@@ -216,13 +216,30 @@ class DiscountDashboardController extends Controller
             ->orderByDesc('total')
             ->get();
 
+        $itemsFirstPage = 8;
+        $itemsNextPages = 20;
+        $firstPageSummary = $discountsSummary->take($itemsFirstPage);
+        $otherPagesSummary = $discountsSummary->slice($itemsFirstPage)->chunk($itemsNextPages);
+        $pagesSummary = 1 + (int) ceil(max(0, $discountsSummary->count() - $itemsFirstPage) / $itemsNextPages);
+        $firstPagePayments = $paymentDiscounts->take($itemsFirstPage);
+        $otherPagesPayments = $paymentDiscounts->slice($itemsFirstPage)->chunk($itemsNextPages);
+        $pagesPayments = 1 + (int) ceil(max(0, $paymentDiscounts->count() - $itemsFirstPage) / $itemsNextPages);
+        $firstPageDebts = $debtDiscounts->take($itemsFirstPage);
+        $otherPagesDebts = $debtDiscounts->slice($itemsFirstPage)->chunk($itemsNextPages);
+        $pagesDebts = 1 + (int) ceil(max(0, $debtDiscounts->count() - $itemsFirstPage) / $itemsNextPages);
+        $totalPages = $pagesSummary + $pagesPayments + $pagesDebts;
+
         $pdf = Pdf::loadView('reports.discountDashboardReport', compact(
             'authUser',
             'locality',
             'chartImages',
-            'discountsSummary',
-            'paymentDiscounts',
-            'debtDiscounts',
+            'firstPageSummary',
+            'otherPagesSummary',
+            'firstPagePayments',
+            'otherPagesPayments',
+            'firstPageDebts',
+            'otherPagesDebts',
+            'totalPages',
             'paymentMonthLabel',
             'paymentYear',
             'debtMonthLabel',

--- a/app/Http/Controllers/DiscountDashboardController.php
+++ b/app/Http/Controllers/DiscountDashboardController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Discount;
 use App\Models\DiscountHistory;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Request;
 
@@ -112,5 +114,121 @@ class DiscountDashboardController extends Controller
             'labels' => $debtDiscounts->pluck('name'),
             'data'   => $debtDiscounts->pluck('total')
         ]);
+    }
+
+    public function generateReport(Request $request)
+    {
+        $authUser = auth()->user();
+        $locality = $authUser->locality;
+
+        $chartImages = json_decode($request->input('charts'), true) ?? [];
+
+        $discountsSummary = Discount::where(function ($q) use ($authUser) {
+                if ($authUser && $authUser->locality_id) {
+                    $q->where('discounts.locality_id', $authUser->locality_id)
+                      ->orWhereNull('discounts.locality_id');
+                }
+            })
+            ->leftJoin('discount_histories as dh', function ($join) {
+                $join->on('discounts.id', '=', 'dh.discount_id')
+                     ->whereNull('dh.deleted_at');
+            })
+            ->select(
+                'discounts.id',
+                'discounts.name',
+                'discounts.percentage',
+                'discounts.color',
+                DB::raw('COUNT(dh.id) as total_uses')
+            )
+            ->groupBy('discounts.id', 'discounts.name', 'discounts.percentage', 'discounts.color')
+            ->orderByDesc('total_uses')
+            ->get();
+
+        $monthNames = [
+            1 => 'Enero', 2 => 'Febrero', 3 => 'Marzo', 4 => 'Abril',
+            5 => 'Mayo', 6 => 'Junio', 7 => 'Julio', 8 => 'Agosto',
+            9 => 'Septiembre', 10 => 'Octubre', 11 => 'Noviembre', 12 => 'Diciembre'
+        ];
+
+        $paymentMonth = $request->input('payment_month');
+        $paymentYear  = $request->input('payment_year');
+        $paymentMonthLabel = $paymentMonth && isset($monthNames[(int)$paymentMonth]) ? $monthNames[(int)$paymentMonth] : null;
+
+        $paymentQuery = DB::table('discount_histories as dh')
+            ->join('discounts as d', 'd.id', '=', 'dh.discount_id')
+            ->select(
+                'd.id',
+                'd.name',
+                'd.percentage',
+                'd.color',
+                DB::raw('COUNT(*) as total')
+            )
+            ->where('dh.module', 'payment')
+            ->whereNull('dh.deleted_at')
+            ->where(function ($q) use ($authUser) {
+                if ($authUser && $authUser->locality_id) {
+                    $q->where('dh.locality_id', $authUser->locality_id)
+                      ->orWhereNull('dh.locality_id');
+                }
+            });
+
+        if ($paymentMonth) {
+            $paymentQuery->whereMonth('dh.created_at', $paymentMonth);
+        }
+        if ($paymentYear) {
+            $paymentQuery->whereYear('dh.created_at', $paymentYear);
+        }
+
+        $paymentDiscounts = $paymentQuery->groupBy('d.id', 'd.name', 'd.percentage', 'd.color')
+            ->orderByDesc('total')
+            ->get();
+
+        $debtMonth = $request->input('debt_month');
+        $debtYear  = $request->input('debt_year');
+        $debtMonthLabel = $debtMonth && isset($monthNames[(int)$debtMonth]) ? $monthNames[(int)$debtMonth] : null;
+
+        $debtQuery = DB::table('discount_histories as dh')
+            ->join('discounts as d', 'd.id', '=', 'dh.discount_id')
+            ->select(
+                'd.id',
+                'd.name',
+                'd.percentage',
+                'd.color',
+                DB::raw('COUNT(*) as total')
+            )
+            ->where('dh.module', 'debt')
+            ->whereNull('dh.deleted_at')
+            ->where(function ($q) use ($authUser) {
+                if ($authUser && $authUser->locality_id) {
+                    $q->where('dh.locality_id', $authUser->locality_id)
+                      ->orWhereNull('dh.locality_id');
+                }
+            });
+
+        if ($debtMonth) {
+            $debtQuery->whereMonth('dh.created_at', $debtMonth);
+        }
+        if ($debtYear) {
+            $debtQuery->whereYear('dh.created_at', $debtYear);
+        }
+
+        $debtDiscounts = $debtQuery->groupBy('d.id', 'd.name', 'd.percentage', 'd.color')
+            ->orderByDesc('total')
+            ->get();
+
+        $pdf = Pdf::loadView('reports.discountDashboardReport', compact(
+            'authUser',
+            'locality',
+            'chartImages',
+            'discountsSummary',
+            'paymentDiscounts',
+            'debtDiscounts',
+            'paymentMonthLabel',
+            'paymentYear',
+            'debtMonthLabel',
+            'debtYear'
+        ))->setPaper('A4', 'portrait');
+
+        return $pdf->stream('Reporte_Panel_Descuentos.pdf');
     }
 }

--- a/resources/views/discountDashboard/index.blade.php
+++ b/resources/views/discountDashboard/index.blade.php
@@ -7,17 +7,33 @@
     <div class="right_col" role="main">
         <div class="col-md-12 col-sm-12">
             <div class="x_panel">
-                <div class="x_title">
+                <div class="x_title mb-3">
                     <h2>Panel de Descuentos</h2>
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="d-flex justify-content-end align-items-center flex-wrap">
+                                <div class="responsive-actions">
+                                    <button class="btn btn-primary" id="btnGenerateReport" title="Generar reporte">
+                                        <i class="fa fa-chart-pie mr-1"></i>
+                                        <span class="d-none d-md-inline">Generar reporte</span>
+                                        <span class="d-inline d-md-none">Reporte</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="x_content">
                     <div class="row">
                         <div class="col-lg-12 mb-4">
                             <div class="card card-primary card-outline">
-                                <div class="card-header">
+                                <div class="card-header d-flex justify-content-between align-items-center">
                                     <h3 class="card-title">
                                         Uso general de descuentos
                                     </h3>
+                                    <button class="btn btn-sm btn-outline-dark download-btn" data-canvas="discountChart">
+                                        <i class="fas fa-download"></i> Descargar
+                                    </button>
                                 </div>
                                 <div class="card-body">
                                     <div class="row align-items-center">
@@ -41,7 +57,7 @@
                                     <h3 class="card-title">
                                         Descuentos aplicados en pagos
                                     </h3>
-                                    <div class="d-flex">
+                                    <div class="d-flex align-items-center">
                                         <select class="form-control form-control-sm mr-2" id="paymentMonth">
                                             <option value="">Mes</option>
                                             <option value="1">Enero</option>
@@ -57,11 +73,14 @@
                                             <option value="11">Noviembre</option>
                                             <option value="12">Diciembre</option>
                                         </select>
-                                        <select class="form-control form-control-sm" id="paymentYear">
+                                        <select class="form-control form-control-sm mr-2" id="paymentYear">
                                             @for($i = date('Y'); $i >= date('Y')-5; $i--)
                                                 <option value="{{ $i }}">{{ $i }}</option>
                                             @endfor
                                         </select>
+                                        <button class="btn btn-sm btn-outline-dark download-btn" data-canvas="paymentChart">
+                                            <i class="fas fa-download"></i> Descargar
+                                        </button>
                                     </div>
                                 </div>
                                 <div class="card-body">
@@ -75,7 +94,7 @@
                                     <h3 class="card-title">
                                         Descuentos aplicados en deudas
                                     </h3>
-                                    <div class="d-flex">
+                                    <div class="d-flex align-items-center">
                                         <select class="form-control form-control-sm mr-2" id="debtMonth">
                                             <option value="">Mes</option>
                                             <option value="1">Enero</option>
@@ -91,11 +110,14 @@
                                             <option value="11">Noviembre</option>
                                             <option value="12">Diciembre</option>
                                         </select>
-                                        <select class="form-control form-control-sm" id="debtYear">
+                                        <select class="form-control form-control-sm mr-2" id="debtYear">
                                             @for($i = date('Y'); $i >= date('Y')-5; $i--)
                                                 <option value="{{ $i }}">{{ $i }}</option>
                                             @endfor
                                         </select>
+                                        <button class="btn btn-sm btn-outline-dark download-btn" data-canvas="debtChart">
+                                            <i class="fas fa-download"></i> Descargar
+                                        </button>
                                     </div>
                                 </div>
                                 <div class="card-body">
@@ -109,6 +131,39 @@
         </div>
     </div>
 </section>
+<style>
+    #btnGenerateReport:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+    }
+    @media (max-width: 767.98px) {
+        .responsive-actions{
+            display: flex !important;
+            flex-direction: column;
+            width: 100%;
+            gap: .5rem;
+            margin-top: .5rem;
+        }
+        .responsive-actions .btn{
+            width: 100%;
+            margin-right: 0 !important;
+            margin-left: 0 !important;
+        }
+    }
+    @media (min-width: 768px) {
+        .responsive-actions{
+            display: flex !important;
+            flex-direction: row;
+            justify-content: flex-end;
+            align-items: center;
+            flex-wrap: nowrap;
+            gap: .5rem;
+        }
+        .responsive-actions .btn{
+            width: auto;
+        }   
+    }
+</style>
 @endsection
 @section('js')
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -264,6 +319,62 @@
                 console.log(xhr.responseText);
             }
         });
+    });
+    document.querySelectorAll('.download-btn').forEach(button => {
+        button.addEventListener('click', function () {
+            const canvasId = this.dataset.canvas;
+            const canvas = document.getElementById(canvasId);
+            if (canvas) {
+                const link = document.createElement('a');
+                link.href = canvas.toDataURL('image/png');
+                link.download = `${canvasId}.png`;
+                link.click();
+            }
+        });
+    });
+    document.getElementById('btnGenerateReport')?.addEventListener('click', () => {
+        const chartImages = {
+            discountChart: document.getElementById('discountChart')?.toDataURL('image/png') || '',
+            paymentChart: document.getElementById('paymentChart')?.toDataURL('image/png') || '',
+            debtChart: document.getElementById('debtChart')?.toDataURL('image/png') || ''
+        };
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '{{ route('discountDashboard.generateReport') }}';
+        form.target = '_blank';
+        const tokenInput = document.createElement('input');
+        tokenInput.type = 'hidden';
+        tokenInput.name = '_token';
+        tokenInput.value = '{{ csrf_token() }}';
+        form.appendChild(tokenInput);
+        const chartsInput = document.createElement('input');
+        chartsInput.type = 'hidden';
+        chartsInput.name = 'charts';
+        chartsInput.value = JSON.stringify(chartImages);
+        form.appendChild(chartsInput);
+        const paymentMonthInput = document.createElement('input');
+        paymentMonthInput.type = 'hidden';
+        paymentMonthInput.name = 'payment_month';
+        paymentMonthInput.value = $('#paymentMonth').val() || '';
+        form.appendChild(paymentMonthInput);
+        const paymentYearInput = document.createElement('input');
+        paymentYearInput.type = 'hidden';
+        paymentYearInput.name = 'payment_year';
+        paymentYearInput.value = $('#paymentYear').val() || '';
+        form.appendChild(paymentYearInput);
+        const debtMonthInput = document.createElement('input');
+        debtMonthInput.type = 'hidden';
+        debtMonthInput.name = 'debt_month';
+        debtMonthInput.value = $('#debtMonth').val() || '';
+        form.appendChild(debtMonthInput);
+        const debtYearInput = document.createElement('input');
+        debtYearInput.type = 'hidden';
+        debtYearInput.name = 'debt_year';
+        debtYearInput.value = $('#debtYear').val() || '';
+        form.appendChild(debtYearInput);
+        document.body.appendChild(form);
+        form.submit();
+        document.body.removeChild(form);
     });
 </script>
 @endsection

--- a/resources/views/discountDashboard/index.blade.php
+++ b/resources/views/discountDashboard/index.blade.php
@@ -320,6 +320,7 @@
             }
         });
     });
+
     document.querySelectorAll('.download-btn').forEach(button => {
         button.addEventListener('click', function () {
             const canvasId = this.dataset.canvas;
@@ -332,6 +333,7 @@
             }
         });
     });
+    
     document.getElementById('btnGenerateReport')?.addEventListener('click', () => {
         const chartImages = {
             discountChart: document.getElementById('discountChart')?.toDataURL('image/png') || '',

--- a/resources/views/reports/discountDashboardReport.blade.php
+++ b/resources/views/reports/discountDashboardReport.blade.php
@@ -1,0 +1,407 @@
+@php
+    $locality = $authUser->locality ?? null;
+    $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
+        ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
+        : public_path('img/backgroundReport.png');
+    $totalPages = 3;
+@endphp
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Reporte de Panel de Descuentos</title>
+        <style>
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
+            html, body {
+                margin: 0;
+                padding: 0;
+                font-family: 'Montserrat', sans-serif;
+            }
+            body {
+                margin: 0;
+                padding: 0;
+                background: none;
+            }
+            .report-page {
+                position: relative;
+                width: 100%;
+                height: 1122px;
+                overflow: hidden;
+                box-sizing: border-box;
+            }
+            .page-break {
+                page-break-before: always;
+            }
+            .page-bg {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                z-index: 1;
+            }
+            .page-bg img {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+            .page-content {
+                position: absolute;
+                top: 24px;
+                left: 0;
+                right: 0;
+                bottom: 42px;
+                width: 82%;
+                margin: 0 auto;
+                z-index: 2;
+            }
+            .page-inner {
+                width: 100%;
+                margin: 0 auto;
+            }
+            .report-footer {
+                position: absolute;
+                left: 0;
+                right: 0;
+                bottom: 8px;
+                text-align: center;
+                z-index: 3;
+            }
+            .text_infoE {
+                font-size: 10pt;
+                color: white;
+                text-decoration: none;
+                display: inline-block;
+            }
+            .page-number {
+                font-weight: bold;
+                font-size: 10pt;
+                letter-spacing: 0.5px;
+            }
+            .footer-branding {
+                color: #0B1C80 !important;
+            }
+            .footer-branding img {
+                filter: brightness(0) saturate(100%) invert(5%) sepia(100%) saturate(10000%) hue-rotate(200deg);
+            }
+            .first-page-header {
+                margin-top: 0;
+                margin-bottom: 5px;
+            }
+            .first-page-logo-row {
+                width: 100%;
+                position: relative;
+                margin-bottom: 4px;
+            }
+            .first-page-logo {
+                text-align: left;
+            }
+            .first-page-logo img {
+                width: 100px;
+                height: 100px;
+                border-radius: 50%;
+                display: inline-block;
+            }
+            .first-page-title-block {
+                margin-top: 70px;
+                text-align: center;
+            }
+            .first-page-title {
+                color: #0B1C80;
+                font-size: 16pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                margin: 0 0 4px 0;
+                line-height: 1.18;
+                text-align: center;
+            }
+            .first-page-subtitle {
+                color: #0B1C80;
+                font-size: 13pt;
+                font-weight: bold;
+                margin: 10px 0 0 0;
+                text-align: center;
+            }
+            .first-page-card-title {
+                color: #0B1C80;
+                font-size: 11.5pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                margin: 15px 0 5px 0;
+                text-align: center;
+                border-bottom: 2px solid #0B1C80;
+                padding-bottom: 4px;
+            }
+            .inner-page-header {
+                width: 100%;
+                margin-top: 15px;
+                margin-bottom: 10px;
+                text-align: center;
+            }
+            .inner-page-committee {
+                color: #ffffff;
+                font-size: 8.5pt;
+                text-align: center;
+                margin: 0 0 4px 0;
+                line-height: 1.2;
+            }
+            .inner-page-title {
+                color: #ffffff;
+                font-size: 12pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                text-align: center;
+                margin: 0;
+            }
+            .inner-card-title {
+                color: #0B1C80;
+                font-size: 11.5pt;
+                font-weight: bold;
+                text-transform: uppercase;
+                margin-top: 170px;
+                margin-bottom: 4px;
+                text-align: center;
+                border-bottom: 2px solid #0B1C80;
+                padding-bottom: 4px;
+            }
+            .filter-badge {
+                color: #0B1C80;
+                font-size: 9pt;
+                font-weight: bold;
+                text-align: center;
+                margin-top: 2px;
+                margin-bottom: 4px;
+            }
+            .chart-container {
+                width: 100%;
+                text-align: center;
+                margin-top: 4px;
+                margin-bottom: 12px;
+            }
+            .chart-container img {
+                max-width: 500px;
+                max-height: 240px;
+                width: auto;
+                height: auto;
+                display: inline-block;
+                margin: 0 auto;
+            }
+            .report-table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 8px auto 0 auto;
+                table-layout: fixed;
+            }
+            .report-table thead th {
+                background: #0B1C80;
+                color: #FFF;
+                padding: 7px 5px;
+                font-size: 9.5pt;
+                text-align: center;
+            }
+            .report-table tbody tr {
+                border-top: 1px solid #bfc9ff;
+            }
+            .report-table td {
+                background-color: transparent;
+                text-align: center;
+                font-size: 9pt;
+                padding: 4px 6px;
+                word-wrap: break-word;
+                line-height: 1.15;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="report-page">
+            <div class="page-bg">
+                <img src="file://{{ $verticalBgPath }}" alt="Background">
+            </div>
+            <div class="page-content">
+                <div class="page-inner">
+                    <div class="first-page-header">
+                        <div class="first-page-logo-row">
+                            <div class="first-page-logo">
+                                @if ($locality && $locality->hasMedia('localityGallery'))
+                                    <img src="{{ $locality->getFirstMediaUrl('localityGallery') }}"
+                                        alt="Photo of {{ $locality->name }}">
+                                @endif
+                                @if (!$locality || !$locality->hasMedia('localityGallery'))
+                                    <img src="{{ public_path('img/localityDefault.png') }}" alt="Default Photo">
+                                @endif
+                            </div>
+                        </div>
+                        <div class="first-page-title-block">
+                            <p class="first-page-title">
+                                COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ mb_strtoupper($locality->name ?? '') }}, {{ mb_strtoupper($locality->municipality ?? '') }}, {{ mb_strtoupper($locality->state ?? '') }}
+                            </p>
+                            <p class="first-page-subtitle">PANEL DE DESCUENTOS</p>
+                        </div>
+                    </div>
+                    <div class="first-page-card-title">1. USO GENERAL DE DESCUENTOS</div>
+                    @if(!empty($chartImages['discountChart']))
+                        <div class="chart-container">
+                            <img src="{{ $chartImages['discountChart'] }}" alt="Uso General de Descuentos">
+                        </div>
+                    @endif
+                    <table class="report-table">
+                        <thead>
+                            <tr>
+                                <th style="width: 15%;">ID</th>
+                                <th style="width: 35%;">DESCUENTO</th>
+                                <th style="width: 20%;">PORCENTAJE</th>
+                                <th style="width: 30%;">TOTAL DE USOS</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @if (!empty($discountsSummary) && count($discountsSummary) > 0)
+                                @foreach ($discountsSummary as $item)
+                                    <tr>
+                                        <td>{{ $item->id }}</td>
+                                        <td>{{ $item->name }}</td>
+                                        <td>{{ $item->percentage }}%</td>
+                                        <td>{{ $item->total_uses }}</td>
+                                    </tr>
+                                @endforeach
+                            @endif
+                            @if (empty($discountsSummary) || count($discountsSummary) === 0)
+                                <tr>
+                                    <td colspan="4">No hay datos de descuentos registrados.</td>
+                                </tr>
+                            @endif
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="report-footer">
+                <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                <span class="text_infoE"> | </span>
+                <span class="text_infoE page-number">Página 1 de {{ $totalPages }}</span>
+                <span class="text_infoE"> | </span>
+                <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+            </div>
+        </div>
+        <div class="report-page page-break">
+            <div class="page-bg">
+                <img src="file://{{ $verticalBgPath }}" alt="Background">
+            </div>
+            <div class="page-content">
+                <div class="page-inner">
+                    <div class="inner-page-header">
+                        <p class="inner-page-committee">
+                            COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ mb_strtoupper($locality->name ?? '') }}, {{ mb_strtoupper($locality->municipality ?? '') }}, {{ mb_strtoupper($locality->state ?? '') }}
+                        </p>
+                        <p class="inner-page-title">PANEL DE DESCUENTOS</p>
+                    </div>
+                    <div class="inner-card-title">2. DESCUENTOS APLICADOS EN PAGOS</div>
+                    @if($paymentMonthLabel || $paymentYear)
+                        <div class="filter-badge">
+                            Filtro aplicado: {{ $paymentMonthLabel ? $paymentMonthLabel : 'Todos los meses' }} {{ $paymentYear ? $paymentYear : '' }}
+                        </div>
+                    @endif
+                    @if(!empty($chartImages['paymentChart']))
+                        <div class="chart-container">
+                            <img src="{{ $chartImages['paymentChart'] }}" alt="Descuentos aplicados en pagos">
+                        </div>
+                    @endif
+                    <table class="report-table">
+                        <thead>
+                            <tr>
+                                <th style="width: 40%;">DESCUENTO</th>
+                                <th style="width: 25%;">PORCENTAJE</th>
+                                <th style="width: 35%;">PAGOS APLICADOS</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @if (!empty($paymentDiscounts) && count($paymentDiscounts) > 0)
+                                @foreach ($paymentDiscounts as $item)
+                                    <tr>
+                                        <td>{{ $item->name }}</td>
+                                        <td>{{ $item->percentage }}%</td>
+                                        <td>{{ $item->total }}</td>
+                                    </tr>
+                                @endforeach
+                            @endif
+                            @if (empty($paymentDiscounts) || count($paymentDiscounts) === 0)
+                                <tr>
+                                    <td colspan="3">No hay pagos registrados con descuentos para el periodo seleccionado.</td>
+                                </tr>
+                            @endif
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="report-footer">
+                <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                <span class="text_infoE"> | </span>
+                <span class="text_infoE page-number">Página 2 de {{ $totalPages }}</span>
+                <span class="text_infoE"> | </span>
+                <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+            </div>
+        </div>
+        <div class="report-page page-break">
+            <div class="page-bg">
+                <img src="file://{{ $verticalBgPath }}" alt="Background">
+            </div>
+            <div class="page-content">
+                <div class="page-inner">
+                    <div class="inner-page-header">
+                        <p class="inner-page-committee">
+                            COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ mb_strtoupper($locality->name ?? '') }}, {{ mb_strtoupper($locality->municipality ?? '') }}, {{ mb_strtoupper($locality->state ?? '') }}
+                        </p>
+                        <p class="inner-page-title">PANEL DE DESCUENTOS</p>
+                    </div>
+                    <div class="inner-card-title">3. DESCUENTOS APLICADOS EN DEUDAS</div>
+                    @if($debtMonthLabel || $debtYear)
+                        <div class="filter-badge">
+                            Filtro aplicado: {{ $debtMonthLabel ? $debtMonthLabel : 'Todos los meses' }} {{ $debtYear ? $debtYear : '' }}
+                        </div>
+                    @endif
+                    @if(!empty($chartImages['debtChart']))
+                        <div class="chart-container">
+                            <img src="{{ $chartImages['debtChart'] }}" alt="Descuentos aplicados en deudas">
+                        </div>
+                    @endif
+                    <table class="report-table">
+                        <thead>
+                            <tr>
+                                <th style="width: 40%;">DESCUENTO</th>
+                                <th style="width: 25%;">PORCENTAJE</th>
+                                <th style="width: 35%;">DEUDAS APLICADAS</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @if (!empty($debtDiscounts) && count($debtDiscounts) > 0)
+                                @foreach ($debtDiscounts as $item)
+                                    <tr>
+                                        <td>{{ $item->name }}</td>
+                                        <td>{{ $item->percentage }}%</td>
+                                        <td>{{ $item->total }}</td>
+                                    </tr>
+                                @endforeach
+                            @endif
+                            @if (empty($debtDiscounts) || count($debtDiscounts) === 0)
+                                <tr>
+                                    <td colspan="3">No hay deudas registradas con descuentos para el periodo seleccionado.</td>
+                                </tr>
+                            @endif
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="report-footer">
+                <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                <span class="text_infoE"> | </span>
+                <span class="text_infoE page-number">Página 3 de {{ $totalPages }}</span>
+                <span class="text_infoE"> | </span>
+                <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+            </div>
+        </div>
+    </body>
+</html>

--- a/resources/views/reports/discountDashboardReport.blade.php
+++ b/resources/views/reports/discountDashboardReport.blade.php
@@ -3,7 +3,7 @@
     $verticalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundVertical')
         ? $locality->getFirstMedia('pdfBackgroundVertical')->getPath()
         : public_path('img/backgroundReport.png');
-    $totalPages = 3;
+    $currentPage = 0;
 @endphp
 <!DOCTYPE html>
 <html>
@@ -216,6 +216,7 @@
         </style>
     </head>
     <body>
+        @php $currentPage++; @endphp
         <div class="report-page">
             <div class="page-bg">
                 <img src="file://{{ $verticalBgPath }}" alt="Background">
@@ -226,8 +227,7 @@
                         <div class="first-page-logo-row">
                             <div class="first-page-logo">
                                 @if ($locality && $locality->hasMedia('localityGallery'))
-                                    <img src="{{ $locality->getFirstMediaUrl('localityGallery') }}"
-                                        alt="Photo of {{ $locality->name }}">
+                                    <img src="{{ $locality->getFirstMediaUrl('localityGallery') }}" alt="Photo of {{ $locality->name }}">
                                 @endif
                                 @if (!$locality || !$locality->hasMedia('localityGallery'))
                                     <img src="{{ public_path('img/localityDefault.png') }}" alt="Default Photo">
@@ -257,8 +257,8 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @if (!empty($discountsSummary) && count($discountsSummary) > 0)
-                                @foreach ($discountsSummary as $item)
+                            @if ($firstPageSummary->isNotEmpty())
+                                @foreach ($firstPageSummary as $item)
                                     <tr>
                                         <td>{{ $item->id }}</td>
                                         <td>{{ $item->name }}</td>
@@ -267,7 +267,7 @@
                                     </tr>
                                 @endforeach
                             @endif
-                            @if (empty($discountsSummary) || count($discountsSummary) === 0)
+                            @if ($firstPageSummary->isEmpty())
                                 <tr>
                                     <td colspan="4">No hay datos de descuentos registrados.</td>
                                 </tr>
@@ -279,12 +279,59 @@
             <div class="report-footer">
                 <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
                 <span class="text_infoE"> | </span>
-                <span class="text_infoE page-number">Página 1 de {{ $totalPages }}</span>
+                <span class="text_infoE page-number">Página {{ $currentPage }} de {{ $totalPages }}</span>
                 <span class="text_infoE"> | </span>
                 <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
                 <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
             </div>
         </div>
+        @foreach ($otherPagesSummary as $chunk)
+            @php $currentPage++; @endphp
+            <div class="report-page page-break">
+                <div class="page-bg">
+                    <img src="file://{{ $verticalBgPath }}" alt="Background">
+                </div>
+                <div class="page-content">
+                    <div class="page-inner">
+                        <div class="inner-page-header">
+                            <p class="inner-page-committee">
+                                COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ mb_strtoupper($locality->name ?? '') }}, {{ mb_strtoupper($locality->municipality ?? '') }}, {{ mb_strtoupper($locality->state ?? '') }}
+                            </p>
+                            <p class="inner-page-title">PANEL DE DESCUENTOS</p>
+                        </div>
+                        <table class="report-table">
+                            <thead>
+                                <tr>
+                                    <th style="width: 15%;">ID</th>
+                                    <th style="width: 35%;">DESCUENTO</th>
+                                    <th style="width: 20%;">PORCENTAJE</th>
+                                    <th style="width: 30%;">TOTAL DE USOS</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($chunk as $item)
+                                    <tr>
+                                        <td>{{ $item->id }}</td>
+                                        <td>{{ $item->name }}</td>
+                                        <td>{{ $item->percentage }}%</td>
+                                        <td>{{ $item->total_uses }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="report-footer">
+                    <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                    <span class="text_infoE"> | </span>
+                    <span class="text_infoE page-number">Página {{ $currentPage }} de {{ $totalPages }}</span>
+                    <span class="text_infoE"> | </span>
+                    <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                    <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+                </div>
+            </div>
+        @endforeach
+        @php $currentPage++; @endphp
         <div class="report-page page-break">
             <div class="page-bg">
                 <img src="file://{{ $verticalBgPath }}" alt="Background">
@@ -317,8 +364,8 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @if (!empty($paymentDiscounts) && count($paymentDiscounts) > 0)
-                                @foreach ($paymentDiscounts as $item)
+                            @if ($firstPagePayments->isNotEmpty())
+                                @foreach ($firstPagePayments as $item)
                                     <tr>
                                         <td>{{ $item->name }}</td>
                                         <td>{{ $item->percentage }}%</td>
@@ -326,7 +373,7 @@
                                     </tr>
                                 @endforeach
                             @endif
-                            @if (empty($paymentDiscounts) || count($paymentDiscounts) === 0)
+                            @if ($firstPagePayments->isEmpty())
                                 <tr>
                                     <td colspan="3">No hay pagos registrados con descuentos para el periodo seleccionado.</td>
                                 </tr>
@@ -338,12 +385,57 @@
             <div class="report-footer">
                 <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
                 <span class="text_infoE"> | </span>
-                <span class="text_infoE page-number">Página 2 de {{ $totalPages }}</span>
+                <span class="text_infoE page-number">Página {{ $currentPage }} de {{ $totalPages }}</span>
                 <span class="text_infoE"> | </span>
                 <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
                 <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
             </div>
         </div>
+        @foreach ($otherPagesPayments as $chunk)
+            @php $currentPage++; @endphp
+            <div class="report-page page-break">
+                <div class="page-bg">
+                    <img src="file://{{ $verticalBgPath }}" alt="Background">
+                </div>
+                <div class="page-content">
+                    <div class="page-inner">
+                        <div class="inner-page-header">
+                            <p class="inner-page-committee">
+                                COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ mb_strtoupper($locality->name ?? '') }}, {{ mb_strtoupper($locality->municipality ?? '') }}, {{ mb_strtoupper($locality->state ?? '') }}
+                            </p>
+                            <p class="inner-page-title">PANEL DE DESCUENTOS</p>
+                        </div>
+                        <table class="report-table">
+                            <thead>
+                                <tr>
+                                    <th style="width: 40%;">DESCUENTO</th>
+                                    <th style="width: 25%;">PORCENTAJE</th>
+                                    <th style="width: 35%;">PAGOS APLICADOS</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($chunk as $item)
+                                    <tr>
+                                        <td>{{ $item->name }}</td>
+                                        <td>{{ $item->percentage }}%</td>
+                                        <td>{{ $item->total }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="report-footer">
+                    <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                    <span class="text_infoE"> | </span>
+                    <span class="text_infoE page-number">Página {{ $currentPage }} de {{ $totalPages }}</span>
+                    <span class="text_infoE"> | </span>
+                    <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                    <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+                </div>
+            </div>
+        @endforeach
+        @php $currentPage++; @endphp
         <div class="report-page page-break">
             <div class="page-bg">
                 <img src="file://{{ $verticalBgPath }}" alt="Background">
@@ -376,8 +468,8 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @if (!empty($debtDiscounts) && count($debtDiscounts) > 0)
-                                @foreach ($debtDiscounts as $item)
+                            @if ($firstPageDebts->isNotEmpty())
+                                @foreach ($firstPageDebts as $item)
                                     <tr>
                                         <td>{{ $item->name }}</td>
                                         <td>{{ $item->percentage }}%</td>
@@ -385,7 +477,7 @@
                                     </tr>
                                 @endforeach
                             @endif
-                            @if (empty($debtDiscounts) || count($debtDiscounts) === 0)
+                            @if ($firstPageDebts->isEmpty())
                                 <tr>
                                     <td colspan="3">No hay deudas registradas con descuentos para el periodo seleccionado.</td>
                                 </tr>
@@ -397,11 +489,55 @@
             <div class="report-footer">
                 <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
                 <span class="text_infoE"> | </span>
-                <span class="text_infoE page-number">Página 3 de {{ $totalPages }}</span>
+                <span class="text_infoE page-number">Página {{ $currentPage }} de {{ $totalPages }}</span>
                 <span class="text_infoE"> | </span>
                 <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
                 <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
             </div>
         </div>
+        @foreach ($otherPagesDebts as $chunk)
+            @php $currentPage++; @endphp
+            <div class="report-page page-break">
+                <div class="page-bg">
+                    <img src="file://{{ $verticalBgPath }}" alt="Background">
+                </div>
+                <div class="page-content">
+                    <div class="page-inner">
+                        <div class="inner-page-header">
+                            <p class="inner-page-committee">
+                                COMITÉ DEL SISTEMA DE AGUA POTABLE DE {{ mb_strtoupper($locality->name ?? '') }}, {{ mb_strtoupper($locality->municipality ?? '') }}, {{ mb_strtoupper($locality->state ?? '') }}
+                            </p>
+                            <p class="inner-page-title">PANEL DE DESCUENTOS</p>
+                        </div>
+                        <table class="report-table">
+                            <thead>
+                                <tr>
+                                    <th style="width: 40%;">DESCUENTO</th>
+                                    <th style="width: 25%;">PORCENTAJE</th>
+                                    <th style="width: 35%;">DEUDAS APLICADAS</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($chunk as $item)
+                                    <tr>
+                                        <td>{{ $item->name }}</td>
+                                        <td>{{ $item->percentage }}%</td>
+                                        <td>{{ $item->total }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="report-footer">
+                    <a class="text_infoE" href="https://aquacontrol.rootheim.com/"><strong>AquaControl</strong></a>
+                    <span class="text_infoE"> | </span>
+                    <span class="text_infoE page-number">Página {{ $currentPage }} de {{ $totalPages }}</span>
+                    <span class="text_infoE"> | </span>
+                    <a class="text_infoE footer-branding" href="https://rootheim.com/">powered by<strong> Root Heim Company </strong></a>
+                    <img src="{{ public_path('img/rootheim.png') }}" width="20" height="15" alt="Root Heim" class="footer-branding">
+                </div>
+            </div>
+        @endforeach
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -122,6 +122,7 @@ Route::group(['middleware' => ['auth', CheckSubscription::class]], function () {
         Route::get('/discount-dashboard', [DiscountDashboardController::class, 'index'])->name('discountDashboard.index');
         Route::get('/discount-dashboard/payment-chart', [DiscountDashboardController::class, 'getPaymentChart'])->name('discountDashboard.getPaymentChart');
         Route::get('/discount-dashboard/debt-chart', [DiscountDashboardController::class, 'getDebtChart'])->name('discountDashboard.getDebtChart');
+        Route::post('/discount-dashboard/report', [DiscountDashboardController::class, 'generateReport'])->name('discountDashboard.generateReport');
     });
 
     Route::group(['middleware' => ['can:viewDebts']], function () {


### PR DESCRIPTION
## Description of Changes

Implemented the **"Generar reporte"** (Generate Report) button in the *Discount Panel* module, mirroring the design and functionality from the *Advance Payments Panel*. Clicking the button automatically generates a PDF report displaying module charts along with their corresponding data tables.

### Key Changes:
- **UI:** Added the "Generar reporte" button to the Discount Panel matching the style and flow of the Advance Payments module.
- **Report Generation:** Set up automatic PDF export handling chart images and rendering their corresponding summary tables.
- **PDF Layout:** Formatted the Blade template to ensure proper branding alignment (left-aligned logo, title block position relative to background design, and clean `@if` control flow).