### PR TITLE
Block 'Edit discount' button when payments or debts exist

### DIFF
--- a/app/Models/Discount.php
+++ b/app/Models/Discount.php
@@ -43,7 +43,12 @@ class Discount extends Model
 
     public function hasDependencies()
     {
-        return $this->payments()->exists() || DiscountHistory::where('discount_id', $this->id) ->where('module', 'debt') ->exists();
+        return $this->payments()->exists() || $this->debts()->exists() || DiscountHistory::where('discount_id', $this->id)->where('module', 'debt')->exists();
+    }
+
+    public function debts()
+    {
+        return $this->hasMany(Debt::class);
     }
 
     public function isProtected(): bool

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -323,9 +323,7 @@
                                 </div>
                                 <div class="col-12 col-md-auto mt-2 mt-md-0 ms-md-auto d-flex align-items-center">
                                     @if($remindersSentToday)
-                                        <div class="text-warning d-flex align-items-center" title="Los recordatorios ya fueron enviados el día de hoy">
-                                            <i class="fas fa-exclamation-circle fa-lg mr-2"></i>
-                                            <span class="font-weight-bold">Ya se enviaron recordatorios</span>
+                                        <div class="text-warning d-flex align-items-center" title="Los recordatorios ya fueron enviados el día de hoy">      
                                         </div>
                                     @else
                                         <form action="{{ route('dashboard.sendEmailsForDebtsExpiringSoon') }}" method="POST" class="w-100" id="sendRemindersForm">
@@ -337,6 +335,12 @@
                                         </form>
                                     @endif
                                 </div>
+                                @if($remindersSentToday)
+                                <div class="col-12 text-left text-warning mt-1">
+                                    <i class="fas fa-exclamation-circle fa-lg mr-2"></i>
+                                    <span class="font-weight-bold">Puedes enviar mensajes después de 24 horas. Ya se enviaron recordatorios.</span>
+                                </div>
+                                @endif
                             </div>
                         </div>
                         <div class="card-box table-responsive">

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -69,6 +69,7 @@
                                     </thead>
                                     <tbody>
                                         @forelse($discounts as $discount)
+                                            @php $hasDependencies = $discount->hasDependencies(); @endphp
                                             <tr>
                                                 <td>{{ $discount->id }}</td>
                                                 <td>
@@ -86,17 +87,17 @@
 
                                                         @if (!$discount->isProtected())
                                                             @can('editDiscount')
-                                                            <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="Editar Registro" data-target="#edit{{ $discount->id }}">
+                                                            <button type="button" class="btn btn-warning mr-2" data-toggle="modal" title="{{ $hasDependencies ? 'Edición no permitida: Existen pagos o deudas asociados con este descuento.' : 'Editar Registro' }}" data-target="#edit{{ $discount->id }}" {{ $hasDependencies ? 'disabled' : '' }}>
                                                                 <i class="fas fa-edit"></i>
                                                             </button>
                                                             @endcan
                                                             @can('deleteDiscount')
-                                                            @if ($discount->hasDependencies())
-                                                                <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen pagos asociados con este descuento." disabled>
+                                                            @if ($hasDependencies)
+                                                                <button type="button" class="btn btn-secondary mr-2" title="Eliminación no permitida: Existen pagos o deudas asociados con este descuento." disabled>
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>
                                                             @endif
-                                                            @if (! $discount->hasDependencies())
+                                                            @if (! $hasDependencies)
                                                                 <button type="button" class="btn btn-danger mr-2" title="Eliminar Registro" data-toggle="modal" data-target="#deleteDiscount{{ $discount->id }}">
                                                                     <i class="fas fa-trash-alt"></i>
                                                                 </button>


### PR DESCRIPTION
## 📝 Description of Changes 
- Added a new relationship `debts()` in the `Discount` model to link discounts with associated debts.
- Updated the `hasDependencies()` method to check not only for payments but also for debts and historical records, ensuring discounts cannot be edited or deleted if dependencies exist.
- Modified the Blade templates (`dashboard.blade.php` and `discounts/index.blade.php`) to:
  - Disable the **Edit discount** button when payments or debts are associated.
  - Show a tooltip message: *"Edition not allowed: Payments or debts are associated with this discount."*
  - Prevent deletion of discounts with dependencies, displaying a clear warning message.
  - Add a user-facing message indicating: *"You can send messages after 24 hours. Reminders have already been sent."*