### PR TITLE
Create formal design for annual expense and income reports

### DIFF
--- a/app/Http/Controllers/GeneralExpenseController.php
+++ b/app/Http/Controllers/GeneralExpenseController.php
@@ -229,7 +229,11 @@ class GeneralExpenseController extends Controller
             $totalExpenses += $expenses;
         }
 
-        $pdf = PDF::loadView('reports.annualExpenses', compact('monthlyExpenses', 'totalExpenses', 'year', 'authUser'))
+        $view = $authUser->locality && $authUser->locality->use_new_report_design
+            ? 'reports.formalReports.annualExpensesFormal'
+            : 'reports.annualExpenses';
+
+        $pdf = PDF::loadView($view, compact('monthlyExpenses', 'totalExpenses', 'year', 'authUser'))
             ->setPaper('A4', 'portrait');
 
         return $pdf->stream('annual_expenses_' . $year . '.pdf');

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -376,7 +376,11 @@ class PaymentController extends Controller
             ->where('locality_id', $authUser->locality_id)
             ->get();
 
-        $pdf = PDF::loadView('reports.annualEarnings', compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser', 'payments'))
+        $view = $authUser->locality && $authUser->locality->use_new_report_design
+            ? 'reports.formalReports.annualEarningsFormal'
+            : 'reports.annualEarnings';
+
+        $pdf = PDF::loadView($view, compact('monthlyEarnings', 'totalEarnings', 'year', 'authUser', 'payments'))
             ->setPaper('A4', 'portrait');
 
         return $pdf->stream('annual_earnings_' . $year . '.pdf');

--- a/resources/views/reports/formalReports/annualEarningsFormal.blade.php
+++ b/resources/views/reports/formalReports/annualEarningsFormal.blade.php
@@ -1,0 +1,101 @@
+@php
+    $authUser = $authUser ?? auth()->user();
+    $locality = $authUser->locality ?? null;
+    $reportTitle = $reportTitle ?? 'INGRESOS DEL ' . ($year ?? now()->year);
+    $generatedAt = $generatedAt ?? now()->format('d/m/Y H:i');
+    $generatedBy = $generatedBy ?? trim(($authUser->name ?? '') . ' ' . ($authUser->last_name ?? ''));
+    $localityLine = $locality
+        ? 'LOCALIDAD DE ' . mb_strtoupper($locality->name ?? '-') . ', ' . mb_strtoupper($locality->municipality ?? '-') . ', ' . mb_strtoupper($locality->state ?? '-')
+        : null;
+    $logoPath = ($locality && $locality->hasMedia('localityGallery'))
+        ? $locality->getFirstMedia('localityGallery')->getPath()
+        : public_path('img/localityDefault.png');
+@endphp
+
+@extends('reports.layouts.base')
+
+@section('title', 'REPORTE ANUAL DE INGRESOS')
+
+@push('styles')
+    <style>
+        .report-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 18px;
+            border: 1px solid #d9d9d9;
+            background: #fff;
+        }
+
+        .report-table th,
+        .report-table td {
+            border: 1px solid #d9d9d9;
+            padding: 8px 10px;
+            font-size: 11px;
+            text-align: center;
+        }
+
+        .report-table th {
+            background: #f4f4f4;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .right {
+            text-align: right;
+        }
+
+        .period-total {
+            margin-top: 25px;
+            padding: 10px;
+            border: 1px solid #111;
+            background-color: #f2f2f2;
+            text-align: right;
+            font-weight: bold;
+            font-size: 13px;
+        }
+    </style>
+@endpush
+
+@section('content')
+    @php
+        $months = [
+            1  => 'Enero',
+            2  => 'Febrero',
+            3  => 'Marzo',
+            4  => 'Abril',
+            5  => 'Mayo',
+            6  => 'Junio',
+            7  => 'Julio',
+            8  => 'Agosto',
+            9  => 'Septiembre',
+            10 => 'Octubre',
+            11 => 'Noviembre',
+            12 => 'Diciembre'
+        ];
+    @endphp
+
+    <table class="report-table">
+        <thead>
+            <tr>
+                <th>MES</th>
+                <th>INGRESOS</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($months as $monthNumber => $monthName)
+                <tr>
+                    <td>{{ $monthName }}</td>
+                    <td>${{ number_format($monthlyEarnings[$monthNumber] ?? 0, 2) }}</td>
+                </tr>
+            @endforeach
+            <tr style="background-color: #f9f9f9; font-weight: bold;">
+                <td class="right">Total del Año:</td>
+                <td>${{ number_format($totalEarnings, 2) }}</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="period-total">
+        TOTAL GENERAL: ${{ number_format($totalEarnings, 2) }}
+    </div>
+@endsection

--- a/resources/views/reports/formalReports/annualExpensesFormal.blade.php
+++ b/resources/views/reports/formalReports/annualExpensesFormal.blade.php
@@ -1,0 +1,101 @@
+@php
+    $authUser = $authUser ?? auth()->user();
+    $locality = $authUser->locality ?? null;
+    $reportTitle = $reportTitle ?? 'GASTOS DEL ' . ($year ?? now()->year);
+    $generatedAt = $generatedAt ?? now()->format('d/m/Y H:i');
+    $generatedBy = $generatedBy ?? trim(($authUser->name ?? '') . ' ' . ($authUser->last_name ?? ''));
+    $localityLine = $locality
+        ? 'LOCALIDAD DE ' . mb_strtoupper($locality->name ?? '-') . ', ' . mb_strtoupper($locality->municipality ?? '-') . ', ' . mb_strtoupper($locality->state ?? '-')
+        : null;
+    $logoPath = ($locality && $locality->hasMedia('localityGallery'))
+        ? $locality->getFirstMedia('localityGallery')->getPath()
+        : public_path('img/localityDefault.png');
+@endphp
+
+@extends('reports.layouts.base')
+
+@section('title', 'REPORTE ANUAL DE GASTOS')
+
+@push('styles')
+    <style>
+        .report-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 18px;
+            border: 1px solid #d9d9d9;
+            background: #fff;
+        }
+
+        .report-table th,
+        .report-table td {
+            border: 1px solid #d9d9d9;
+            padding: 8px 10px;
+            font-size: 11px;
+            text-align: center;
+        }
+
+        .report-table th {
+            background: #f4f4f4;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .right {
+            text-align: right;
+        }
+
+        .period-total {
+            margin-top: 25px;
+            padding: 10px;
+            border: 1px solid #111;
+            background-color: #f2f2f2;
+            text-align: right;
+            font-weight: bold;
+            font-size: 13px;
+        }
+    </style>
+@endpush
+
+@section('content')
+    @php
+        $months = [
+            1  => 'Enero',
+            2  => 'Febrero',
+            3  => 'Marzo',
+            4  => 'Abril',
+            5  => 'Mayo',
+            6  => 'Junio',
+            7  => 'Julio',
+            8  => 'Agosto',
+            9  => 'Septiembre',
+            10 => 'Octubre',
+            11 => 'Noviembre',
+            12 => 'Diciembre'
+        ];
+    @endphp
+
+    <table class="report-table">
+        <thead>
+            <tr>
+                <th>MES</th>
+                <th>GASTOS</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($months as $monthNumber => $monthName)
+                <tr>
+                    <td>{{ $monthName }}</td>
+                    <td>${{ number_format($monthlyExpenses[$monthNumber] ?? 0, 2) }}</td>
+                </tr>
+            @endforeach
+            <tr style="background-color: #f9f9f9; font-weight: bold;">
+                <td class="right">Total del Año:</td>
+                <td>${{ number_format($totalExpenses, 2) }}</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="period-total">
+        TOTAL GENERAL: ${{ number_format($totalExpenses, 2) }}
+    </div>
+@endsection


### PR DESCRIPTION

- Added **formal design templates** for both annual **expenses** and **earnings** reports.
- Introduced new Blade views:
  - `annualExpensesFormal.blade.php`
  - `annualEarningsFormal.blade.php`

## 🛠️ Controller Updates
- **GeneralExpenseController**:
  - Modified `annualExpensesReport()` to dynamically select between the old report view and the new formal design based on user locality settings.
- **PaymentController**:
  - Updated `annualEarningsReport()` with similar logic to support the new formal report design.

## 📄 Report Enhancements
- Added structured tables with **monthly breakdowns** and **yearly totals** for both expenses and earnings.
- Included metadata such as:
  - Report title (e.g., *INGRESOS DEL 2026*, *GASTOS DEL 2026*)
  - Generation date and time
  - Author and locality information with logo support

## 📊 Visual Improvements
- Applied consistent **A4 portrait layout** for PDF generation.
- Enhanced table styling:
  - Borders, background colors, and typography for readability.
  - Highlighted **annual totals** with bold formatting.