### PR TITLE
adjust date range using startOfDay and endOfDay to include current da…

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -490,8 +490,8 @@ class PaymentController extends Controller
     public function clientPaymentReport(Request $request)
     {
         $customerId = $request->input('customerId');
-        $startDate = $request->input('startDate');
-        $endDate = $request->input('endDate');
+        $startDate = \Carbon\Carbon::parse($request->input('startDate'))->startOfDay();
+        $endDate = \Carbon\Carbon::parse($request->input('endDate'))->endOfDay();
         $customer = Customer::with('user')->findOrFail($customerId);
         $authUser = auth()->user();
 
@@ -514,8 +514,8 @@ class PaymentController extends Controller
     {
         $customerId = $request->input('waterCustomerId');
         $waterConnectionId = $request->input('waterConnectionId');
-        $startDate = $request->input('waterStartDate');
-        $endDate = $request->input('waterEndDate');
+        $startDate = \Carbon\Carbon::parse($request->input('waterStartDate'))->startOfDay();
+        $endDate = \Carbon\Carbon::parse($request->input('waterEndDate'))->endOfDay();
 
         $customer = Customer::with('user')->findOrFail($customerId);
         $authUser = auth()->user();


### PR DESCRIPTION
Fixed an issue in payment report generation (`clientPaymentReport` and `waterConnectionPaymentsReport`) where selecting the same date for both start and end dates (e.g., today) resulted in an empty report despite existing records.

### Root Cause
Dates passed in `YYYY-MM-DD` format were interpreted by the database as `00:00:00`. Consequently, any payment registered after the first second of the day was excluded from the SQL query filter.

### Changes Made
- Applied `Carbon::parse()->startOfDay()` to `startDate`.
- Applied `Carbon::parse()->endOfDay()` to `endDate` to extend the query range up to `23:59:59`, ensuring full-day coverage.