### PR TITLE
feat(debts): display discount information in debt details modal

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -35,9 +35,12 @@ class DebtController extends Controller
                         ->orWhereRaw("CONCAT(name, ' ', last_name) LIKE ?", ["%{$search}%"]);
                 });
             })
-            ->with(['waterConnections.debts' => function ($query) {
-                $query->where('status', '!=', 'paid');
-            }])
+            ->with([
+                'waterConnections.debts.discount',
+                'waterConnections.debts' => function ($query) {
+                    $query->where('status', '!=', 'paid');
+                }
+            ])
             ->orderByDesc(
                 Debt::select('debts.created_at')
                     ->join('water_connections', 'water_connections.id', '=', 'debts.water_connection_id')
@@ -305,9 +308,12 @@ class DebtController extends Controller
                         ->orWhere('id', 'like', "%{$search}%");
                 });
             })
-            ->with(['debts' => function ($query) {
-                $query->orderBy('created_at', 'desc');
-            }])
+            ->with([
+                'debts.discount',
+                'debts' => function ($query) {
+                    $query->orderBy('created_at', 'desc');
+                }
+            ])
             ->orderBy('created_at', 'desc')
             ->paginate(10);
         return view('viewCustomerDebts.index', compact('waterConnections', 'hasOpenPay', 'locality', 'customer'));

--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -96,6 +96,12 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>Descuento</label>
+                                                <inputtype="text"class="form-control"value="{{ $waterConnectionDebt->discount ? $waterConnectionDebt->discount->name . ' - ' . $waterConnectionDebt->discount->percentage . '%' : 'Sin descuento' }}"readonly>
+                                            </div>
+                                        </div>
                                         <div class="col-lg-6">
                                             <div class="form-group">
                                                 <label>Fecha de Inicio</label>


### PR DESCRIPTION
## Description

### Summary

Implemented the display of discount information within the debt details modal, allowing users to identify whether a debt has an applied discount and view its details directly from the debt information view.

### Changes Made

- Added the **Discount** field to the debt information modal.
- Integrated the `discount` relationship to retrieve the discount information associated with the debt.
- Displayed the discount name and percentage when a discount is applied.
- Added a visual fallback showing **"No discount"** when the debt does not have an associated discount.
- Updated the data loading process to include discount information in the view.

### Expected Result

- Users can view applied discounts directly from the debt details modal.
- No additional navigation is required to check discount information.
- The displayed information follows the existing style and structure of the debts module.

### Evidence

The debt details modal now displays:

- **Discount:** Discount name and applied percentage when available.
- **Discount:** No discount when the debt does not have an associated discount.

### Change Type

✅ New feature  
✅ Improved debt information visibility