### PR TITLE
Remove problematic DataTable initialization for debt registration

### DIFF
--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -86,7 +86,7 @@
                                             @include('debts.showDebts', ['debt' => (object)['waterConnection' => (object)['customer' => $customer]]])
                                         @empty
                                             <tr>
-                                                <td colspan="5">No hay deudas registradas.</td>
+                                                <td colspan="4">No hay deudas registradas.</td>
                                             </tr>
                                         @endforelse
                                     </tbody>
@@ -122,13 +122,7 @@
     });
 
     $(document).ready(function() {
-        $('#debts').DataTable({
-            responsive: true,
-            paging: false,
-            info: false,
-            searching: false
-        });
-
+        console.log('Debts JS cargado');
         var successMessage = "{{ session('success') }}";
         var errorMessage = "{{ session('error') }}";
         if (successMessage) {


### PR DESCRIPTION
## Changes Made

- Updated table cell in `debts/index.blade.php`:
  - Changed `colspan="5"` to `colspan="4"` to match the correct number of columns.

- Simplified JavaScript initialization:
  - Removed DataTable setup block that was causing issues when registering debts.
  - Replaced with a simple `console.log('Debts JS cargado');` for debugging purposes.