### PR TITLE
feat(debts): display discount information in debt details modal

### DIFF
--- a/app/Http/Controllers/GeneralExpenseController.php
+++ b/app/Http/Controllers/GeneralExpenseController.php
@@ -278,7 +278,7 @@ class GeneralExpenseController extends Controller
                 'start' => $currentStart->toDateString(),
                 'end' => $currentEnd->toDateString(),
                 'dailyGains' => $dailyGains,
-                'weekTotal' => $weekTotal
+                'weekTotal' => $weekGains
             ];
 
             $currentStart = $currentEnd->copy()->addDay();

--- a/resources/views/debts/show.blade.php
+++ b/resources/views/debts/show.blade.php
@@ -99,7 +99,7 @@
                                         <div class="col-md-12">
                                             <div class="form-group">
                                                 <label>Descuento</label>
-                                                <inputtype="text"class="form-control"value="{{ $waterConnectionDebt->discount ? $waterConnectionDebt->discount->name . ' - ' . $waterConnectionDebt->discount->percentage . '%' : 'Sin descuento' }}"readonly>
+                                                <input type="text"class="form-control"value="{{ $waterConnectionDebt->discount ? $waterConnectionDebt->discount->name . ' - ' . $waterConnectionDebt->discount->percentage . '%' : 'Sin descuento' }}"readonly>
                                             </div>
                                         </div>
                                         <div class="col-lg-6">


### PR DESCRIPTION
## Description

### Summary

Fixed two issues related to debt details and the weekly gains report. The weekly gains report now uses the correct weekly total value, and the discount field in the debt details view is rendered properly.

### Changes Made

- Fixed the weekly gains report by assigning the calculated `weekGains` value to the `weekTotal` field.
- Corrected the HTML syntax of the discount input field in the debt details view.
- Ensured the assigned discount name and percentage are displayed correctly in read-only mode.

### Files Modified

- `app/Http/Controllers/GeneralExpenseController.php`
  - Replaced the undefined `$weekTotal` variable with the calculated `$weekGains` value in the weekly gains report.

- `resources/views/debts/show.blade.php`
  - Fixed the malformed `<input>` element so the discount field is displayed correctly.

### Testing

- Verified that the weekly gains report is generated without the `Undefined variable $weekTotal` error.
- Confirmed that the weekly totals are calculated and displayed correctly.
- Verified that the discount field is rendered correctly in the debt details view.
- Confirmed that debts with and without discounts display the expected information.