### PR TITLE
Add formal report and update locality logic for conditional rendering

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -297,7 +297,7 @@ class CustomerController extends Controller
             ->get();
 
         $customersPerFirstPage = 26;
-        $customersPerNextPages = 40;
+        $customersPerNextPages = 30;
 
         $firstPageCustomers = $customers->take($customersPerFirstPage);
         $remainingCustomers = $customers->slice($customersPerFirstPage);
@@ -305,7 +305,11 @@ class CustomerController extends Controller
 
         $totalPages = 1 + ceil(max(0, $customers->count() - $customersPerFirstPage) / $customersPerNextPages);
 
-        $pdf = PDF::loadView('reports.pdfCustomers', compact(
+        $view = $authUser->locality && $authUser->locality->use_new_report_design
+            ? 'reports.formalReports.customersFormal'
+            : 'reports.pdfCustomers';
+
+        $pdf = PDF::loadView($view, compact(
             'authUser',
             'firstPageCustomers',
             'otherPagesCustomers',


### PR DESCRIPTION

This update introduces a new formal report and modifies the logic in the `Locality` model to conditionally render report views based on locality configuration.

- Updated pagination logic for customer reports:
  - Changed `customersPerNextPages` from 40 to 30.
- Introduced conditional view selection in PDF generation:
  - If `use_new_report_design` is enabled, the system uses `reports.formalReports.customersFormal`.
  - Otherwise, it falls back to `reports.pdfCustomers`.

Localities with the new configuration will now correctly display the newly created formal reports, while others continue to use the standard report design without disruption.
