### PR TITLE
The total data appears correctly in the weekly earnings report

### DIFF
--- a/app/Http/Controllers/GeneralExpenseController.php
+++ b/app/Http/Controllers/GeneralExpenseController.php
@@ -248,6 +248,8 @@ class GeneralExpenseController extends Controller
 
             $day = $currentStart->copy();
             while ($day->lte($currentEnd)) {
+                $gains = null;
+
                 if ($day->between($startDate, $endDate)) {
                     $expenses = GeneralExpense::where('locality_id', $authUser->locality_id)
                         ->whereDate('expense_date', $day->toDateString())
@@ -260,8 +262,6 @@ class GeneralExpenseController extends Controller
                         ->sum('amount');
                     $earnings = $payments + $generalEarnings;
                     $gains = $earnings - $expenses;
-                } else {
-                    $gains = null;
                 }
 
                 $dailyGains[] = [
@@ -271,7 +271,11 @@ class GeneralExpenseController extends Controller
                 $day->addDay();
             }
 
-            $weekGains = array_sum(array_filter($dailyGains, 'is_numeric'));
+            $weekGains = collect($dailyGains)
+                ->filter(function ($item) use ($startDate, $endDate) {
+                    return $item['date']->between($startDate, $endDate) && $item['amount'] !== null;
+                })->sum('amount');
+
             $totalPeriodGains += $weekGains;
 
             $weeks[] = [


### PR DESCRIPTION
Refactored the weeklyGainsReport method to improve clarity and accuracy in weekly gains calculation.

🔄 Key Changes
Explicitly initialized $gains as null at the start of the loop.

Removed redundant else block that reassigned $gains to null.

Replaced array_sum(array_filter(...)) with a Laravel collection pipeline:

Filters daily gains to include only dates within the selected period.

Excludes entries with null amounts.

Sums valid amounts for weekly totals.
