### PR TITLE
fix: preserve category colors and remove duplicate debt button

### DIFF
--- a/resources/views/debts/index.blade.php
+++ b/resources/views/debts/index.blade.php
@@ -27,17 +27,12 @@
                                         <i class="fa fa-plus"></i>
                                         Asignar a Todos
                                     </button>
-                                    <button type="button" class="btn btn-success mx-1" data-toggle="modal"
-                                            title="Registrar Deuda" data-target="#createDebt">
+                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mr-lg-2 w-100 w-lg-auto" data-toggle="modal" title="Registrar Deuda" data-target="#createDebt">
                                         <i class="fa fa-plus"></i>
                                         <span class="d-none d-lg-inline">Registrar Deuda</span>
-                                        <span class="d-inline d-lg-none">Registrar Deuda</span>
+                                        <span class="d-inline d-lg-none">Crear Deuda</span>
                                     </button>
-                                    <button type="button" class="btn btn-success mb-2 mb-lg-0 mr-lg-2 w-100 w-lg-auto" data-toggle="modal" title="Crear Deuda" data-target="#createDebt">
-                                        <i class="fa fa-plus"></i>
-                                        Crear Deuda
-                                    </button>
-                                    <a class="btn btn-secondary w-100 w-lg-auto" target="_blank" title="Clientes con deudas" href="{{ route('report.with-debts') }}">
+                                    <a class="btn btn-secondary mb-2 mb-lg-0 w-100 w-lg-auto" target="_blank" title="Clientes con deudas" href="{{ route('report.with-debts') }}">
                                         <i class="fas fa-file-pdf"></i>
                                         Clientes con deudas
                                     </a>

--- a/resources/views/reports/generateIncidentCategoyListReport.blade.php
+++ b/resources/views/reports/generateIncidentCategoyListReport.blade.php
@@ -165,6 +165,23 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                 font-size: 14pt;
                 text-align: center;
             }
+            .oval_color {
+                display: inline-block;
+                background-color: #6c757d;
+                color: #fff;
+                font-weight: bold;
+                font-size: 9pt;
+                border-radius: 18px;
+                padding: 4px 12px;
+                margin: 0 2px;
+                min-width: 90px;
+                max-width: 150px;
+                text-align: center;
+                box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+                line-height: 1.2;
+                word-wrap: break-word;
+                white-space: normal;
+            }
         </style>
     </head>
     <body>
@@ -202,7 +219,11 @@ $horizontalBgPath = $locality && $locality->getFirstMedia('pdfBackgroundHorizont
                     @foreach ($incidentCategories as $incidentCategorie)
                         <tr>
                             <td class="text_center">{{ $incidentCategorie->id }}</td>
-                            <td class="text_center">{{ $incidentCategorie->name }}</td>
+                            <td class="text_center" style="vertical-align:middle;">
+                                <span class="oval_color" style="background-color: {{ pdf_color($incidentCategorie->color ?? 'bg-secondary') }} !important;">
+                                    {{ $incidentCategorie->name }}
+                                </span>
+                            </td>
                             <td class="text_center">{{ $incidentCategorie->description }}</td>
                         </tr>
                     @endforeach


### PR DESCRIPTION
## 📝 Description
This PR improves the incident category reporting and debt UI consistency by aligning category badge rendering with the index view and removing the duplicated debt creation control.
__________________________
### 🚀 Key Changes
**🎨 Report Styling**
[generateIncidentCategoyListReport.blade.php](vscode-file://vscode-app/c:/Users/Alexis%20Hernandez/AppData/Local/Programs/Microsoft%20VS%20Code/c2d1b13fdc/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added oval_color badge styling for the incident category name.
Rendered category names as colored badges using pdf_color(...).
Made the report badge appearance consistent with the index/category list.
**💳 Debt Module**
[index.blade.php](vscode-file://vscode-app/c:/Users/Alexis%20Hernandez/AppData/Local/Programs/Microsoft%20VS%20Code/c2d1b13fdc/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Removed the duplicate Crear Deuda button.
Standardized responsive button spacing and alignment so action buttons are visually consistent.
_____________________
### 🧪 Testing Checklist
Verify the Deudas page shows only one debt creation button and that it is aligned with the other controls.
Generate the incident category report and confirm category names are displayed as colored badges.
Confirm badge colors in the report match the category color logic used on the index view.