### PR TITLE
adjust flexbox layout to align button to the right

### DIFF
--- a/resources/views/employeePositions/index.blade.php
+++ b/resources/views/employeePositions/index.blade.php
@@ -9,9 +9,8 @@
             <div class="x_panel">
                 <div class="x_title">
                     <h2>Departamentos de Empleados</h2>
-                    <div class="row mb-2">
-                        <div class="col-lg-12">
-                            <div class="col-12 col-lg-8 mb-3">
+                    <div class="row mb-3 align-items-center">
+                            <div class="col-12 col-md-8 col-lg-8 mb-2 mb-md-0">
                                 <form method="GET" action="{{ route('employeePositions.index') }}">
                                     <div class="input-group">
                                         <input type="text" name="search" class="form-control" placeholder="Buscar por Nombre, Descripción" value="{{ request('search') }}">
@@ -23,7 +22,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="col-12 col-lg-4 mb-3 text-lg-right">
+                            <div class="col-12 col-md-4 mb-3 d-flex justify-content-md-end justify-content-center">
                                 <button type="button" class="btn btn-success btn-block btn-lg-inline" data-toggle="modal" data-target="#createPositionModal">
                                     <i class="fa fa-plus"></i>
                                     <span class="d-none d-md-inline">


### PR DESCRIPTION
Fixed the Bootstrap grid layout structure in the employeePositions.index view. Previously, the "Registrar Posición" button was constrained within a partial column and failed to align completely to the right side of the interface.

Changes made:

Restructured the <div class="row"> container by applying Flexbox alignment (d-flex justify-content-end align-items-center).

Removed the unnecessary col-lg-12 wrapper that was breaking the grid layout.

Properly split the row layout between the search form (col-md-8) and the primary action (col-md-4).

Cleaned up obsolete and non-existent CSS classes (align-right, btn-lg-inline).